### PR TITLE
Theme presets (#3)

### DIFF
--- a/drizzle/0008_add_theme_id.sql
+++ b/drizzle/0008_add_theme_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_profile` ADD `theme_id` text DEFAULT 'classic' NOT NULL;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,633 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "aea96eea-db87-48fe-abc4-cb8c89f4bc01",
+  "prevId": "7a06cc49-22e8-4ba2-8bf4-78ebcd926ada",
+  "tables": {
+    "email_verification_request": {
+      "name": "email_verification_request",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_verification_request_user_id_user_id_fk": {
+          "name": "email_verification_request_user_id_user_id_fk",
+          "tableFrom": "email_verification_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_session": {
+      "name": "password_reset_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_session_user_id_user_id_fk": {
+          "name": "password_reset_session_user_id_user_id_fk",
+          "tableFrom": "password_reset_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "challenge_run": {
+      "name": "challenge_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_on": {
+          "name": "started_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_on": {
+          "name": "finished_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_run_user_id_user_id_fk": {
+          "name": "challenge_run_user_id_user_id_fk",
+          "tableFrom": "challenge_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game": {
+      "name": "game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_on": {
+          "name": "completed_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "won": {
+          "name": "won",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "board": {
+          "name": "board",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moves": {
+          "name": "moves",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rng_state": {
+          "name": "rng_state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "move_count": {
+          "name": "move_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "undo_cooldown_remaining": {
+          "name": "undo_cooldown_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_player_id_user_id_fk": {
+          "name": "game_player_id_user_id_fk",
+          "tableFrom": "game",
+          "tableTo": "user",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin": {
+          "name": "admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_score": {
+          "name": "best_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'classic'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profile_user_id_user_id_fk": {
+          "name": "user_profile_user_id_user_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_session": {
+      "name": "stripe_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_json": {
+          "name": "session_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_session_user_id_user_id_fk": {
+          "name": "stripe_session_user_id_user_id_fk",
+          "tableFrom": "stripe_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1784073723842,
       "tag": "0007_safe_bruce_banner",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1784074000000,
+      "tag": "0008_add_theme_id",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/assets/themes.js
+++ b/src/lib/assets/themes.js
@@ -1,5 +1,53 @@
-export const defaultTheme = {
-	name: "Default",
+/**
+ * @typedef {Object} Theme
+ * @property {string} id
+ * @property {string} name
+ * @property {boolean} [pro]
+ * @property {string} primary
+ * @property {string} secondary
+ * @property {string} background
+ * @property {string} boardBackground
+ * @property {string} emptyTile
+ * @property {string} textLight
+ * @property {string} textDark
+ * @property {string} [text]
+ * @property {string} unknownTile
+ * @property {number} textScale
+ * @property {number} luminanceThreshold
+ * @property {number} movementSpeed
+ * @property {Record<number, string>} tiles
+ */
+
+/** Shared tile ramp used by Classic / Light / Soft */
+const classicTiles = {
+	2: "#eee4d9",
+	4: "#ece0c8",
+	8: "#f2b179",
+	16: "#eb8e53",
+	32: "#f67c5f",
+	64: "#e95937",
+	128: "#f3d96c",
+	256: "#f1d14c",
+	512: "#efd179",
+	1024: "#eece69",
+	2048: "#edc32e",
+	4096: "#5eda92",
+	8192: "#9fca46",
+	16384: "#3E5641",
+	32768: "#AD9BAA",
+	65536: "#5BC0EB",
+	131072: "#540D6E",
+	262144: "#7B2D26",
+	524288: "#065A82",
+	1048576: "#F4F7BE",
+	2097152: "#63A375",
+};
+
+/** @type {Theme} */
+export const classicTheme = {
+	id: "classic",
+	name: "Classic",
+	pro: false,
 	primary: "#e88f4f",
 	secondary: "#C2D4B0",
 	background: "#fbf8ef",
@@ -7,25 +55,87 @@ export const defaultTheme = {
 	emptyTile: "#cdc1b4",
 	textLight: "#776e65",
 	textDark: "#f9f6f2",
+	text: "#776e65",
 	unknownTile: "#5f5f5f",
 	textScale: 3,
 	luminanceThreshold: 0.7,
-	movementSpeed: 50, // ms per tile space
-	/** @type {Record<number, string>} */
+	movementSpeed: 50,
+	tiles: { ...classicTiles },
+};
+
+/** @type {Theme} */
+export const darkTheme = {
+	id: "dark",
+	name: "Dark",
+	pro: false,
+	primary: "#e88f4f",
+	secondary: "#3d5a45",
+	background: "#1a1a1e",
+	boardBackground: "#2a2a32",
+	emptyTile: "#3a3a45",
+	textLight: "#e8e4df",
+	textDark: "#1a1a1e",
+	text: "#e8e4df",
+	unknownTile: "#6b6b78",
+	textScale: 3,
+	luminanceThreshold: 0.45,
+	movementSpeed: 50,
 	tiles: {
-		2: "#eee4d9",
-		4: "#ece0c8",
-		8: "#f2b179",
-		16: "#eb8e53",
-		32: "#f67c5f",
-		64: "#e95937",
-		128: "#f3d96c",
-		256: "#f1d14c",
-		512: "#efd179",
-		1024: "#eece69",
-		2048: "#edc32e",
-		4096: "#5eda92",
-		8192: "#9fca46",
+		2: "#4a4a55",
+		4: "#5c5348",
+		8: "#c47a3a",
+		16: "#d48a3a",
+		32: "#e06a4a",
+		64: "#d44528",
+		128: "#d4b84a",
+		256: "#c9a82e",
+		512: "#bf9e3a",
+		1024: "#b8942a",
+		2048: "#a88818",
+		4096: "#2e9a5c",
+		8192: "#6a8a28",
+		16384: "#2a3a2e",
+		32768: "#6a5a6a",
+		65536: "#2a7a9a",
+		131072: "#4a0a5a",
+		262144: "#5a1a18",
+		524288: "#044a6a",
+		1048576: "#8a8a5a",
+		2097152: "#3a6a4a",
+	},
+};
+
+/** @type {Theme} */
+export const lightTheme = {
+	id: "light",
+	name: "Light",
+	pro: false,
+	primary: "#4a90d9",
+	secondary: "#a8c5a0",
+	background: "#ffffff",
+	boardBackground: "#dce3ea",
+	emptyTile: "#eef2f6",
+	textLight: "#4a5560",
+	textDark: "#ffffff",
+	text: "#2d3740",
+	unknownTile: "#8899aa",
+	textScale: 3,
+	luminanceThreshold: 0.65,
+	movementSpeed: 50,
+	tiles: {
+		2: "#f7f9fc",
+		4: "#e8eef5",
+		8: "#7eb3e8",
+		16: "#5a9ad9",
+		32: "#4a85c8",
+		64: "#3a70b7",
+		128: "#6ec4a8",
+		256: "#4aaf8e",
+		512: "#3a9a7a",
+		1024: "#2a8568",
+		2048: "#1a7056",
+		4096: "#e8a05a",
+		8192: "#d4883a",
 		16384: "#3E5641",
 		32768: "#AD9BAA",
 		65536: "#5BC0EB",
@@ -36,3 +146,179 @@ export const defaultTheme = {
 		2097152: "#63A375",
 	},
 };
+
+/** @type {Theme} */
+export const highContrastTheme = {
+	id: "high-contrast",
+	name: "High Contrast",
+	pro: true,
+	primary: "#ffcc00",
+	secondary: "#00e5ff",
+	background: "#000000",
+	boardBackground: "#111111",
+	emptyTile: "#222222",
+	textLight: "#ffffff",
+	textDark: "#000000",
+	text: "#ffffff",
+	unknownTile: "#888888",
+	textScale: 3,
+	luminanceThreshold: 0.5,
+	movementSpeed: 50,
+	tiles: {
+		2: "#ffffff",
+		4: "#eeeeee",
+		8: "#ffcc00",
+		16: "#ff9900",
+		32: "#ff6600",
+		64: "#ff3300",
+		128: "#00e5ff",
+		256: "#00b8ff",
+		512: "#0088ff",
+		1024: "#0055ff",
+		2048: "#00ff88",
+		4096: "#88ff00",
+		8192: "#ccff00",
+		16384: "#ff00aa",
+		32768: "#aa00ff",
+		65536: "#ff00ff",
+		131072: "#ffff00",
+		262144: "#00ffff",
+		524288: "#ff0088",
+		1048576: "#88ffff",
+		2097152: "#ffff88",
+	},
+};
+
+/** Soft / muted palette — Pro exclusive */
+/** @type {Theme} */
+export const softTheme = {
+	id: "soft",
+	name: "Soft",
+	pro: true,
+	primary: "#a67c6d",
+	secondary: "#9aab9a",
+	background: "#e8e4df",
+	boardBackground: "#c4b8ae",
+	emptyTile: "#d4cbc3",
+	textLight: "#5c534c",
+	textDark: "#f5f2ee",
+	text: "#5c534c",
+	unknownTile: "#8a8078",
+	textScale: 3,
+	luminanceThreshold: 0.65,
+	movementSpeed: 50,
+	tiles: {
+		2: "#f0ebe6",
+		4: "#e4dbd2",
+		8: "#d4a890",
+		16: "#c49078",
+		32: "#b47860",
+		64: "#a06050",
+		128: "#b8c4a0",
+		256: "#a0b088",
+		512: "#889c70",
+		1024: "#708858",
+		2048: "#587440",
+		4096: "#90a8b8",
+		8192: "#7890a0",
+		16384: "#607888",
+		32768: "#b8a0b0",
+		65536: "#8898a8",
+		131072: "#706080",
+		262144: "#886060",
+		524288: "#507088",
+		1048576: "#c8c8a8",
+		2097152: "#708870",
+	},
+};
+
+/** Playful teal / coral alternate — Pro exclusive */
+/** @type {Theme} */
+export const coralTheme = {
+	id: "coral",
+	name: "Coral",
+	pro: true,
+	primary: "#ff6b6b",
+	secondary: "#4ecdc4",
+	background: "#fff5f0",
+	boardBackground: "#e8a090",
+	emptyTile: "#f0c8bc",
+	textLight: "#5a4038",
+	textDark: "#fff8f5",
+	text: "#5a4038",
+	unknownTile: "#8a6860",
+	textScale: 3,
+	luminanceThreshold: 0.6,
+	movementSpeed: 50,
+	tiles: {
+		2: "#fff0eb",
+		4: "#ffe0d6",
+		8: "#ff8a7a",
+		16: "#ff6b6b",
+		32: "#ee5a5a",
+		64: "#dd4848",
+		128: "#5ed4cc",
+		256: "#4ecdc4",
+		512: "#3eb8b0",
+		1024: "#2ea39c",
+		2048: "#1e8e88",
+		4096: "#ffb347",
+		8192: "#ffa02e",
+		16384: "#3E5641",
+		32768: "#AD9BAA",
+		65536: "#5BC0EB",
+		131072: "#540D6E",
+		262144: "#7B2D26",
+		524288: "#065A82",
+		1048576: "#F4F7BE",
+		2097152: "#63A375",
+	},
+};
+
+/** @type {Record<string, Theme>} */
+export const themes = {
+	classic: classicTheme,
+	dark: darkTheme,
+	light: lightTheme,
+	"high-contrast": highContrastTheme,
+	soft: softTheme,
+	coral: coralTheme,
+};
+
+export const DEFAULT_THEME_ID = "classic";
+
+/** @deprecated Prefer classicTheme / getTheme(); kept for existing imports */
+export const defaultTheme = classicTheme;
+
+/**
+ * @param {string | null | undefined} id
+ * @returns {Theme}
+ */
+export function getTheme(id) {
+	if (id && id in themes) {
+		return themes[id];
+	}
+	return classicTheme;
+}
+
+/**
+ * @returns {Theme[]}
+ */
+export function listThemes() {
+	return Object.values(themes);
+}
+
+/**
+ * Resolve a theme the user is allowed to use.
+ * Falls back to Classic if the id is missing, unknown, or Pro-locked.
+ * @param {string | null | undefined} id
+ * @param {boolean} [isPro]
+ * @returns {Theme}
+ */
+export function resolveTheme(id, isPro = false) {
+	const theme = getTheme(id);
+	if (theme.pro && !isPro) {
+		return classicTheme;
+	}
+	return theme;
+}

--- a/src/lib/components/ThemePreview.svelte
+++ b/src/lib/components/ThemePreview.svelte
@@ -1,0 +1,111 @@
+<script>
+	/**
+	 * Mini board preview using theme tokens.
+	 * @typedef {Object} PreviewTheme
+	 * @property {string} boardBackground
+	 * @property {string} emptyTile
+	 * @property {string} [primary]
+	 * @property {Record<number, string>} [tiles]
+	 * @property {string} [textDark]
+	 * @property {string} [textLight]
+	 * @property {number} [luminanceThreshold]
+	 */
+
+	/** @type {{ theme: PreviewTheme, selected?: boolean }} */
+	let { theme, selected = false } = $props();
+
+	const previewValues = [
+		2,
+		4,
+		8,
+		16,
+		null,
+		32,
+		64,
+		128,
+		null,
+		256,
+		512,
+		1024,
+		null,
+		2048,
+		4096,
+		null,
+	];
+
+	/**
+	 * @param {number} value
+	 * @param {PreviewTheme} t
+	 */
+	function tileBg(value, t) {
+		return t.tiles?.[value] ?? t.primary ?? "#888";
+	}
+
+	/**
+	 * Rough luminance for preview text color
+	 * @param {string} hex
+	 */
+	function isLight(hex) {
+		const h = hex.replace("#", "");
+		if (h.length < 6) return true;
+		const r = parseInt(h.slice(0, 2), 16);
+		const g = parseInt(h.slice(2, 4), 16);
+		const b = parseInt(h.slice(4, 6), 16);
+		const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+		return lum > (theme.luminanceThreshold ?? 0.6);
+	}
+</script>
+
+<div
+	class="preview-board"
+	class:selected
+	style:background={theme.boardBackground}
+	aria-hidden="true"
+>
+	{#each previewValues as value, i (i)}
+		{#if value == null}
+			<div class="preview-tile empty" style:background={theme.emptyTile}></div>
+		{:else}
+			{@const bg = tileBg(value, theme)}
+			<div
+				class="preview-tile"
+				style:background={bg}
+				style:color={isLight(bg) ? (theme.textLight ?? "#333") : (theme.textDark ?? "#fff")}
+			>
+				{value}
+			</div>
+		{/if}
+	{/each}
+</div>
+
+<style>
+	.preview-board {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 4px;
+		padding: 6px;
+		border-radius: 8px;
+		width: 100%;
+		aspect-ratio: 1;
+		box-sizing: border-box;
+	}
+
+	.preview-board.selected {
+		outline: 3px solid var(--color-primary, #e88f4f);
+		outline-offset: 2px;
+	}
+
+	.preview-tile {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 4px;
+		font-size: 0.55rem;
+		font-weight: 700;
+		min-height: 0;
+	}
+
+	.preview-tile.empty {
+		color: transparent;
+	}
+</style>

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -13,6 +13,8 @@ export const TILE_MERGE_DURATION = 100;
 export const TILE_MOVE_DURATION_MS = 12;
 export const LOCAL_STORAGE_CURRENT_GAME = "play-4096.currentGame";
 export const LOCAL_STORAGE_BEST_SCORE = "play-4096.bestScore";
+export const LOCAL_STORAGE_THEME = "play-4096.theme";
+export const THEME_COOKIE_NAME = "play-4096.theme";
 export const DEFAULT_WIN_TILE = 4096;
 
 export const USER_STATUS = {

--- a/src/lib/localStorage.svelte.js
+++ b/src/lib/localStorage.svelte.js
@@ -1,5 +1,10 @@
 import { browser } from "$app/environment";
-import { LOCAL_STORAGE_BEST_SCORE, LOCAL_STORAGE_CURRENT_GAME } from "./constants";
+import {
+	LOCAL_STORAGE_BEST_SCORE,
+	LOCAL_STORAGE_CURRENT_GAME,
+	LOCAL_STORAGE_THEME,
+} from "./constants";
+import { getTheme } from "./assets/themes";
 
 /**
  * Save the game to local storage
@@ -78,4 +83,30 @@ export function loadBestScore() {
 export function clearBestScore() {
 	if (!browser) return;
 	localStorage.removeItem(LOCAL_STORAGE_BEST_SCORE);
+}
+
+/**
+ * Persist selected theme id locally (guest / cache fallback)
+ * @param {string} themeId
+ */
+export function saveThemeId(themeId) {
+	if (!browser) return;
+	localStorage.setItem(LOCAL_STORAGE_THEME, themeId);
+}
+
+/**
+ * @returns {string | null}
+ */
+export function loadThemeId() {
+	if (!browser) return null;
+	const id = localStorage.getItem(LOCAL_STORAGE_THEME);
+	if (id && getTheme(id).id === id) {
+		return id;
+	}
+	return null;
+}
+
+export function clearThemeId() {
+	if (!browser) return;
+	localStorage.removeItem(LOCAL_STORAGE_THEME);
 }

--- a/src/lib/server/db/schema/userSchemas.js
+++ b/src/lib/server/db/schema/userSchemas.js
@@ -20,4 +20,5 @@ export const userProfile = sqliteTable("user_profile", {
 	displayName: text("display_name"),
 	avatarUrl: text("avatar_url"),
 	bestScore: integer("best_score"),
+	themeId: text("theme_id").notNull().default("classic"),
 });

--- a/src/lib/server/theme.js
+++ b/src/lib/server/theme.js
@@ -1,0 +1,100 @@
+import { THEME_COOKIE_NAME, USER_LEVELS } from "$lib/constants";
+import { DEFAULT_THEME_ID, getTheme, resolveTheme } from "$lib/assets/themes";
+import { getUserProfile } from "$lib/server/user";
+import { db } from "$lib/server/db";
+import * as table from "$lib/server/db/schema";
+import { eq } from "drizzle-orm";
+
+const THEME_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+/**
+ * @param {import("@sveltejs/kit").Cookies} cookies
+ * @param {string} themeId
+ */
+export function setThemeCookie(cookies, themeId) {
+	cookies.set(THEME_COOKIE_NAME, themeId, {
+		path: "/",
+		maxAge: THEME_COOKIE_MAX_AGE,
+		sameSite: "lax",
+		httpOnly: false, // readable by client for localStorage sync
+	});
+}
+
+/**
+ * @param {import("@sveltejs/kit").Cookies} cookies
+ * @returns {string}
+ */
+export function getThemeIdFromCookie(cookies) {
+	const value = cookies.get(THEME_COOKIE_NAME);
+	if (value && getTheme(value).id === value) {
+		return value;
+	}
+	return DEFAULT_THEME_ID;
+}
+
+/**
+ * Resolve the active theme for a request: DB preference (logged-in) > cookie > classic.
+ * Pro-locked themes fall back to Classic for free users.
+ *
+ * @param {import("@sveltejs/kit").RequestEvent} event
+ */
+export function loadThemeForEvent(event) {
+	const cookieThemeId = getThemeIdFromCookie(event.cookies);
+	let themeId = cookieThemeId;
+	let isPro = false;
+
+	if (event.locals.user) {
+		const profile = getUserProfile(event.locals.user.id);
+		isPro = profile?.level === USER_LEVELS.PRO;
+		if (profile?.themeId) {
+			themeId = profile.themeId;
+		}
+	}
+
+	const theme = resolveTheme(themeId, isPro);
+
+	if (theme.id !== cookieThemeId) {
+		setThemeCookie(event.cookies, theme.id);
+	}
+
+	return {
+		theme,
+		themeId: theme.id,
+		isPro,
+	};
+}
+
+/**
+ * Persist a theme selection for the current request (cookie always; DB when logged in).
+ * @param {import("@sveltejs/kit").RequestEvent} event
+ * @param {string} themeId
+ * @returns {Promise<{ ok: true, themeId: string } | { ok: false, error: string }>}
+ */
+export async function setThemePreference(event, themeId) {
+	const theme = getTheme(themeId);
+	if (theme.id !== themeId) {
+		return { ok: false, error: "Unknown theme" };
+	}
+
+	let isPro = false;
+	if (event.locals.user) {
+		const profile = getUserProfile(event.locals.user.id);
+		isPro = profile?.level === USER_LEVELS.PRO;
+	}
+
+	if (theme.pro && !isPro) {
+		return { ok: false, error: "That theme requires Pro" };
+	}
+
+	const resolved = resolveTheme(themeId, isPro);
+	setThemeCookie(event.cookies, resolved.id);
+
+	if (event.locals.user) {
+		await db
+			.update(table.userProfile)
+			.set({ themeId: resolved.id })
+			.where(eq(table.userProfile.userId, event.locals.user.id));
+	}
+
+	return { ok: true, themeId: resolved.id };
+}

--- a/src/lib/server/user.js
+++ b/src/lib/server/user.js
@@ -28,6 +28,7 @@ export function getUserProfile(userId) {
 			displayName: table.userProfile.displayName,
 			avatarUrl: table.userProfile.avatarUrl,
 			bestScore: table.userProfile.bestScore,
+			themeId: table.userProfile.themeId,
 		})
 		.from(table.user)
 		.innerJoin(table.userProfile, eq(table.user.id, table.userProfile.userId))

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -1,8 +1,5 @@
-import { defaultTheme } from "$lib/assets/themes";
-
 /** @type {import("./$types").LayoutLoad} */
-export function load() {
-	return {
-		theme: defaultTheme,
-	};
+export function load({ data }) {
+	// Pass through server-resolved theme data (theme object + picker metadata)
+	return data;
 }

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,0 +1,25 @@
+import { loadThemeForEvent } from "$lib/server/theme";
+import { listThemes } from "$lib/assets/themes";
+
+/** @type {import("./$types").LayoutServerLoad} */
+export async function load(event) {
+	const { theme, themeId, isPro } = loadThemeForEvent(event);
+
+	return {
+		theme,
+		themeId,
+		isPro,
+		themes: listThemes().map(
+			({ id, name, pro, primary, secondary, background, boardBackground, emptyTile }) => ({
+				id,
+				name,
+				pro: !!pro,
+				primary,
+				secondary,
+				background,
+				boardBackground,
+				emptyTile,
+			})
+		),
+	};
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,8 +4,16 @@
 	import { page } from "$app/state";
 	import FooterNav from "./FooterNav.svelte";
 	import Seo from "./Seo.svelte";
+	import { saveThemeId } from "$lib/localStorage.svelte";
 
 	let { children } = $props();
+
+	// Keep localStorage in sync with the resolved server theme
+	$effect(() => {
+		if (page.data.themeId) {
+			saveThemeId(page.data.themeId);
+		}
+	});
 
 	/**
 	 * Utility function to darken a color

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -3,7 +3,15 @@
 	import { page } from "$app/state";
 	import Btn from "$lib/components/Btn.svelte";
 	import { clearBestScore, clearGame } from "$lib/localStorage.svelte";
-	import { LogOutIcon, PencilIcon, TrashIcon, CrownIcon, MailIcon, LockIcon } from "@lucide/svelte";
+	import {
+		LogOutIcon,
+		PencilIcon,
+		TrashIcon,
+		CrownIcon,
+		MailIcon,
+		LockIcon,
+		PaletteIcon,
+	} from "@lucide/svelte";
 	import { USER_LEVELS } from "$lib/constants";
 	import ProBadge from "$lib/components/ProBadge.svelte";
 	import { gameState } from "../game/state.svelte";
@@ -104,6 +112,12 @@
 				<PencilIcon size={18} />
 			</div>
 			<div class="flex-5/6 text-start">Edit Profile</div>
+		</Btn>
+		<Btn class="flex w-60 gap-2" href="/themes">
+			<div class="flex flex-1/6 items-center justify-end">
+				<PaletteIcon size={18} />
+			</div>
+			<div class="flex-5/6 text-start">Themes</div>
 		</Btn>
 		{#if data.userProfile.level !== USER_LEVELS.PRO}
 			<a

--- a/src/routes/stripe/+page.svelte
+++ b/src/routes/stripe/+page.svelte
@@ -37,7 +37,7 @@
 		},
 		{
 			name: "Exclusive themes and customization",
-			implemented: false,
+			implemented: true,
 		},
 		{
 			name: "Cross-platform games",

--- a/src/routes/themes/+page.server.js
+++ b/src/routes/themes/+page.server.js
@@ -1,0 +1,27 @@
+import { fail } from "@sveltejs/kit";
+import { setThemePreference } from "$lib/server/theme";
+import { getTheme } from "$lib/assets/themes";
+
+/** @type {import("./$types").PageServerLoad} */
+export async function load({ parent }) {
+	const data = await parent();
+	// Full theme objects for live preview (tiles etc.)
+	return {
+		previewThemes: data.themes.map((meta) => getTheme(meta.id)),
+	};
+}
+
+/** @type {import("./$types").Actions} */
+export const actions = {
+	setTheme: async (event) => {
+		const formData = await event.request.formData();
+		const themeId = formData.get("themeId")?.toString() ?? "";
+
+		const result = await setThemePreference(event, themeId);
+		if (!result.ok) {
+			return fail(400, { theme: { success: false, message: result.error } });
+		}
+
+		return { theme: { success: true, themeId: result.themeId } };
+	},
+};

--- a/src/routes/themes/+page.svelte
+++ b/src/routes/themes/+page.svelte
@@ -1,0 +1,132 @@
+<script>
+	import { enhance } from "$app/forms";
+	import { invalidateAll } from "$app/navigation";
+	import { page } from "$app/state";
+	import ThemePreview from "$lib/components/ThemePreview.svelte";
+	import { saveThemeId } from "$lib/localStorage.svelte";
+	import { CrownIcon } from "@lucide/svelte";
+	import { getTheme } from "$lib/assets/themes";
+
+	let { data, form } = $props();
+
+	let selectedId = $state(data.themeId);
+	let previewId = $state(data.themeId);
+	let saving = $state(false);
+	let errorMessage = $state("");
+
+	$effect(() => {
+		selectedId = data.themeId;
+		previewId = data.themeId;
+	});
+
+	let previewTheme = $derived(getTheme(previewId));
+	let isPro = $derived(!!data.isPro);
+
+	/** @type {import('./$types').SubmitFunction} */
+	function onSelectTheme() {
+		saving = true;
+		errorMessage = "";
+
+		return async ({ result, update }) => {
+			await update({ reset: false });
+
+			if (result.type === "success" && result.data?.theme?.success) {
+				const id = result.data.theme.themeId;
+				selectedId = id;
+				previewId = id;
+				saveThemeId(id);
+				await invalidateAll();
+			} else if (result.type === "failure") {
+				errorMessage = result.data?.theme?.message ?? "Could not save theme";
+			}
+
+			saving = false;
+		};
+	}
+</script>
+
+<svelte:head>
+	<title>Themes - 4096</title>
+	<meta name="description" content="Choose a color theme for 4096." />
+</svelte:head>
+
+<main
+	class="mx-auto h-full w-full max-w-lg overflow-y-auto px-4 pt-10 pb-28"
+	style:color={page.data.theme?.textLight ?? page.data.theme?.text}
+>
+	<h1 class="mb-1 text-3xl font-bold" style:color={page.data.theme?.primary}>Themes</h1>
+	<p class="mb-6 text-sm opacity-80">
+		Pick a preset. The board and UI update immediately. Pro unlocks exclusive palettes.
+	</p>
+
+	{#if errorMessage || form?.theme?.message}
+		<p class="mb-4 text-sm text-red-600">{errorMessage || form?.theme?.message}</p>
+	{/if}
+
+	<div class="mb-6">
+		<p class="mb-2 text-sm font-semibold opacity-70">Preview</p>
+		<div class="mx-auto max-w-[220px]">
+			<ThemePreview theme={previewTheme} selected />
+		</div>
+		<p class="mt-2 text-center text-sm font-medium" style:color={previewTheme.primary}>
+			{previewTheme.name}
+		</p>
+	</div>
+
+	<div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+		{#each data.previewThemes as theme (theme.id)}
+			{@const locked = theme.pro && !isPro}
+			{@const active = selectedId === theme.id}
+			{#if locked}
+				<a
+					href="/stripe"
+					class="theme-card flex flex-col gap-2 rounded-lg p-3 text-left transition-opacity hover:opacity-90"
+					style:background={theme.background}
+					style:color={theme.textLight ?? theme.text}
+					style:border={`2px solid ${active ? theme.primary : theme.emptyTile}`}
+					onmouseenter={() => (previewId = theme.id)}
+					onmouseleave={() => (previewId = selectedId)}
+					onfocus={() => (previewId = theme.id)}
+					onblur={() => (previewId = selectedId)}
+				>
+					<div class="pointer-events-none">
+						<ThemePreview {theme} selected={active} />
+					</div>
+					<div class="flex items-center justify-between gap-1 text-sm font-bold">
+						<span>{theme.name}</span>
+						<span class="inline-flex items-center gap-0.5 text-xs opacity-80">
+							<CrownIcon size={14} />
+							Pro
+						</span>
+					</div>
+				</a>
+			{:else}
+				<form method="post" action="?/setTheme" use:enhance={onSelectTheme} class="contents">
+					<input type="hidden" name="themeId" value={theme.id} />
+					<button
+						type="submit"
+						disabled={saving}
+						class="theme-card flex flex-col gap-2 rounded-lg p-3 text-left transition-transform hover:scale-[1.02] disabled:opacity-60"
+						style:background={theme.background}
+						style:color={theme.textLight ?? theme.text}
+						style:border={`2px solid ${active ? theme.primary : theme.emptyTile}`}
+						onmouseenter={() => (previewId = theme.id)}
+						onmouseleave={() => (previewId = selectedId)}
+						onfocus={() => (previewId = theme.id)}
+						onblur={() => (previewId = selectedId)}
+					>
+						<div class="pointer-events-none">
+							<ThemePreview {theme} selected={active} />
+						</div>
+						<div class="flex items-center justify-between gap-1 text-sm font-bold">
+							<span>{theme.name}</span>
+							{#if active}
+								<span class="text-xs opacity-70">Active</span>
+							{/if}
+						</div>
+					</button>
+				</form>
+			{/if}
+		{/each}
+	</div>
+</main>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #3 — built-in theme presets with a picker and persistence.

## Demo

**Picker (all presets + Pro locks)**

[Themes picker desktop overview](https://cursor.com/agents/bc-019f61ba-7b4e-7935-879d-c27972b1e06f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fthemes-desktop.png)

**Switching presets**

[Classic theme selected](https://cursor.com/agents/bc-019f61ba-7b4e-7935-879d-c27972b1e06f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fthemes-classic.png)
[Dark theme selected](https://cursor.com/agents/bc-019f61ba-7b4e-7935-879d-c27972b1e06f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fthemes-dark.png)
[Light theme selected](https://cursor.com/agents/bc-019f61ba-7b4e-7935-879d-c27972b1e06f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fthemes-light.png)

**In-game**

[Game board with Classic theme](https://cursor.com/agents/bc-019f61ba-7b4e-7935-879d-c27972b1e06f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fgame-classic.png)
[Game board with Dark theme](https://cursor.com/agents/bc-019f61ba-7b4e-7935-879d-c27972b1e06f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fgame-dark.png)

## What’s included
- **6 presets**: Classic (current default), Dark, Light, High Contrast, Soft, Coral
- **Picker UI** at `/themes` with live board preview (hover to preview; click to apply)
- Account page link to Themes
- **Persistence**: `user_profile.theme_id` for logged-in users; cookie + localStorage fallback for everyone
- **Pro gating**: High Contrast, Soft, and Coral require Pro (locked cards link to `/stripe`)
- Stripe upgrade page marks “Exclusive themes and customization” as shipped

## Out of scope (per issue)
- Custom theme editor / freeform color pickers

## Notes
- Rebased onto latest `main` (includes Challenges)
- Migration is now `0008_add_theme_id` (after main’s `0007_safe_bruce_banner`); run `pnpm db:migrate`

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f61ba-7b4e-7935-879d-c27972b1e06f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f61ba-7b4e-7935-879d-c27972b1e06f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

