### PR TITLE
Queue undo during move animations instead of disabling the button

### DIFF
--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -4,6 +4,7 @@
 	import { Game } from "$lib/game.svelte.js";
 	import { gameState } from "../state.svelte.js";
 	import {
+		LoaderCircleIcon,
 		MenuIcon,
 		MoveHorizontalIcon,
 		MoveVerticalIcon,
@@ -47,6 +48,8 @@
 	let showGameOver = $state(false);
 	let showWin = $state(false);
 	let openMenu = $state(false);
+	/** True while waiting for move animations to finish before applying undo */
+	let undoQueued = $state(false);
 
 	$effect(() => {
 		if (!game) return;
@@ -74,9 +77,25 @@
 		}
 	});
 
+	// Flush a queued undo once animations settle (or drop it if undo is no longer available)
+	$effect(() => {
+		if (!undoQueued) return;
+
+		if (!game?.canUndo) {
+			undoQueued = false;
+			return;
+		}
+
+		if (!animationIdle) return;
+
+		undoQueued = false;
+		onUndo?.();
+	});
+
 	function newGame() {
 		showGameOver = false;
 		showWin = false;
+		undoQueued = false;
 		gameState.currentGame = new Game();
 	}
 
@@ -106,18 +125,28 @@
 	}
 
 	function handleUndo() {
+		if (!game?.canUndo || undoQueued) return;
+
+		if (!animationIdle) {
+			undoQueued = true;
+			return;
+		}
+
 		onUndo?.();
 	}
 
-	let undoDisabled = $derived(!game?.canUndo || !animationIdle);
+	// Only disable for real undo unavailability (cooldown / no snapshot) — not mid-animation
+	let undoDisabled = $derived(!game?.canUndo);
 	let undoTitle = $derived(
 		!game
 			? "Undo"
-			: game.canUndo
-				? "Undo last move"
-				: game.undoCooldownRemaining > 0
-					? `Undo available in ${game.undoCooldownRemaining} move${game.undoCooldownRemaining === 1 ? "" : "s"}`
-					: "Nothing to undo"
+			: undoQueued
+				? "Undoing…"
+				: game.canUndo
+					? "Undo last move"
+					: game.undoCooldownRemaining > 0
+						? `Undo available in ${game.undoCooldownRemaining} move${game.undoCooldownRemaining === 1 ? "" : "s"}`
+						: "Nothing to undo"
 	);
 </script>
 
@@ -196,9 +225,14 @@
 		disabled={undoDisabled}
 		title={undoTitle}
 		aria-label={undoTitle}
+		aria-busy={undoQueued}
 	>
-		<Undo2Icon size={18} />
-		{#if game && game.undoCooldownRemaining > 0}
+		{#if undoQueued}
+			<LoaderCircleIcon class="animate-spin" size={18} />
+		{:else}
+			<Undo2Icon size={18} />
+		{/if}
+		{#if game && game.undoCooldownRemaining > 0 && !undoQueued}
 			<span class="cooldown-badge">{game.undoCooldownRemaining}</span>
 		{/if}
 	</button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The undo button was flashing disabled on every move because it was gated on `animationIdle` during the short tile animation window.

## Changes
- Keep the undo button enabled while move animations play (still disabled for real unavailability: cooldown / nothing to undo).
- If the player clicks undo mid-animation, queue the action and show a circular progress spinner in the button until animations settle, then apply undo.
- Drop the queued undo if undo becomes unavailable (e.g. new game) before it flushes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f616e-30fe-7ebb-adf0-eba4be3d7070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f616e-30fe-7ebb-adf0-eba4be3d7070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

