### PR TITLE
Add admin-only rate-limited migrate up endpoint

### DIFF
--- a/src/lib/server/db/migrate.js
+++ b/src/lib/server/db/migrate.js
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { readMigrationFiles } from "drizzle-orm/migrator";
+
+import { getDb } from "./index.js";
+
+const MIGRATIONS_TABLE = "__drizzle_migrations";
+
+/**
+ * Resolve the migrations folder shipped with the app image / repo.
+ * @returns {string}
+ */
+export function getMigrationsFolder() {
+	const candidates = [
+		path.join(process.cwd(), "drizzle"),
+		path.resolve("drizzle"),
+		path.join(process.cwd(), "..", "drizzle"),
+	];
+
+	for (const folder of candidates) {
+		if (existsSync(path.join(folder, "meta", "_journal.json"))) {
+			return folder;
+		}
+	}
+
+	throw new Error("Unable to locate drizzle migrations folder");
+}
+
+/**
+ * @returns {{ tag: string, when: number, idx: number }[]}
+ */
+function readJournalEntries(migrationsFolder = getMigrationsFolder()) {
+	const journalPath = path.join(migrationsFolder, "meta", "_journal.json");
+	const journal = JSON.parse(readFileSync(journalPath, "utf8"));
+	return journal.entries ?? [];
+}
+
+/**
+ * @returns {string[]} Applied migration hashes (oldest first)
+ */
+function getAppliedHashes() {
+	const db = getDb();
+	try {
+		const rows = /** @type {{ hash: string }[]} */ (
+			db.$client.prepare(`SELECT hash FROM ${MIGRATIONS_TABLE} ORDER BY created_at ASC`).all()
+		);
+		return rows.map((row) => String(row.hash));
+	} catch {
+		// Table missing on a brand-new DB — treat as zero applied
+		return [];
+	}
+}
+
+/**
+ * Migration status relative to the journal packaged with this build.
+ * @returns {{
+ *   migrationsFolder: string,
+ *   journal: { tag: string, when: number, idx: number }[],
+ *   appliedCount: number,
+ *   pendingCount: number,
+ *   pending: { tag: string, when: number, idx: number }[],
+ * }}
+ */
+export function getMigrationStatus() {
+	const migrationsFolder = getMigrationsFolder();
+	const journal = readJournalEntries(migrationsFolder);
+	const files = readMigrationFiles({ migrationsFolder });
+	const applied = new Set(getAppliedHashes());
+
+	const pending = [];
+	for (let i = 0; i < files.length; i++) {
+		if (!applied.has(files[i].hash)) {
+			pending.push(journal[i] ?? { tag: `unknown-${i}`, when: files[i].folderMillis, idx: i });
+		}
+	}
+
+	return {
+		migrationsFolder,
+		journal,
+		appliedCount: applied.size,
+		pendingCount: pending.length,
+		pending,
+	};
+}
+
+/**
+ * Apply all pending migrations (drizzle "up").
+ * @returns {{ before: ReturnType<typeof getMigrationStatus>, after: ReturnType<typeof getMigrationStatus> }}
+ */
+export function migrateUp() {
+	const migrationsFolder = getMigrationsFolder();
+	const before = getMigrationStatus();
+
+	migrate(getDb(), { migrationsFolder });
+
+	const after = getMigrationStatus();
+	return { before, after };
+}

--- a/src/routes/api/admin/migrate/+server.js
+++ b/src/routes/api/admin/migrate/+server.js
@@ -1,0 +1,100 @@
+import { json } from "@sveltejs/kit";
+
+import { ExpiringTokenBucket } from "$lib/server/auth/rateLimit.js";
+import { getUser } from "$lib/server/user.js";
+import { getMigrationStatus, migrateUp } from "$lib/server/db/migrate.js";
+import { getLogger } from "$lib/server/requestContext.js";
+
+/** Few migrations per hour — enough for emergencies, not spam */
+const migrateBucket = new ExpiringTokenBucket(3, 60 * 60);
+
+/**
+ * @param {import("@sveltejs/kit").RequestEvent} event
+ */
+function requireAdmin(event) {
+	if (!event.locals.user) {
+		return json({ error: "Not logged in" }, { status: 401 });
+	}
+
+	const user = getUser(event.locals.user.id);
+	if (!user?.admin) {
+		return json({ error: "Admin access required" }, { status: 403 });
+	}
+
+	return null;
+}
+
+/** @type {import("./$types").RequestHandler} */
+export async function GET(event) {
+	const denied = requireAdmin(event);
+	if (denied) return denied;
+
+	try {
+		return json({ success: true, status: getMigrationStatus() });
+	} catch (err) {
+		getLogger().error({ err }, "Failed to read migration status");
+		return json({ error: "Failed to read migration status" }, { status: 500 });
+	}
+}
+
+/** @type {import("./$types").RequestHandler} */
+export async function POST(event) {
+	const denied = requireAdmin(event);
+	if (denied) return denied;
+
+	const userId = event.locals.user.id;
+
+	/** @type {{ command?: string }} */
+	let body = {};
+	try {
+		body = await event.request.json();
+	} catch {
+		return json({ error: "JSON body required" }, { status: 400 });
+	}
+
+	const command = body.command;
+	if (command !== "up") {
+		return json(
+			{
+				error: 'Unsupported command. Use { "command": "up" } to apply pending migrations.',
+			},
+			{ status: 400 }
+		);
+	}
+
+	// Burn quota before running migrate to limit expensive / damaging retries
+	if (!migrateBucket.consume(userId, 1) || !migrateBucket.consume("global", 1)) {
+		return json({ error: "Rate limit exceeded. Try again later." }, { status: 429 });
+	}
+
+	const log = getLogger();
+	try {
+		const result = migrateUp();
+		log.info(
+			{
+				userId,
+				pendingBefore: result.before.pendingCount,
+				pendingAfter: result.after.pendingCount,
+				appliedAfter: result.after.appliedCount,
+			},
+			"Admin ran database migrate up"
+		);
+
+		return json({
+			success: true,
+			command: "up",
+			applied: result.before.pendingCount - result.after.pendingCount,
+			before: result.before,
+			after: result.after,
+		});
+	} catch (err) {
+		log.error({ err, userId }, "Admin migrate up failed");
+		return json(
+			{
+				error: "Migration failed",
+				message: err instanceof Error ? err.message : String(err),
+			},
+			{ status: 500 }
+		);
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
Migrate-on-start (PR #18) covers normal deploys. An admin escape hatch is still useful when schema gets ahead of the DB without waiting on a full rebuild (or to inspect pending migrations).

## What
- `GET /api/admin/migrate` — migration status (journal + pending)
- `POST /api/admin/migrate` with `{ "command": "up" }` — apply pending drizzle migrations via `drizzle-orm` migrator

## Guards
- Must be logged in **and** `user.admin === true`
- Rate limited: 3 calls / hour per admin and globally (`ExpiringTokenBucket`)
- Only the `up` command is accepted (easy to extend later)

## Example
```bash
curl -b cookies.txt https://play-4096.com/api/admin/migrate
curl -b cookies.txt -X POST https://play-4096.com/api/admin/migrate \
  -H 'Content-Type: application/json' \
  -d '{"command":"up"}'
```

Keeps migrate-on-start as the primary path; this is the emergency/manual lever.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6133-88ab-7412-9dc7-bec33b85b726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6133-88ab-7412-9dc7-bec33b85b726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

