### PR TITLE
Add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`play4096` is a single-service SvelteKit app (Svelte 5 + Tailwind 4) with a
+`better-sqlite3` database via Drizzle ORM. It's a 2048-style tile game with user
+auth, a leaderboard, and optional Stripe payments / SMTP email. Standard scripts
+live in `package.json` (`dev`, `build`, `lint`, `check`, `db:migrate`, `db:seed`).
+
+Node and pnpm are the runtime (see `packageManager` in `package.json`). Deps are
+refreshed by the startup update script (`pnpm install`).
+
+Non-obvious setup/run notes:
+
+- **`DATABASE_URL` is required.** Both `drizzle.config.js` and the DB client throw
+  if it is unset. Local dev reads it from a gitignored `.env` file (Vite loads
+  `.env` automatically). If `.env` is missing, recreate it from `.env.example`
+  with `DATABASE_URL=data/local.db` and `ENVIRONMENT=development`.
+- **The SQLite DB is gitignored** (`data/local.db`). On a fresh checkout, create it
+  with `mkdir -p data && pnpm db:migrate` before running the app. Optionally seed an
+  admin user (`admin` / `admin123`) with `pnpm db:seed`.
+- **Dev server:** `pnpm dev` serves on `http://localhost:5173` (bound to `0.0.0.0`).
+  Use `pnpm build` + `pnpm preview`/`pnpm start` for a production-style run.
+- **Stripe and SMTP are optional in development** — leave their env vars blank.
+  Email sends are skipped and Stripe is only exercised when the payment flow is
+  used; they only hard-fail when `ENVIRONMENT=production`.
+- **`pnpm check` (svelte-check) currently reports 4 pre-existing type errors** in
+  `src/lib/server/email.js` and `src/routes/animated/+page.svelte`. These are
+  unrelated to environment setup and do not block dev/build.
+- `pnpm lint` runs `eslint . --fix` (it will auto-fix in place).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for `play4096` (SvelteKit + SQLite/Drizzle 2048-style game). Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing durable, non-obvious setup/run caveats for future agents.

The update script for VM startup is `pnpm install`. No application code was changed.

## What was verified

- `pnpm install` — dependencies install cleanly (Node 22, pnpm 10.19)
- `pnpm db:migrate` — creates/migrates the SQLite DB (`data/local.db`)
- `pnpm lint` — passes
- `pnpm build` — production build succeeds
- `pnpm dev` — dev server runs on `http://localhost:5173`
- Hello-world: registered a user (auth + DB write) and played the game end-to-end (tiles move/merge, score increases to 64)

## Notes captured in AGENTS.md

- `DATABASE_URL` is required; local dev reads it from a gitignored `.env` (recreate from `.env.example`).
- SQLite DB is gitignored — run `mkdir -p data && pnpm db:migrate` on a fresh checkout.
- Stripe/SMTP are optional in dev.
- `pnpm check` has 4 pre-existing type errors unrelated to setup.

## Walkthrough

[play4096_game_demo.mp4](https://cursor.com/agents/bc-3786482f-3565-4168-8ef4-df0305e5da6c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplay4096_game_demo.mp4)

[play4096 home page](https://cursor.com/agents/bc-3786482f-3565-4168-8ef4-df0305e5da6c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplay4096_home.webp)
[game board with score 64](https://cursor.com/agents/bc-3786482f-3565-4168-8ef4-df0305e5da6c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplay4096_game_score64.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3786482f-3565-4168-8ef4-df0305e5da6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3786482f-3565-4168-8ef4-df0305e5da6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

