### PR TITLE
Seeded deterministic tile spawns and cooldown undo

### DIFF
--- a/drizzle/0005_fixed_thunderbolt.sql
+++ b/drizzle/0005_fixed_thunderbolt.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `game` ADD `seed` integer;--> statement-breakpoint
+ALTER TABLE `game` ADD `rng_state` integer;--> statement-breakpoint
+ALTER TABLE `game` ADD `move_count` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `game` ADD `undo_cooldown_remaining` integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,530 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6708621d-d2b2-4aa0-afb7-0d19d6c041ff",
+  "prevId": "85c850f6-7906-4301-a483-666021961391",
+  "tables": {
+    "email_verification_request": {
+      "name": "email_verification_request",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_verification_request_user_id_user_id_fk": {
+          "name": "email_verification_request_user_id_user_id_fk",
+          "tableFrom": "email_verification_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_session": {
+      "name": "password_reset_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_session_user_id_user_id_fk": {
+          "name": "password_reset_session_user_id_user_id_fk",
+          "tableFrom": "password_reset_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game": {
+      "name": "game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_on": {
+          "name": "completed_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "won": {
+          "name": "won",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "board": {
+          "name": "board",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rng_state": {
+          "name": "rng_state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "move_count": {
+          "name": "move_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "undo_cooldown_remaining": {
+          "name": "undo_cooldown_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_player_id_user_id_fk": {
+          "name": "game_player_id_user_id_fk",
+          "tableFrom": "game",
+          "tableTo": "user",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin": {
+          "name": "admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_score": {
+          "name": "best_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profile_user_id_user_id_fk": {
+          "name": "user_profile_user_id_user_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_session": {
+      "name": "stripe_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_json": {
+          "name": "session_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_session_user_id_user_id_fk": {
+          "name": "stripe_session_user_id_user_id_fk",
+          "tableFrom": "stripe_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1761939188611,
       "tag": "0004_green_shooting_star",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1784042375952,
+      "tag": "0005_fixed_thunderbolt",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/test-rng.mjs
+++ b/scripts/test-rng.mjs
@@ -1,0 +1,27 @@
+import { createSeededRng, generateSeed } from "../src/lib/rng.js";
+import assert from "node:assert/strict";
+
+const seed = 123456;
+const a = createSeededRng(seed);
+const b = createSeededRng(seed);
+const seqA = Array.from({ length: 20 }, () => a.next());
+const seqB = Array.from({ length: 20 }, () => b.next());
+assert.deepEqual(seqA, seqB, "same seed must produce identical sequences");
+
+const c = createSeededRng(seed);
+for (let i = 0; i < 5; i++) c.next();
+const midState = c.state;
+const continued = Array.from({ length: 5 }, () => c.next());
+
+const restored = createSeededRng(0);
+restored.state = midState;
+assert.deepEqual(
+	Array.from({ length: 5 }, () => restored.next()),
+	continued,
+	"restoring rngState must continue the same sequence"
+);
+
+const seeds = new Set(Array.from({ length: 50 }, () => generateSeed()));
+assert.ok(seeds.size > 40, "generateSeed should produce varied values");
+
+console.log("rng tests passed");

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -4,6 +4,8 @@ export const SUPPORT_EMAIL = "support@play-4096.com";
 export const TWO_TO_FOUR_RATIO = 0.9;
 export const DEFAULT_BOARD_SIZE = 4;
 export const DEFAULT_STARTING_TILES = 2;
+/** Moves required after an undo before undo can be used again */
+export const UNDO_COOLDOWN_MOVES = 10;
 export const SPAWN_START_SCALE = 0.5;
 export const DEFAULT_LUMINANCE_THRESHOLD = 0.7;
 export const TILE_SPAWN_DURATION = 100;

--- a/src/lib/game.svelte.js
+++ b/src/lib/game.svelte.js
@@ -7,7 +7,9 @@ import {
 	DIRECTIONS,
 	EVENT_TYPES,
 	TWO_TO_FOUR_RATIO,
+	UNDO_COOLDOWN_MOVES,
 } from "./constants";
+import { createSeededRng, generateSeed } from "./rng.js";
 
 /**
  * Get the background color for a tile using current theme
@@ -99,6 +101,7 @@ export class Game {
 		boardSize = DEFAULT_BOARD_SIZE,
 		startingTiles = DEFAULT_STARTING_TILES,
 		initialState = null,
+		seed = undefined,
 	} = {}) {
 		this.id = id ?? initialState?.id;
 		this.boardSize = boardSize;
@@ -113,8 +116,40 @@ export class Game {
 		this.gameOver = $state(false);
 		this.won = $state(false);
 		this.canContinue = $state(false);
+		/** @type {number} */
+		this.moveCount = $state(0);
+		/** @type {number} Moves remaining before undo is available again */
+		this.undoCooldownRemaining = $state(0);
+		/** @type {boolean} Reactive flag — true when a one-step undo snapshot exists */
+		this.hasUndoSnapshot = $state(false);
+
+		const resolvedSeed = seed ?? initialState?.seed ?? generateSeed();
+		/** @type {number} */
+		this.seed = resolvedSeed;
+		this.rng = createSeededRng(resolvedSeed);
+		if (initialState?.rngState != null) {
+			this.rng.state = initialState.rngState;
+		}
+
+		/**
+		 * Snapshot of board/score/rng used for a single-step undo.
+		 * Not persisted across reloads.
+		 * @type {import("./types").GameUndoSnapshot | null}
+		 */
+		this.#previousState = null;
 
 		this.initialize(initialState, startingTiles);
+	}
+
+	/** @type {import("./types").GameUndoSnapshot | null} */
+	#previousState;
+
+	/**
+	 * Whether the player can undo the last move right now
+	 * @returns {boolean}
+	 */
+	get canUndo() {
+		return this.hasUndoSnapshot && this.undoCooldownRemaining === 0;
 	}
 
 	/**
@@ -128,9 +163,11 @@ export class Game {
 
 		// Load initial state if provided
 		if (initialState) {
-			this.board = initialState.board;
+			this.board = initialState.board.map((row) => [...row]);
 			this.score = initialState.score;
 			this.boardSize = this.board.length;
+			this.moveCount = initialState.moveCount ?? 0;
+			this.undoCooldownRemaining = initialState.undoCooldownRemaining ?? 0;
 			this.checkWin();
 			this.checkGameOver();
 
@@ -145,6 +182,29 @@ export class Game {
 				this.addNewTile();
 			}
 		}
+	}
+
+	/**
+	 * Undo the last successful move, if allowed.
+	 * After undoing, undo stays disabled until UNDO_COOLDOWN_MOVES new moves.
+	 * @returns {boolean} Whether an undo was applied
+	 */
+	undo() {
+		if (!this.canUndo || !this.#previousState) return false;
+
+		const snapshot = this.#previousState;
+		this.board = snapshot.board.map((row) => [...row]);
+		this.score = snapshot.score;
+		this.gameOver = snapshot.gameOver;
+		this.won = snapshot.won;
+		this.canContinue = snapshot.canContinue;
+		this.rng.state = snapshot.rngState;
+		this.moveCount = snapshot.moveCount;
+		this.#previousState = null;
+		this.hasUndoSnapshot = false;
+		this.undoCooldownRemaining = UNDO_COOLDOWN_MOVES;
+
+		return true;
 	}
 
 	/**
@@ -165,12 +225,12 @@ export class Game {
 	}
 
 	/**
-	 * Add a new tile (2 or 4) to a random empty position
+	 * Add a new tile (2 or 4) to a seeded-random empty position
 	 * @param {number | null} valueInput
 	 */
 	addNewTile(valueInput = null) {
 		const type = EVENT_TYPES.SPAWN;
-		const newTileValue = valueInput ?? (Math.random() < TWO_TO_FOUR_RATIO ? 2 : 4);
+		const newTileValue = valueInput ?? (this.rng.next() < TWO_TO_FOUR_RATIO ? 2 : 4);
 
 		// Find all empty cells
 		const emptyCells = [];
@@ -184,8 +244,8 @@ export class Game {
 
 		if (emptyCells.length === 0) return null;
 
-		// Pick a random empty cell and set it to the new tile value
-		const randomCell = emptyCells[Math.floor(Math.random() * emptyCells.length)];
+		// Pick a seeded-random empty cell and set it to the new tile value
+		const randomCell = emptyCells[this.rng.nextInt(emptyCells.length)];
 		this.board[randomCell.row][randomCell.col] = newTileValue;
 
 		// Generate the spawn event
@@ -302,6 +362,17 @@ export class Game {
 		 */
 		let moveQueue = [];
 
+		// Snapshot before any merges so score/board/rng stay undoable
+		const undoSnapshot = {
+			board: this.board.map((row) => [...row]),
+			score: this.score,
+			gameOver: this.gameOver,
+			won: this.won,
+			canContinue: this.canContinue,
+			rngState: this.rng.state,
+			moveCount: this.moveCount,
+		};
+
 		const newBoard = this.board.map((row) => [...row]);
 
 		if (direction === DIRECTIONS.LEFT) {
@@ -407,9 +478,16 @@ export class Game {
 
 		// If a move was made, do some stuff
 		if (moveQueue.length > 0) {
+			this.#previousState = undoSnapshot;
+			this.hasUndoSnapshot = true;
+
 			// Add a snapshot of the board to the move queue and update state
 			moveQueue.push({ snapshot: newBoard });
 			this.board = newBoard;
+			this.moveCount += 1;
+			if (this.undoCooldownRemaining > 0) {
+				this.undoCooldownRemaining -= 1;
+			}
 
 			// Update win state and add events
 			if (!this.won && this.checkWin()) {
@@ -496,6 +574,10 @@ export class Game {
 			score: this.score,
 			complete: this.gameOver,
 			won: this.won,
+			seed: this.seed,
+			rngState: this.rng.state,
+			moveCount: this.moveCount,
+			undoCooldownRemaining: this.undoCooldownRemaining,
 		};
 	}
 }

--- a/src/lib/localStorage.svelte.js
+++ b/src/lib/localStorage.svelte.js
@@ -3,13 +3,27 @@ import { LOCAL_STORAGE_BEST_SCORE, LOCAL_STORAGE_CURRENT_GAME } from "./constant
 
 /**
  * Save the game to local storage
- * @param {import("./types").GameState} game
+ * @param {import("./types").GameState & {
+ *   seed?: number;
+ *   rngState?: number;
+ *   moveCount?: number;
+ *   undoCooldownRemaining?: number;
+ * }} game
  */
-export function saveGame({ id, board, score }) {
+export function saveGame({ id, board, score, seed, rngState, moveCount, undoCooldownRemaining }) {
 	if (!browser) return;
 	localStorage.setItem(
 		LOCAL_STORAGE_CURRENT_GAME,
-		JSON.stringify({ id, board, score, lastUpdated: Date.now() })
+		JSON.stringify({
+			id,
+			board,
+			score,
+			seed,
+			rngState,
+			moveCount,
+			undoCooldownRemaining,
+			lastUpdated: Date.now(),
+		})
 	);
 }
 

--- a/src/lib/rng.js
+++ b/src/lib/rng.js
@@ -1,0 +1,47 @@
+/**
+ * Mulberry32 — small, fast, deterministic PRNG.
+ * @param {number} seed
+ * @returns {{ next: () => number, nextInt: (max: number) => number, state: number }}
+ */
+export function createSeededRng(seed) {
+	let state = seed >>> 0;
+
+	return {
+		get state() {
+			return state;
+		},
+		set state(value) {
+			state = value >>> 0;
+		},
+		/**
+		 * @returns {number} Float in [0, 1)
+		 */
+		next() {
+			state = (state + 0x6d2b79f5) >>> 0;
+			let t = state;
+			t = Math.imul(t ^ (t >>> 15), t | 1);
+			t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+			return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+		},
+		/**
+		 * @param {number} max Exclusive upper bound
+		 * @returns {number} Integer in [0, max)
+		 */
+		nextInt(max) {
+			return Math.floor(this.next() * max);
+		},
+	};
+}
+
+/**
+ * Generate a fresh game seed from crypto when available.
+ * @returns {number}
+ */
+export function generateSeed() {
+	if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+		const buf = new Uint32Array(1);
+		crypto.getRandomValues(buf);
+		return buf[0] >>> 0;
+	}
+	return (Math.random() * 0xffffffff) >>> 0;
+}

--- a/src/lib/server/db/schema/gameSchemas.ts
+++ b/src/lib/server/db/schema/gameSchemas.ts
@@ -15,4 +15,8 @@ export const game = sqliteTable("game", {
 	won: integer("won", { mode: "boolean" }).notNull(),
 	complete: integer("complete", { mode: "boolean" }).notNull(),
 	board: text("board", { mode: "json" }).$type<number[][]>().notNull(),
+	seed: integer("seed"),
+	rngState: integer("rng_state"),
+	moveCount: integer("move_count").notNull().default(0),
+	undoCooldownRemaining: integer("undo_cooldown_remaining").notNull().default(0),
 });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -49,12 +49,27 @@ export interface GameOptions {
   boardSize?: number;
   startingTiles?: number;
   initialState?: GameState | null;
+  seed?: number;
+}
+
+export interface GameUndoSnapshot {
+  board: number[][];
+  score: number;
+  gameOver: boolean;
+  won: boolean;
+  canContinue: boolean;
+  rngState: number;
+  moveCount: number;
 }
 
 export interface GameState {
   id?: string;
   board: number[][];
   score: number;
+  seed?: number;
+  rngState?: number;
+  moveCount?: number;
+  undoCooldownRemaining?: number;
 }
 
 export interface GameSaveData {
@@ -64,4 +79,8 @@ export interface GameSaveData {
   board: number[][];
   won: boolean;
   complete: boolean;
+  seed?: number;
+  rngState?: number;
+  moveCount?: number;
+  undoCooldownRemaining?: number;
 }

--- a/src/routes/game/+page.server.js
+++ b/src/routes/game/+page.server.js
@@ -15,6 +15,10 @@ export function load({ locals }) {
 				id: dbGame.id,
 				board: dbGame.board,
 				score: dbGame.score ?? 0,
+				seed: dbGame.seed ?? undefined,
+				rngState: dbGame.rngState ?? undefined,
+				moveCount: dbGame.moveCount ?? 0,
+				undoCooldownRemaining: dbGame.undoCooldownRemaining ?? 0,
 				lastUpdated: dbGame.updatedOn.getTime(),
 			};
 		}

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -136,7 +136,7 @@
 			if (result.id) {
 				game.id = result.id;
 				// Refresh local snapshot so id survives reloads before the next effect tick
-				localSaveGame(game);
+				localSaveGame(game.json());
 			}
 		} catch (error) {
 			console.error("Failed to save game to server:", error);
@@ -200,7 +200,7 @@
 	// Update best score and save board to localstorage
 	$effect(() => {
 		if (!gameState.currentGame) return;
-		localSaveGame(gameState.currentGame);
+		localSaveGame(gameState.currentGame.json());
 		if (gameState.currentGame.score > gameState.bestScore) {
 			gameState.bestScore = gameState.currentGame.score;
 		}

--- a/src/routes/game/components/AnimatedBoard.svelte
+++ b/src/routes/game/components/AnimatedBoard.svelte
@@ -12,7 +12,7 @@
 	const PADDING = 10;
 	const TILE_BORDER_RADIUS = 6;
 
-	let { pendingEvents = [], popEvent } = $props();
+	let { pendingEvents = [], popEvent, onUndo = undefined } = $props();
 
 	let game = $derived(gameState.currentGame);
 	let theme = $derived(page.data.theme || defaultTheme);
@@ -136,9 +136,25 @@
 	onDestroy(() => {
 		animator.destroy();
 	});
+
+	/**
+	 * Undo last move and reset the board visuals immediately
+	 */
+	function handleUndo() {
+		if (!game?.canUndo) return;
+
+		pendingEvents.splice(0, pendingEvents.length);
+		const undid = game.undo();
+		if (!undid) return;
+
+		animator.syncFromBoard(game.board);
+		boardSignature = JSON.stringify(game.board);
+		frame += 1;
+		onUndo?.();
+	}
 </script>
 
-<GameControls {animationIdle} />
+<GameControls {animationIdle} onUndo={handleUndo} />
 
 <div class="board-container" bind:this={boardContainer}>
 	<div

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -10,6 +10,7 @@
 		PlusIcon,
 		RotateCcwIcon,
 		RotateCwIcon,
+		Undo2Icon,
 		XIcon,
 	} from "@lucide/svelte";
 	import { cubicOut } from "svelte/easing";
@@ -38,7 +39,7 @@
 
 	let game = $derived(gameState.currentGame);
 
-	let { animationIdle = true } = $props();
+	let { animationIdle = true, onUndo = undefined } = $props();
 
 	const GAME_OVER_DELAY = 600;
 	const GAME_WIN_DELAY = 400;
@@ -103,6 +104,21 @@
 		if (!game) return;
 		game.mirrorBoardVertically();
 	}
+
+	function handleUndo() {
+		onUndo?.();
+	}
+
+	let undoDisabled = $derived(!game?.canUndo || !animationIdle);
+	let undoTitle = $derived(
+		!game
+			? "Undo"
+			: game.canUndo
+				? "Undo last move"
+				: game.undoCooldownRemaining > 0
+					? `Undo available in ${game.undoCooldownRemaining} move${game.undoCooldownRemaining === 1 ? "" : "s"}`
+					: "Nothing to undo"
+	);
 </script>
 
 <!-- Header -->
@@ -174,6 +190,18 @@
 		{/snippet}
 	</Menu>
 	<div class="flex-1"></div>
+	<button
+		class="controls-btn bg-primary hover:bg-primary-dark relative disabled:cursor-not-allowed disabled:opacity-40"
+		onclick={handleUndo}
+		disabled={undoDisabled}
+		title={undoTitle}
+		aria-label={undoTitle}
+	>
+		<Undo2Icon size={18} />
+		{#if game && game.undoCooldownRemaining > 0}
+			<span class="cooldown-badge">{game.undoCooldownRemaining}</span>
+		{/if}
+	</button>
 	<button class="controls-btn bg-primary hover:bg-primary-dark" onclick={rotateBoard}>
 		<RotateCwIcon size={18} />
 	</button>
@@ -196,7 +224,11 @@
 		<div class="overlay-content">
 			<h2>Game Over!</h2>
 			<p>Final Score: {game.score.toLocaleString()}</p>
-			<button class="overlay-btn" onclick={newGame}>Try Again</button>
+			{#if game.canUndo}
+				<button class="overlay-btn" onclick={handleUndo}>Undo Last Move</button>
+			{/if}
+			<button class="overlay-btn" class:secondary={game.canUndo} onclick={newGame}>Try Again</button
+			>
 		</div>
 	</div>
 {/if}
@@ -217,6 +249,10 @@
 
 	.controls-btn {
 		@apply rounded-full p-2 text-white;
+	}
+
+	.cooldown-badge {
+		@apply absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-black/70 px-1 text-[10px] leading-none font-bold text-white;
 	}
 
 	.overlay {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Each new game gets a seed; tile value (2 vs 4) and empty-cell spawn use a Mulberry32 PRNG, so the same seed + move sequence always produces the same board.
- Seed, RNG state, move count, and undo cooldown are persisted to localStorage and the DB so refreshes / multi-device saves stay consistent.
- Added a one-step **Undo** control (also on the game-over overlay). After undoing, it stays disabled for 10 moves; remaking the same move after undo cannot reroll because the RNG state is restored too.

## Notes
- Undo snapshots are in-memory only (lost on reload), which is intentional.
- Cooldown length is `UNDO_COOLDOWN_MOVES = 10` in `src/lib/constants.js` if you want to tune it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6133-88ab-7412-9dc7-bec33b85b726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6133-88ab-7412-9dc7-bec33b85b726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

