### PR TITLE
Game History & Replay (Pro)

### DIFF
--- a/drizzle/0006_parched_post.sql
+++ b/drizzle/0006_parched_post.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `game` ADD `moves` text;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,537 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "efa90bdd-20b2-462b-9786-016a569fdfb8",
+  "prevId": "6708621d-d2b2-4aa0-afb7-0d19d6c041ff",
+  "tables": {
+    "email_verification_request": {
+      "name": "email_verification_request",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_verification_request_user_id_user_id_fk": {
+          "name": "email_verification_request_user_id_user_id_fk",
+          "tableFrom": "email_verification_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_session": {
+      "name": "password_reset_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_session_user_id_user_id_fk": {
+          "name": "password_reset_session_user_id_user_id_fk",
+          "tableFrom": "password_reset_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game": {
+      "name": "game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_on": {
+          "name": "completed_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "won": {
+          "name": "won",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "board": {
+          "name": "board",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moves": {
+          "name": "moves",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rng_state": {
+          "name": "rng_state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "move_count": {
+          "name": "move_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "undo_cooldown_remaining": {
+          "name": "undo_cooldown_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_player_id_user_id_fk": {
+          "name": "game_player_id_user_id_fk",
+          "tableFrom": "game",
+          "tableTo": "user",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin": {
+          "name": "admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_score": {
+          "name": "best_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profile_user_id_user_id_fk": {
+          "name": "user_profile_user_id_user_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_session": {
+      "name": "stripe_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_json": {
+          "name": "session_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_session_user_id_user_id_fk": {
+          "name": "stripe_session_user_id_user_id_fk",
+          "tableFrom": "stripe_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1784042375952,
       "tag": "0005_fixed_thunderbolt",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1784051197662,
+      "tag": "0006_parched_post",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/game.svelte.js
+++ b/src/lib/game.svelte.js
@@ -87,6 +87,20 @@ export function isSameGame(game1, game2) {
 }
 
 /**
+ * Resolve the recorded move list when hydrating a Game.
+ * Fresh games start with []; legacy mid-game saves without a moves field are not replayable.
+ * @param {import("./types").GameState | null | undefined} initialState
+ * @returns {number[] | null}
+ */
+function resolveRecordedMoves(initialState) {
+	if (!initialState) return [];
+	if (initialState.moves === null) return null;
+	if (Array.isArray(initialState.moves)) return [...initialState.moves];
+	if ((initialState.moveCount ?? 0) === 0) return [];
+	return null;
+}
+
+/**
  * Game Class
  *
  * Encapsulates the game state and logic
@@ -122,6 +136,12 @@ export class Game {
 		this.undoCooldownRemaining = $state(0);
 		/** @type {boolean} Reactive flag — true when a one-step undo snapshot exists */
 		this.hasUndoSnapshot = $state(false);
+		/**
+		 * Recorded successful move directions for replay.
+		 * null means recording was invalidated (cheat / legacy mid-game).
+		 * @type {number[] | null}
+		 */
+		this.moves = $state(resolveRecordedMoves(initialState));
 
 		const resolvedSeed = seed ?? initialState?.seed ?? generateSeed();
 		/** @type {number} */
@@ -203,8 +223,19 @@ export class Game {
 		this.#previousState = null;
 		this.hasUndoSnapshot = false;
 		this.undoCooldownRemaining = UNDO_COOLDOWN_MOVES;
+		if (this.moves) {
+			this.moves = this.moves.slice(0, -1);
+		}
 
 		return true;
+	}
+
+	/**
+	 * Stop recording moves so this game cannot be replayed from seed+directions
+	 * (used after board transforms that bypass moveTiles).
+	 */
+	invalidateMoveRecording() {
+		this.moves = null;
 	}
 
 	/**
@@ -485,6 +516,9 @@ export class Game {
 			moveQueue.push({ snapshot: newBoard });
 			this.board = newBoard;
 			this.moveCount += 1;
+			if (this.moves) {
+				this.moves = [...this.moves, direction];
+			}
 			if (this.undoCooldownRemaining > 0) {
 				this.undoCooldownRemaining -= 1;
 			}
@@ -517,6 +551,8 @@ export class Game {
 	rotateBoard(factor) {
 		if (factor <= 0) return;
 
+		this.invalidateMoveRecording();
+
 		const newBoard = Array(this.boardSize)
 			.fill(null)
 			.map(() => Array(this.boardSize).fill(0));
@@ -535,6 +571,8 @@ export class Game {
 	 * Mirror the board horizontally
 	 */
 	mirrorBoardHorizontally() {
+		this.invalidateMoveRecording();
+
 		const newBoard = Array(this.boardSize)
 			.fill(null)
 			.map(() => Array(this.boardSize).fill(0));
@@ -551,6 +589,8 @@ export class Game {
 	 * Mirror the board vertically
 	 */
 	mirrorBoardVertically() {
+		this.invalidateMoveRecording();
+
 		const newBoard = Array(this.boardSize)
 			.fill(null)
 			.map(() => Array(this.boardSize).fill(0));
@@ -578,6 +618,7 @@ export class Game {
 			rngState: this.rng.state,
 			moveCount: this.moveCount,
 			undoCooldownRemaining: this.undoCooldownRemaining,
+			moves: this.moves,
 		};
 	}
 }

--- a/src/lib/localStorage.svelte.js
+++ b/src/lib/localStorage.svelte.js
@@ -8,9 +8,19 @@ import { LOCAL_STORAGE_BEST_SCORE, LOCAL_STORAGE_CURRENT_GAME } from "./constant
  *   rngState?: number;
  *   moveCount?: number;
  *   undoCooldownRemaining?: number;
+ *   moves?: number[] | null;
  * }} game
  */
-export function saveGame({ id, board, score, seed, rngState, moveCount, undoCooldownRemaining }) {
+export function saveGame({
+	id,
+	board,
+	score,
+	seed,
+	rngState,
+	moveCount,
+	undoCooldownRemaining,
+	moves,
+}) {
 	if (!browser) return;
 	localStorage.setItem(
 		LOCAL_STORAGE_CURRENT_GAME,
@@ -22,6 +32,7 @@ export function saveGame({ id, board, score, seed, rngState, moveCount, undoCool
 			rngState,
 			moveCount,
 			undoCooldownRemaining,
+			moves: moves ?? null,
 			lastUpdated: Date.now(),
 		})
 	);

--- a/src/lib/server/db/schema/gameSchemas.ts
+++ b/src/lib/server/db/schema/gameSchemas.ts
@@ -15,6 +15,8 @@ export const game = sqliteTable("game", {
 	won: integer("won", { mode: "boolean" }).notNull(),
 	complete: integer("complete", { mode: "boolean" }).notNull(),
 	board: text("board", { mode: "json" }).$type<number[][]>().notNull(),
+	/** Recorded move directions (see DIRECTIONS) for Pro replay — null when not replayable */
+	moves: text("moves", { mode: "json" }).$type<number[] | null>(),
 	seed: integer("seed"),
 	rngState: integer("rng_state"),
 	moveCount: integer("move_count").notNull().default(0),

--- a/src/lib/server/db/schema/index.js
+++ b/src/lib/server/db/schema/index.js
@@ -1,4 +1,4 @@
 export * from "./authSchemas.js";
 export * from "./userSchemas.js";
 export * from "./stripeSchemas.js";
-export * from "./gameSchemas";
+export * from "./gameSchemas.js";

--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -1,6 +1,6 @@
 import * as table from "$lib/server/db/schema";
 import { db } from "$lib/server/db";
-import { and, desc, eq, not } from "drizzle-orm";
+import { and, desc, eq, not, sql } from "drizzle-orm";
 import assert from "node:assert";
 
 /**
@@ -26,6 +26,30 @@ export async function saveScore(score, userId) {
 }
 
 /**
+ * Normalize moves for persistence
+ * @param {number[] | null | undefined} moves
+ * @returns {number[] | null}
+ */
+function normalizeMoves(moves) {
+	if (moves === null) return null;
+	if (Array.isArray(moves)) return moves;
+	return [];
+}
+
+/**
+ * Whether a saved game can be deterministically replayed from seed + moves
+ * @param {{ seed: number | null, moves: number[] | null, moveCount: number }} game
+ */
+export function gameHasReplay(game) {
+	return (
+		game.seed != null &&
+		Array.isArray(game.moves) &&
+		game.moves.length > 0 &&
+		game.moves.length === game.moveCount
+	);
+}
+
+/**
  * Save a game to the database.
  *
  * Creates a game if the id is not in the database.
@@ -44,10 +68,15 @@ export async function saveGame(game) {
 		assert(existingGame, `Game with id ${game.id} not found`);
 	}
 
-	// If game with id already exists, check for win (to save a completedOn date) and update the game
+	const moves = normalizeMoves(game.moves);
+
+	// If game with id already exists, check for completion and update the game
 	if (game.id && existingGame) {
 		let completedOn = existingGame.completedOn;
-		if (!existingGame.won && game.won) {
+		// Stamp completedOn the first time a game finishes (win or loss)
+		if (!existingGame.complete && game.complete) {
+			completedOn = new Date();
+		} else if (!existingGame.won && game.won && !completedOn) {
 			completedOn = new Date();
 		}
 
@@ -62,6 +91,7 @@ export async function saveGame(game) {
 				rngState: game.rngState ?? null,
 				moveCount: game.moveCount ?? 0,
 				undoCooldownRemaining: game.undoCooldownRemaining ?? 0,
+				moves,
 				completedOn,
 				updatedOn: new Date(),
 			})
@@ -70,6 +100,7 @@ export async function saveGame(game) {
 
 	// If game did not exist in db, create it.
 	else {
+		const now = new Date();
 		const newGame = db
 			.insert(table.game)
 			.values({
@@ -83,8 +114,10 @@ export async function saveGame(game) {
 				rngState: game.rngState ?? null,
 				moveCount: game.moveCount ?? 0,
 				undoCooldownRemaining: game.undoCooldownRemaining ?? 0,
-				createdOn: new Date(),
-				updatedOn: new Date(),
+				moves,
+				createdOn: now,
+				updatedOn: now,
+				completedOn: game.complete ? now : null,
 			})
 			.returning({ id: table.game.id })
 			.get();
@@ -106,6 +139,105 @@ export function getCurrentGame(userId) {
 		.from(table.game)
 		.where(and(eq(table.game.playerId, userId), not(eq(table.game.complete, true))))
 		.orderBy(desc(table.game.updatedOn))
+		.get();
+
+	return game ?? null;
+}
+
+/**
+ * List completed games for history (Pro feature)
+ *
+ * @param {string} userId
+ * @param {{
+ *   sort?: import("$lib/types").GameHistorySort,
+ *   filter?: import("$lib/types").GameHistoryFilter,
+ *   limit?: number,
+ *   offset?: number,
+ * }} [options]
+ * @returns {import("$lib/types").GameHistoryEntry[]}
+ */
+export function getCompletedGames(userId, options = {}) {
+	const sort = options.sort ?? "date";
+	const filter = options.filter ?? "all";
+	const limit = options.limit ?? 50;
+	const offset = options.offset ?? 0;
+
+	/** @type {import("drizzle-orm").SQL | undefined} */
+	let filterClause;
+	if (filter === "won") {
+		filterClause = eq(table.game.won, true);
+	} else if (filter === "lost") {
+		filterClause = and(eq(table.game.won, false), eq(table.game.complete, true));
+	}
+
+	const whereClause = filterClause
+		? and(eq(table.game.playerId, userId), eq(table.game.complete, true), filterClause)
+		: and(eq(table.game.playerId, userId), eq(table.game.complete, true));
+
+	/** @type {import("drizzle-orm").SQL[]} */
+	let orderBy;
+	if (sort === "score") {
+		orderBy = [desc(table.game.score), desc(table.game.updatedOn)];
+	} else if (sort === "moves") {
+		orderBy = [desc(table.game.moveCount), desc(table.game.updatedOn)];
+	} else {
+		// Prefer completedOn when present, fall back to updatedOn
+		orderBy = [
+			desc(sql`coalesce(${table.game.completedOn}, ${table.game.updatedOn})`),
+			desc(table.game.updatedOn),
+		];
+	}
+
+	const rows = db
+		.select({
+			id: table.game.id,
+			score: table.game.score,
+			won: table.game.won,
+			complete: table.game.complete,
+			moveCount: table.game.moveCount,
+			createdOn: table.game.createdOn,
+			updatedOn: table.game.updatedOn,
+			completedOn: table.game.completedOn,
+			seed: table.game.seed,
+			moves: table.game.moves,
+		})
+		.from(table.game)
+		.where(whereClause)
+		.orderBy(...orderBy)
+		.limit(limit)
+		.offset(offset)
+		.all();
+
+	return rows.map((row) => ({
+		id: row.id,
+		score: row.score ?? 0,
+		won: row.won,
+		complete: row.complete,
+		moveCount: row.moveCount,
+		createdOn: row.createdOn,
+		updatedOn: row.updatedOn,
+		completedOn: row.completedOn,
+		hasReplay: gameHasReplay({
+			seed: row.seed,
+			moves: row.moves,
+			moveCount: row.moveCount,
+		}),
+	}));
+}
+
+/**
+ * Get a completed game owned by the user (for replay)
+ *
+ * @param {string} gameId
+ * @param {string} userId
+ */
+export function getCompletedGameById(gameId, userId) {
+	const game = db
+		.select()
+		.from(table.game)
+		.where(
+			and(eq(table.game.id, gameId), eq(table.game.playerId, userId), eq(table.game.complete, true))
+		)
 		.get();
 
 	return game ?? null;

--- a/src/lib/tileAnimator.js
+++ b/src/lib/tileAnimator.js
@@ -47,10 +47,23 @@ export class TileAnimator {
 
 	#lastTimestamp = 0;
 
-	/** @param {{ onAnimatingChange?: (animating: boolean) => void, onFrame?: () => void }} [options] */
+	/** Playback speed multiplier (1 = normal). Higher values shorten animation durations. */
+	#speed = 1;
+
+	/** @param {{ onAnimatingChange?: (animating: boolean) => void, onFrame?: () => void, speed?: number }} [options] */
 	constructor(options = {}) {
 		this.#onAnimatingChange = options.onAnimatingChange;
 		this.#onFrame = options.onFrame;
+		if (options.speed != null) {
+			this.#speed = Math.max(0.25, options.speed);
+		}
+	}
+
+	/**
+	 * @param {number} speed
+	 */
+	setSpeed(speed) {
+		this.#speed = Math.max(0.25, speed);
 	}
 
 	/**
@@ -239,8 +252,9 @@ export class TileAnimator {
 	}
 
 	#animate = (timestamp) => {
-		const dt = Math.min(timestamp - this.#lastTimestamp, 32);
+		const rawDt = Math.min(timestamp - this.#lastTimestamp, 32);
 		this.#lastTimestamp = timestamp;
+		const dt = rawDt * this.#speed;
 
 		let allComplete = true;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,6 +70,8 @@ export interface GameState {
   rngState?: number;
   moveCount?: number;
   undoCooldownRemaining?: number;
+  /** Recorded move directions; null when replay was invalidated (e.g. cheat) */
+  moves?: number[] | null;
 }
 
 export interface GameSaveData {
@@ -83,4 +85,21 @@ export interface GameSaveData {
   rngState?: number;
   moveCount?: number;
   undoCooldownRemaining?: number;
+  /** Recorded move directions; null when replay was invalidated (e.g. cheat) */
+  moves?: number[] | null;
 }
+
+export interface GameHistoryEntry {
+  id: string;
+  score: number;
+  won: boolean;
+  complete: boolean;
+  moveCount: number;
+  createdOn: Date;
+  updatedOn: Date;
+  completedOn: Date | null;
+  hasReplay: boolean;
+}
+
+export type GameHistorySort = "date" | "score" | "moves";
+export type GameHistoryFilter = "all" | "won" | "lost";

--- a/src/routes/game/+page.server.js
+++ b/src/routes/game/+page.server.js
@@ -19,6 +19,7 @@ export function load({ locals }) {
 				rngState: dbGame.rngState ?? undefined,
 				moveCount: dbGame.moveCount ?? 0,
 				undoCooldownRemaining: dbGame.undoCooldownRemaining ?? 0,
+				moves: dbGame.moves ?? null,
 				lastUpdated: dbGame.updatedOn.getTime(),
 			};
 		}

--- a/src/routes/game/components/AnimatedBoard.svelte
+++ b/src/routes/game/components/AnimatedBoard.svelte
@@ -12,9 +12,28 @@
 	const PADDING = 10;
 	const TILE_BORDER_RADIUS = 6;
 
-	let { pendingEvents = [], popEvent, onUndo = undefined } = $props();
+	/**
+	 * @type {{
+	 *   pendingEvents?: import("$lib/types").GameEvent[],
+	 *   popEvent: () => import("$lib/types").GameEvent | undefined,
+	 *   onUndo?: () => void,
+	 *   game?: import("$lib/game.svelte.js").Game | null,
+	 *   showControls?: boolean,
+	 *   speed?: number,
+	 *   animationIdle?: boolean,
+	 * }}
+	 */
+	let {
+		pendingEvents = [],
+		popEvent,
+		onUndo = undefined,
+		game: gameProp = undefined,
+		showControls = true,
+		speed = 1,
+		animationIdle = $bindable(true),
+	} = $props();
 
-	let game = $derived(gameState.currentGame);
+	let game = $derived(gameProp !== undefined ? gameProp : gameState.currentGame);
 	let theme = $derived(page.data.theme || defaultTheme);
 
 	/** @type {HTMLDivElement | null} */
@@ -30,9 +49,17 @@
 		onFrame: () => {
 			frame += 1;
 		},
+		speed,
 	});
 
-	let animationIdle = $derived(!animating && pendingEvents.length === 0);
+	$effect(() => {
+		animator.setSpeed(speed);
+	});
+
+	$effect(() => {
+		animationIdle = !animating && pendingEvents.length === 0;
+	});
+
 	let renderTiles = $derived.by(() => {
 		frame;
 		return animator.tiles;
@@ -152,9 +179,23 @@
 		frame += 1;
 		onUndo?.();
 	}
+
+	/**
+	 * Force visual resync from the current game board (used by replay reset/scrub)
+	 */
+	export function syncBoard() {
+		if (!game) return;
+		pendingEvents.splice(0, pendingEvents.length);
+		animator.syncFromBoard(game.board);
+		boardSignature = JSON.stringify(game.board);
+		syncedGame = game;
+		frame += 1;
+	}
 </script>
 
-<GameControls {animationIdle} onUndo={handleUndo} />
+{#if showControls}
+	<GameControls {animationIdle} onUndo={handleUndo} />
+{/if}
 
 <div class="board-container" bind:this={boardContainer}>
 	<div

--- a/src/routes/replay/+page.server.js
+++ b/src/routes/replay/+page.server.js
@@ -1,0 +1,33 @@
+import { USER_LEVELS } from "$lib/constants";
+import { getCompletedGames } from "$lib/server/game";
+import { getUserProfile } from "$lib/server/user";
+
+/** @type {import("./$types").PageServerLoad} */
+export function load({ locals, url }) {
+	const user = locals.user ? getUserProfile(locals.user.id) : null;
+	const isPro = user?.level === USER_LEVELS.PRO;
+
+	/** @type {import("$lib/types").GameHistorySort} */
+	const sortParam = /** @type {import("$lib/types").GameHistorySort} */ (
+		url.searchParams.get("sort")
+	);
+	/** @type {import("$lib/types").GameHistoryFilter} */
+	const filterParam = /** @type {import("$lib/types").GameHistoryFilter} */ (
+		url.searchParams.get("filter")
+	);
+
+	const sort =
+		sortParam === "score" || sortParam === "moves" || sortParam === "date" ? sortParam : "date";
+	const filter =
+		filterParam === "won" || filterParam === "lost" || filterParam === "all" ? filterParam : "all";
+
+	const games = isPro && user ? getCompletedGames(user.id, { sort, filter }) : [];
+
+	return {
+		user,
+		isPro,
+		games,
+		sort,
+		filter,
+	};
+}

--- a/src/routes/replay/+page.svelte
+++ b/src/routes/replay/+page.svelte
@@ -1,11 +1,144 @@
 <script>
 	import { page } from "$app/state";
+	import Btn from "$lib/components/Btn.svelte";
+	import { USER_LEVELS } from "$lib/constants";
+	import { PlayIcon } from "@lucide/svelte";
+
+	let { data } = $props();
+
+	/**
+	 * @param {Date | string | null} value
+	 */
+	function formatDate(value) {
+		if (!value) return "—";
+		const date = value instanceof Date ? value : new Date(value);
+		return date.toLocaleString(undefined, {
+			month: "short",
+			day: "numeric",
+			year: "numeric",
+			hour: "numeric",
+			minute: "2-digit",
+		});
+	}
+
+	/**
+	 * Build a history URL preserving other query params
+	 * @param {{ sort?: string, filter?: string }} updates
+	 */
+	function historyHref(updates) {
+		const sort = updates.sort ?? data.sort;
+		const filter = updates.filter ?? data.filter;
+		return `/replay?sort=${encodeURIComponent(sort)}&filter=${encodeURIComponent(filter)}`;
+	}
 </script>
 
-<main class="mx-auto mt-10 p-8" style:color={page.data.theme?.primary}>
-	<h1 class="text-3xl font-bold">My Past Games</h1>
-	<p class="text-sm text-gray-500">
-		This page is coming soon. Check back later to see your past games, replay them, and create
-		checkpoints.
+<svelte:head>
+	<title>Game History - 4096</title>
+	<meta name="description" content="Browse and replay your completed 4096 games." />
+</svelte:head>
+
+<main class="mx-auto mt-10 mb-[5rem] w-full max-w-lg p-8" style:color={page.data.theme?.primary}>
+	<h1 class="text-3xl font-bold">Game History</h1>
+	<p class="mb-4 text-sm text-gray-500">
+		Completed games only — replay wins and losses move by move.
 	</p>
+
+	{#if !data.user}
+		<div class="rounded-lg border border-dashed border-gray-300 px-6 py-12 text-center">
+			<p class="mb-1 font-semibold text-gray-700">Sign in to view your history</p>
+			<p class="mb-4 text-sm text-gray-500">
+				Game history and replay are available for Pro players.
+			</p>
+			<Btn href="/login?redirectTo=/replay" class="justify-center">Log in</Btn>
+		</div>
+	{:else if data.user.level !== USER_LEVELS.PRO}
+		<div
+			class="rounded-lg border border-dashed border-orange-200 bg-orange-50 px-6 py-12 text-center"
+		>
+			<p class="mb-1 font-semibold text-gray-800">Pro feature</p>
+			<p class="mb-4 text-sm text-gray-600">
+				Upgrade to Pro to browse past games and watch move-by-move replays.
+			</p>
+			<Btn href="/stripe" class="justify-center">Upgrade to Pro</Btn>
+		</div>
+	{:else}
+		<div class="mb-4 flex flex-wrap gap-2">
+			<div class="flex flex-1 gap-1 rounded-md bg-gray-100 p-1">
+				{#each [{ key: "all", label: "All" }, { key: "won", label: "Wins" }, { key: "lost", label: "Losses" }] as option (option.key)}
+					<a
+						href={historyHref({ filter: option.key })}
+						class="flex-1 rounded px-2 py-1.5 text-center text-sm font-semibold transition-colors {data.filter ===
+						option.key
+							? 'bg-[var(--color-secondary)] text-gray-900'
+							: 'text-gray-600 hover:bg-gray-200'}"
+					>
+						{option.label}
+					</a>
+				{/each}
+			</div>
+		</div>
+
+		<div class="mb-4 flex items-center gap-2 text-sm text-gray-600">
+			<span class="shrink-0">Sort:</span>
+			{#each [{ key: "date", label: "Date" }, { key: "score", label: "Score" }, { key: "moves", label: "Moves" }] as option (option.key)}
+				<a
+					href={historyHref({ sort: option.key })}
+					class="rounded px-2 py-1 font-medium {data.sort === option.key
+						? 'bg-gray-200 text-gray-900'
+						: 'hover:bg-gray-100'}"
+				>
+					{option.label}
+				</a>
+			{/each}
+		</div>
+
+		{#if data.games.length === 0}
+			<div class="rounded-lg border border-dashed border-gray-300 px-6 py-12 text-center">
+				<p class="mb-1 font-semibold text-gray-700">No completed games yet</p>
+				<p class="mb-4 text-sm text-gray-500">
+					Finish a game (win or lose) and it will show up here for replay.
+				</p>
+				<Btn href="/game" class="justify-center">Play a game</Btn>
+			</div>
+		{:else}
+			<ul class="space-y-2">
+				{#each data.games as game (game.id)}
+					<li
+						class="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-3 text-gray-800"
+					>
+						<div
+							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xs font-bold {game.won
+								? 'bg-green-100 text-green-700'
+								: 'bg-red-100 text-red-700'}"
+						>
+							{game.won ? "WIN" : "LOSS"}
+						</div>
+						<div class="min-w-0 flex-1">
+							<div class="flex items-baseline gap-2">
+								<span class="text-lg font-bold">{game.score.toLocaleString()}</span>
+								<span class="text-xs text-gray-500">{game.moveCount} moves</span>
+							</div>
+							<div class="truncate text-xs text-gray-500">
+								{formatDate(game.completedOn ?? game.updatedOn)}
+							</div>
+						</div>
+						{#if game.hasReplay}
+							<a
+								href="/replay/{game.id}"
+								class="inline-flex items-center gap-1 rounded-md bg-[var(--color-primary)] px-3 py-2 text-sm font-bold text-white"
+								aria-label="Replay game"
+							>
+								<PlayIcon size={16} />
+								Replay
+							</a>
+						{:else}
+							<span class="text-xs text-gray-400" title="Move list unavailable for this game">
+								No replay
+							</span>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	{/if}
 </main>

--- a/src/routes/replay/[id]/+page.server.js
+++ b/src/routes/replay/[id]/+page.server.js
@@ -1,0 +1,43 @@
+import { error, redirect } from "@sveltejs/kit";
+import { USER_LEVELS } from "$lib/constants";
+import { gameHasReplay, getCompletedGameById } from "$lib/server/game";
+import { requireLoginProfile } from "$lib/server/user";
+
+/** @type {import("./$types").PageServerLoad} */
+export function load({ params }) {
+	const user = requireLoginProfile();
+
+	if (user.level !== USER_LEVELS.PRO) {
+		redirect(302, "/stripe");
+	}
+
+	const game = getCompletedGameById(params.id, user.id);
+	if (!game) {
+		error(404, "Game not found");
+	}
+
+	const hasReplay = gameHasReplay({
+		seed: game.seed,
+		moves: game.moves,
+		moveCount: game.moveCount,
+	});
+
+	if (!hasReplay || game.seed == null || !Array.isArray(game.moves)) {
+		error(400, "This game cannot be replayed");
+	}
+
+	return {
+		user,
+		replay: {
+			id: game.id,
+			score: game.score ?? 0,
+			won: game.won,
+			complete: game.complete,
+			moveCount: game.moveCount,
+			seed: game.seed,
+			moves: game.moves,
+			completedOn: game.completedOn,
+			updatedOn: game.updatedOn,
+		},
+	};
+}

--- a/src/routes/replay/[id]/+page.svelte
+++ b/src/routes/replay/[id]/+page.svelte
@@ -116,7 +116,7 @@
 </svelte:head>
 
 <main
-	class="game-container mx-auto mt-6 mb-[5rem] w-full max-w-lg px-4"
+	class="game-container mx-auto mt-6 mb-[8rem] w-full max-w-lg px-4"
 	style:color={page.data.theme?.primary}
 >
 	<div class="mb-3 flex items-center gap-2">
@@ -156,7 +156,7 @@
 			{speed}
 		/>
 
-		<div class="mt-2">
+		<div class="relative z-10 mt-2 pb-4">
 			<div class="mb-3 h-1.5 overflow-hidden rounded-full bg-gray-200">
 				<div
 					class="h-full rounded-full bg-[var(--color-primary)] transition-[width] duration-150"

--- a/src/routes/replay/[id]/+page.svelte
+++ b/src/routes/replay/[id]/+page.svelte
@@ -1,0 +1,211 @@
+<script>
+	import { browser } from "$app/environment";
+	import { page } from "$app/state";
+	import { Game } from "$lib/game.svelte.js";
+	import AnimatedBoard from "../../game/components/AnimatedBoard.svelte";
+	import {
+		PauseIcon,
+		PlayIcon,
+		RotateCcwIcon,
+		SkipForwardIcon,
+		ChevronLeftIcon,
+	} from "@lucide/svelte";
+
+	let { data } = $props();
+
+	const SPEED_OPTIONS = [1, 2, 4, 8];
+
+	/** @type {import("$lib/types").GameEvent[]} */
+	let pendingEvents = $state([]);
+	let animationIdle = $state(true);
+	let playing = $state(false);
+	let speed = $state(2);
+	let moveIndex = $state(0);
+	/** @type {import("$lib/game.svelte.js").Game | null} */
+	let replayGame = $state(null);
+	/** @type {{ syncBoard: () => void } | null} */
+	let boardRef = $state(null);
+
+	let totalMoves = $derived(data.replay.moves.length);
+	let atEnd = $derived(moveIndex >= totalMoves);
+	let progressLabel = $derived(`${Math.min(moveIndex, totalMoves)} / ${totalMoves}`);
+
+	/**
+	 * Recreate the game from seed (opening tiles) — no final board
+	 */
+	function createReplayGame() {
+		return new Game({ seed: data.replay.seed });
+	}
+
+	function resetReplay() {
+		playing = false;
+		pendingEvents = [];
+		moveIndex = 0;
+		replayGame = createReplayGame();
+		queueMicrotask(() => boardRef?.syncBoard());
+	}
+
+	/**
+	 * @returns {import("$lib/types").GameEvent | undefined}
+	 */
+	function popEvent() {
+		return pendingEvents.shift();
+	}
+
+	/**
+	 * Apply the next recorded direction and queue animation events
+	 * @returns {boolean} Whether a move was applied
+	 */
+	function stepForward() {
+		if (!replayGame || atEnd || pendingEvents.length > 0 || !animationIdle) return false;
+
+		const direction = data.replay.moves[moveIndex];
+		const events = replayGame.moveTiles(direction);
+		if (events.length === 0) {
+			// Corrupted / desynced move — stop playback
+			playing = false;
+			return false;
+		}
+
+		pendingEvents.push(...events);
+		moveIndex += 1;
+		return true;
+	}
+
+	function togglePlay() {
+		if (atEnd) {
+			resetReplay();
+			playing = true;
+			return;
+		}
+		playing = !playing;
+	}
+
+	function cycleSpeed() {
+		const idx = SPEED_OPTIONS.indexOf(speed);
+		speed = SPEED_OPTIONS[(idx + 1) % SPEED_OPTIONS.length];
+	}
+
+	// Autoplay: when idle and playing, advance
+	$effect(() => {
+		if (!browser || !playing || !animationIdle || atEnd) {
+			if (atEnd) playing = false;
+			return;
+		}
+
+		const timer = setTimeout(() => {
+			if (!stepForward()) {
+				playing = false;
+			}
+		}, 16);
+
+		return () => clearTimeout(timer);
+	});
+
+	$effect(() => {
+		if (!browser) return;
+		// Initialize once from loaded replay data
+		data.replay.id;
+		resetReplay();
+	});
+</script>
+
+<svelte:head>
+	<title>Replay - 4096</title>
+	<meta name="description" content="Watch a move-by-move replay of a completed 4096 game." />
+</svelte:head>
+
+<main
+	class="game-container mx-auto mt-6 mb-[5rem] w-full max-w-lg px-4"
+	style:color={page.data.theme?.primary}
+>
+	<div class="mb-3 flex items-center gap-2">
+		<a
+			href="/replay"
+			class="inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm text-gray-600 hover:bg-gray-100"
+		>
+			<ChevronLeftIcon size={16} />
+			History
+		</a>
+		<span class="text-sm text-gray-400">·</span>
+		<span
+			class="rounded-full px-2 py-0.5 text-xs font-bold {data.replay.won
+				? 'bg-green-100 text-green-700'
+				: 'bg-red-100 text-red-700'}"
+		>
+			{data.replay.won ? "Win" : "Loss"}
+		</span>
+		<span class="text-sm font-semibold text-gray-700">
+			{data.replay.score.toLocaleString()} pts
+		</span>
+	</div>
+
+	{#if replayGame}
+		<div class="mb-2 flex items-center justify-between text-sm text-gray-600">
+			<span>Score: <strong class="text-gray-900">{replayGame.score.toLocaleString()}</strong></span>
+			<span>Move {progressLabel}</span>
+		</div>
+
+		<AnimatedBoard
+			bind:this={boardRef}
+			bind:animationIdle
+			game={replayGame}
+			{pendingEvents}
+			{popEvent}
+			showControls={false}
+			{speed}
+		/>
+
+		<div class="mt-2">
+			<div class="mb-3 h-1.5 overflow-hidden rounded-full bg-gray-200">
+				<div
+					class="h-full rounded-full bg-[var(--color-primary)] transition-[width] duration-150"
+					style:width={`${totalMoves ? (moveIndex / totalMoves) * 100 : 0}%`}
+				></div>
+			</div>
+
+			<div class="flex items-center justify-center gap-2">
+				<button
+					type="button"
+					class="inline-flex items-center justify-center rounded-md bg-gray-100 p-3 text-gray-800 hover:bg-gray-200"
+					onclick={resetReplay}
+					aria-label="Restart replay"
+				>
+					<RotateCcwIcon size={20} />
+				</button>
+
+				<button
+					type="button"
+					class="inline-flex items-center justify-center rounded-md bg-[var(--color-primary)] p-3 text-white"
+					onclick={togglePlay}
+					aria-label={playing ? "Pause" : "Play"}
+				>
+					{#if playing}
+						<PauseIcon size={22} />
+					{:else}
+						<PlayIcon size={22} />
+					{/if}
+				</button>
+
+				<button
+					type="button"
+					class="inline-flex items-center justify-center rounded-md bg-gray-100 p-3 text-gray-800 hover:bg-gray-200 disabled:opacity-40"
+					onclick={() => stepForward()}
+					disabled={playing || atEnd || !animationIdle}
+					aria-label="Step forward"
+				>
+					<SkipForwardIcon size={20} />
+				</button>
+
+				<button
+					type="button"
+					class="min-w-[3.5rem] rounded-md bg-gray-100 px-3 py-3 text-sm font-bold text-gray-800 hover:bg-gray-200"
+					onclick={cycleSpeed}
+					aria-label="Playback speed"
+				>
+					{speed}x
+				</button>
+			</div>
+		</div>
+	{/if}
+</main>

--- a/src/routes/stripe/+page.svelte
+++ b/src/routes/stripe/+page.svelte
@@ -29,7 +29,7 @@
 		},
 		{
 			name: "Game History & Replay",
-			implemented: false,
+			implemented: true,
 		},
 		{
 			name: "Board Power Ups & Checkpoints",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #1 — Game History & Replay for completed games.

## Changes
- Persist a `moves` JSON array on `game` (migration `0006`) with direction ints recorded on each successful move (popped on undo; invalidated by rotate/mirror cheats)
- Set `completedOn` when a game completes (win or loss)
- History UI at `/replay` with win/loss filter and date/score/moves sort; empty and Pro upgrade states
- Replay UI at `/replay/[id]` regenerating play from `seed` + moves through the existing `AnimatedBoard` / `TileAnimator` pipeline with play/pause, step, and 1×–8× speed
- Pro soft-gate on history list; hard gate on replay detail (`/stripe`)
- Mark “Game History & Replay” as implemented on the Stripe upgrade page

## Testing
- Inserted completed win/loss fixtures; filters and sort behave correctly
- Stepped/played a 251-move replay at 8×; restart returns to move 0
- Live play persists `moves` on throttled save
- Free users see upgrade CTA on `/replay`; replay detail redirects to `/stripe`
- `pnpm build` succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f61b9-fb21-7a1c-a46e-c5b25a9f9624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f61b9-fb21-7a1c-a46e-c5b25a9f9624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

