### PR TITLE
Add post-deploy health check with version polling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,13 @@
 #   Build Time + Runtime Vars (add to GitHub Variables)
 # ========================================================
 
+# Git commit SHA baked into the app at build time (CI sets this automatically).
+BUILD_VERSION=development
+
+# Production health endpoint polled after deploy (GitHub Actions variable).
+# Example: https://play4096.com/api/health
+# HEALTH_CHECK_URL=
+
 # URL for the database file.
 DATABASE_URL=data/local.db
 

--- a/.github/scripts/wait-for-deployment.sh
+++ b/.github/scripts/wait-for-deployment.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTED_VERSION="${1:?Expected version (commit SHA) is required}"
+HEALTH_URL="${2:?Health check URL is required}"
+TIMEOUT_SECONDS="${3:-300}"
+INTERVAL_SECONDS="${4:-10}"
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+last_response=""
+attempt=0
+
+echo "Waiting for deployment version ${EXPECTED_VERSION} at ${HEALTH_URL}"
+echo "Timeout: ${TIMEOUT_SECONDS}s, polling every ${INTERVAL_SECONDS}s"
+
+while (( SECONDS < deadline )); do
+	attempt=$((attempt + 1))
+
+	if response=$(curl -sf --max-time 15 "$HEALTH_URL" 2>/dev/null); then
+		last_response="$response"
+		status=$(echo "$response" | jq -r '.status // empty')
+		version=$(echo "$response" | jq -r '.version // empty')
+
+		if [[ "$status" == "healthy" && "$version" == "$EXPECTED_VERSION" ]]; then
+			echo "Deployment verified after ${attempt} attempt(s)."
+			echo "$response" | jq .
+			exit 0
+		fi
+
+		echo "Attempt ${attempt}: status=${status:-unknown} version=${version:-unknown} (expected ${EXPECTED_VERSION})"
+	else
+		echo "Attempt ${attempt}: health check request failed, retrying..."
+	fi
+
+	sleep "$INTERVAL_SECONDS"
+done
+
+echo "Deployment verification failed after ${TIMEOUT_SECONDS}s."
+if [[ -n "$last_response" ]]; then
+	echo "Last response:"
+	echo "$last_response" | jq . 2>/dev/null || echo "$last_response"
+else
+	echo "No successful health check responses were received."
+fi
+exit 1

--- a/.github/workflows/BuildApp.yml
+++ b/.github/workflows/BuildApp.yml
@@ -49,6 +49,7 @@ jobs:
 
       - name: Build Svelte App
         env:
+          BUILD_VERSION: ${{ github.sha }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
         run: |

--- a/.github/workflows/CI_CD.yaml
+++ b/.github/workflows/CI_CD.yaml
@@ -22,3 +22,10 @@ jobs:
     secrets:
       WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
       WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+
+  VerifyDeployment:
+    needs: DeployApp
+    uses: ./.github/workflows/VerifyDeployment.yml
+    with:
+      expected_version: ${{ github.sha }}
+      health_check_url: ${{ vars.HEALTH_CHECK_URL != '' && vars.HEALTH_CHECK_URL || 'https://play4096.com/api/health' }}

--- a/.github/workflows/Manual_Deploy.yaml
+++ b/.github/workflows/Manual_Deploy.yaml
@@ -26,3 +26,10 @@ jobs:
     secrets:
       WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
       WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
+
+  VerifyDeployment:
+    needs: DeployApp
+    uses: ./.github/workflows/VerifyDeployment.yml
+    with:
+      expected_version: ${{ github.sha }}
+      health_check_url: ${{ vars.HEALTH_CHECK_URL != '' && vars.HEALTH_CHECK_URL || 'https://play4096.com/api/health' }}

--- a/.github/workflows/VerifyDeployment.yml
+++ b/.github/workflows/VerifyDeployment.yml
@@ -1,0 +1,40 @@
+name: Verify Deployment
+
+on:
+  workflow_call:
+    inputs:
+      expected_version:
+        description: "Git commit SHA expected to be running after deployment"
+        required: true
+        type: string
+      health_check_url:
+        description: "Full URL of the deployment health endpoint"
+        required: true
+        type: string
+      timeout_seconds:
+        description: "Maximum time to wait for the new version to become healthy"
+        required: false
+        type: number
+        default: 300
+      poll_interval_seconds:
+        description: "Seconds between health check attempts"
+        required: false
+        type: number
+        default: 10
+
+jobs:
+  verify:
+    name: Verify deployment health
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Wait for healthy deployment
+        run: |
+          chmod +x .github/scripts/wait-for-deployment.sh
+          .github/scripts/wait-for-deployment.sh \
+            "${{ inputs.expected_version }}" \
+            "${{ inputs.health_check_url }}" \
+            "${{ inputs.timeout_seconds }}" \
+            "${{ inputs.poll_interval_seconds }}"

--- a/src/lib/server/buildInfo.js
+++ b/src/lib/server/buildInfo.js
@@ -1,0 +1,4 @@
+import { BUILD_VERSION } from "$env/static/private";
+
+/** Git commit SHA baked in at build time, or "development" for local builds. */
+export const buildVersion = BUILD_VERSION;

--- a/src/routes/api/health/+server.js
+++ b/src/routes/api/health/+server.js
@@ -1,0 +1,31 @@
+import { json } from "@sveltejs/kit";
+import { sql } from "drizzle-orm";
+import { buildVersion } from "$lib/server/buildInfo.js";
+import { db } from "$lib/server/db/index.js";
+
+/** @type {import("./$types").RequestHandler} */
+export async function GET() {
+	/** @type {Record<string, string>} */
+	const checks = {};
+
+	try {
+		db.run(sql`SELECT 1`);
+		checks.database = "ok";
+	} catch (err) {
+		checks.database = "error";
+		return json(
+			{
+				status: "unhealthy",
+				version: buildVersion,
+				checks,
+			},
+			{ status: 503 },
+		);
+	}
+
+	return json({
+		status: "healthy",
+		version: buildVersion,
+		checks,
+	});
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds deployment verification so CI/CD fails if the new version does not become healthy within 5 minutes after the deploy webhook fires.

- **`GET /api/health`** — returns `{ status, version, checks }` where `version` is the git commit SHA baked in at build time and `checks.database` confirms SQLite connectivity. Returns HTTP 503 when unhealthy.
- **`BUILD_VERSION`** — set from `github.sha` during the Vite build in `BuildApp.yml` and embedded into the production bundle.
- **`VerifyDeployment` workflow** — polls the health endpoint every 10 seconds for up to 5 minutes, waiting until `status === "healthy"` and `version` matches the deployed commit. Runs after the existing deploy webhook step in both CI/CD and Manual Deploy pipelines.
- **Configurable URL** — uses the `HEALTH_CHECK_URL` repository variable when set, otherwise defaults to `https://play4096.com/api/health`.

## How it works

```mermaid
sequenceDiagram
    participant CI as GitHub Actions
    participant GHCR as Container Registry
    participant Host as Deploy Host
    participant App as play4096.com

    CI->>CI: Build with BUILD_VERSION=sha
    CI->>GHCR: Push image
    CI->>Host: POST deploy webhook
    loop Every 10s for 5 min
        CI->>App: GET /api/health
        App-->>CI: version + status
    end
    CI->>CI: Pass if version matches sha
```

## Setup

Optionally set the **`HEALTH_CHECK_URL`** repository variable (e.g. `https://play4096.com/api/health`) if the default does not match your production URL.

## Test plan

- [x] Built app locally with `BUILD_VERSION=test-sha123`
- [x] Verified `/api/health` returns expected version and database check
- [x] Verified `wait-for-deployment.sh` passes on matching version and fails on mismatch/timeout

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f5c52-bbfd-757e-b2fe-0ac6cf6a665b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f5c52-bbfd-757e-b2fe-0ac6cf6a665b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

