### PR TITLE
Fix production 500s: run DB migrations on container start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,10 @@ COPY drizzle.config.js ./drizzle.config.js
 COPY ./drizzle ./drizzle
 COPY ./build ./build
 COPY ./src ./src
+COPY ./scripts/docker-entrypoint.sh ./scripts/docker-entrypoint.sh
+
+RUN chmod +x ./scripts/docker-entrypoint.sh
 
 EXPOSE 3000
 EXPOSE 3001
-CMD [ "pnpm", "start" ]
+CMD ["./scripts/docker-entrypoint.sh"]

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+echo "[entrypoint] Running database migrations..."
+pnpm db:migrate
+
+echo "[entrypoint] Starting application..."
+exec node build

--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -54,7 +54,14 @@ export async function saveGame(game) {
 		await db
 			.update(table.game)
 			.set({
-				...game,
+				board: game.board,
+				score: game.score,
+				won: game.won,
+				complete: game.complete,
+				seed: game.seed ?? null,
+				rngState: game.rngState ?? null,
+				moveCount: game.moveCount ?? 0,
+				undoCooldownRemaining: game.undoCooldownRemaining ?? 0,
 				completedOn,
 				updatedOn: new Date(),
 			})
@@ -66,12 +73,18 @@ export async function saveGame(game) {
 		const newGame = db
 			.insert(table.game)
 			.values({
-				...game,
 				id: crypto.randomUUID(),
-				createdOn: new Date(),
-				updatedOn: new Date(),
+				playerId: game.playerId,
+				board: game.board,
+				score: game.score,
 				won: game.won,
 				complete: game.complete,
+				seed: game.seed ?? null,
+				rngState: game.rngState ?? null,
+				moveCount: game.moveCount ?? 0,
+				undoCooldownRemaining: game.undoCooldownRemaining ?? 0,
+				createdOn: new Date(),
+				updatedOn: new Date(),
 			})
 			.returning({ id: table.game.id })
 			.get();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause
PR #17 added `seed` / `rng_state` / `move_count` / `undo_cooldown_remaining` to the `game` table, but the Docker image never runs `drizzle-kit migrate` on startup. Production was still on the old schema, so any logged-in path that `SELECT`s/`INSERT`s/`UPDATE`s `game` failed with `no such column: seed` → 500s.

Public pages and `/api/health` stayed healthy because they do not touch those columns.

## Fix
- Add `scripts/docker-entrypoint.sh` that runs `pnpm db:migrate` before `node build`
- Point the Dockerfile `CMD` at that entrypoint
- Persist game saves with explicit column writes (no object spread)

After merge + deploy, the new container will apply migration `0005` automatically and game save/load should recover.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6133-88ab-7412-9dc7-bec33b85b726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6133-88ab-7412-9dc7-bec33b85b726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

