### PR TITLE
Add Challenges (time, clear, recovery)

### DIFF
--- a/drizzle/0007_safe_bruce_banner.sql
+++ b/drizzle/0007_safe_bruce_banner.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `challenge_run` (
+	`id` text PRIMARY KEY NOT NULL,
+	`challenge_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`status` text NOT NULL,
+	`score` integer DEFAULT 0 NOT NULL,
+	`metrics` text,
+	`started_on` integer NOT NULL,
+	`finished_on` integer,
+	`updated_on` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,625 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7a06cc49-22e8-4ba2-8bf4-78ebcd926ada",
+  "prevId": "efa90bdd-20b2-462b-9786-016a569fdfb8",
+  "tables": {
+    "email_verification_request": {
+      "name": "email_verification_request",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_verification_request_user_id_user_id_fk": {
+          "name": "email_verification_request_user_id_user_id_fk",
+          "tableFrom": "email_verification_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_session": {
+      "name": "password_reset_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_session_user_id_user_id_fk": {
+          "name": "password_reset_session_user_id_user_id_fk",
+          "tableFrom": "password_reset_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "challenge_run": {
+      "name": "challenge_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_on": {
+          "name": "started_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_on": {
+          "name": "finished_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_run_user_id_user_id_fk": {
+          "name": "challenge_run_user_id_user_id_fk",
+          "tableFrom": "challenge_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game": {
+      "name": "game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_on": {
+          "name": "completed_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "won": {
+          "name": "won",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "board": {
+          "name": "board",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moves": {
+          "name": "moves",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rng_state": {
+          "name": "rng_state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "move_count": {
+          "name": "move_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "undo_cooldown_remaining": {
+          "name": "undo_cooldown_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_player_id_user_id_fk": {
+          "name": "game_player_id_user_id_fk",
+          "tableFrom": "game",
+          "tableTo": "user",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin": {
+          "name": "admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_score": {
+          "name": "best_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profile_user_id_user_id_fk": {
+          "name": "user_profile_user_id_user_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_session": {
+      "name": "stripe_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_json": {
+          "name": "session_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_session_user_id_user_id_fk": {
+          "name": "stripe_session_user_id_user_id_fk",
+          "tableFrom": "stripe_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1784051197662,
       "tag": "0006_parched_post",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1784073723842,
+      "tag": "0007_safe_bruce_banner",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/challenges.js
+++ b/src/lib/challenges.js
@@ -1,0 +1,207 @@
+/**
+ * Challenge content definitions (static for v1).
+ * Three types: time, clear, recovery — see issue #5.
+ */
+
+export const CHALLENGE_TYPES = {
+	TIME: "time",
+	CLEAR: "clear",
+	RECOVERY: "recovery",
+};
+
+export const CHALLENGE_RUN_STATUS = {
+	IN_PROGRESS: "in_progress",
+	WON: "won",
+	LOST: "lost",
+	ABANDONED: "abandoned",
+};
+
+/**
+ * @typedef {Object} TimeChallengeParams
+ * @property {number} [seed]
+ * @property {number[][]} [board]
+ * @property {number} targetScore
+ * @property {number} durationSec
+ */
+
+/**
+ * @typedef {Object} ClearChallengeParams
+ * @property {number} [seed]
+ * @property {number[][]} board
+ * @property {number} [maxFilled] Success when occupied cells ≤ this
+ * @property {number} [clearPercent] Success when occupied ≤ ceil(initial * (1 - percent/100))
+ */
+
+/**
+ * @typedef {Object} RecoveryChallengeParams
+ * @property {number} [seed]
+ * @property {number[][]} board
+ * @property {number} [winTile]
+ */
+
+/**
+ * @typedef {Object} ChallengeDefinition
+ * @property {string} id
+ * @property {typeof CHALLENGE_TYPES[keyof typeof CHALLENGE_TYPES]} type
+ * @property {string} title
+ * @property {string} description
+ * @property {string} difficulty
+ * @property {TimeChallengeParams | ClearChallengeParams | RecoveryChallengeParams} params
+ */
+
+/** @type {ChallengeDefinition[]} */
+export const CHALLENGES = [
+	{
+		id: "sprint-500",
+		type: CHALLENGE_TYPES.TIME,
+		title: "Score Sprint",
+		description: "Reach 500 points before the clock hits zero. Starts from a fresh board.",
+		difficulty: "Easy",
+		params: {
+			seed: 2048,
+			targetScore: 500,
+			durationSec: 60,
+		},
+	},
+	{
+		id: "space-maker",
+		type: CHALLENGE_TYPES.CLEAR,
+		title: "Space Maker",
+		description: "This board is packed. Merge until 4 or fewer tiles remain.",
+		difficulty: "Medium",
+		params: {
+			seed: 4096,
+			board: [
+				[2, 2, 4, 4],
+				[8, 8, 16, 16],
+				[2, 2, 4, 4],
+				[8, 8, 0, 0],
+			],
+			maxFilled: 4,
+		},
+	},
+	{
+		id: "near-miss",
+		type: CHALLENGE_TYPES.RECOVERY,
+		title: "Near Miss",
+		description: "Pull off a 2048 from this awkward high-tile scramble.",
+		difficulty: "Hard",
+		params: {
+			seed: 1024,
+			winTile: 2048,
+			board: [
+				[1024, 512, 256, 128],
+				[4, 8, 16, 32],
+				[2, 64, 0, 0],
+				[0, 0, 0, 0],
+			],
+		},
+	},
+];
+
+/**
+ * @param {string} id
+ * @returns {ChallengeDefinition | undefined}
+ */
+export function getChallengeById(id) {
+	return CHALLENGES.find((c) => c.id === id);
+}
+
+/**
+ * Count occupied (non-zero) cells on a board.
+ * @param {number[][]} board
+ */
+export function countFilledCells(board) {
+	let count = 0;
+	for (const row of board) {
+		for (const cell of row) {
+			if (cell !== 0) count += 1;
+		}
+	}
+	return count;
+}
+
+/**
+ * Resolve the clear-board filled-cell target from challenge params.
+ * @param {ClearChallengeParams} params
+ */
+export function resolveClearTarget(params) {
+	const initialFilled = countFilledCells(params.board);
+	if (typeof params.maxFilled === "number") {
+		return params.maxFilled;
+	}
+	if (typeof params.clearPercent === "number") {
+		return Math.ceil(initialFilled * (1 - params.clearPercent / 100));
+	}
+	return 0;
+}
+
+/**
+ * Evaluate whether a challenge run has succeeded or failed.
+ *
+ * @param {ChallengeDefinition} challenge
+ * @param {{
+ *   board: number[][];
+ *   score: number;
+ *   gameOver: boolean;
+ *   won: boolean;
+ *   elapsedMs?: number;
+ * }} state
+ * @returns {'won' | 'lost' | 'ongoing'}
+ */
+export function evaluateChallenge(challenge, state) {
+	const { type, params } = challenge;
+
+	if (type === CHALLENGE_TYPES.TIME) {
+		const { targetScore, durationSec } = /** @type {TimeChallengeParams} */ (params);
+		const elapsedMs = state.elapsedMs ?? 0;
+		if (state.score >= targetScore) return "won";
+		if (elapsedMs >= durationSec * 1000) return "lost";
+		if (state.gameOver) return "lost";
+		return "ongoing";
+	}
+
+	if (type === CHALLENGE_TYPES.CLEAR) {
+		const clearParams = /** @type {ClearChallengeParams} */ (params);
+		const target = resolveClearTarget(clearParams);
+		if (countFilledCells(state.board) <= target) return "won";
+		if (state.gameOver) return "lost";
+		return "ongoing";
+	}
+
+	if (type === CHALLENGE_TYPES.RECOVERY) {
+		const { winTile = 4096 } = /** @type {RecoveryChallengeParams} */ (params);
+		const hasWinTile = state.board.some((row) => row.some((cell) => cell >= winTile));
+		if (state.won || hasWinTile) return "won";
+		if (state.gameOver) return "lost";
+		return "ongoing";
+	}
+
+	return "ongoing";
+}
+
+/**
+ * Human-readable objective line for UI.
+ * @param {ChallengeDefinition} challenge
+ */
+export function formatChallengeObjective(challenge) {
+	const { type, params } = challenge;
+
+	if (type === CHALLENGE_TYPES.TIME) {
+		const p = /** @type {TimeChallengeParams} */ (params);
+		return `Score ${p.targetScore.toLocaleString()} in ${p.durationSec}s`;
+	}
+
+	if (type === CHALLENGE_TYPES.CLEAR) {
+		const p = /** @type {ClearChallengeParams} */ (params);
+		const target = resolveClearTarget(p);
+		return `Reduce to ${target} or fewer tiles`;
+	}
+
+	if (type === CHALLENGE_TYPES.RECOVERY) {
+		const p = /** @type {RecoveryChallengeParams} */ (params);
+		return `Reach ${p.winTile ?? 4096}`;
+	}
+
+	return challenge.description;
+}

--- a/src/lib/game.svelte.js
+++ b/src/lib/game.svelte.js
@@ -116,9 +116,12 @@ export class Game {
 		startingTiles = DEFAULT_STARTING_TILES,
 		initialState = null,
 		seed = undefined,
+		winTile = DEFAULT_WIN_TILE,
 	} = {}) {
 		this.id = id ?? initialState?.id;
 		this.boardSize = boardSize;
+		/** @type {number} */
+		this.winTile = winTile;
 
 		/** @type {number[][]} */
 		this.board = $state(
@@ -245,7 +248,7 @@ export class Game {
 	checkWin() {
 		for (let i = 0; i < this.boardSize; i++) {
 			for (let j = 0; j < this.boardSize; j++) {
-				if (this.board[i][j] === DEFAULT_WIN_TILE) {
+				if (this.board[i][j] >= this.winTile) {
 					this.won = true;
 					return true;
 				}

--- a/src/lib/server/challenge.js
+++ b/src/lib/server/challenge.js
@@ -1,0 +1,173 @@
+import * as table from "$lib/server/db/schema";
+import { db } from "$lib/server/db";
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { CHALLENGE_RUN_STATUS, CHALLENGES, getChallengeById } from "$lib/challenges.js";
+
+/**
+ * @param {string} userId
+ * @returns {Record<string, { bestStatus: string | null; attempts: number; wins: number }>}
+ */
+export function getChallengeStatsForUser(userId) {
+	const runs = db
+		.select({
+			challengeId: table.challengeRun.challengeId,
+			status: table.challengeRun.status,
+		})
+		.from(table.challengeRun)
+		.where(eq(table.challengeRun.userId, userId))
+		.all();
+
+	/** @type {Record<string, { bestStatus: string | null; attempts: number; wins: number }>} */
+	const stats = {};
+
+	for (const challenge of CHALLENGES) {
+		stats[challenge.id] = { bestStatus: null, attempts: 0, wins: 0 };
+	}
+
+	for (const run of runs) {
+		if (!stats[run.challengeId]) {
+			stats[run.challengeId] = { bestStatus: null, attempts: 0, wins: 0 };
+		}
+		const entry = stats[run.challengeId];
+		if (run.status !== CHALLENGE_RUN_STATUS.ABANDONED) {
+			entry.attempts += 1;
+		}
+		if (run.status === CHALLENGE_RUN_STATUS.WON) {
+			entry.wins += 1;
+			entry.bestStatus = CHALLENGE_RUN_STATUS.WON;
+		} else if (
+			run.status === CHALLENGE_RUN_STATUS.LOST &&
+			entry.bestStatus !== CHALLENGE_RUN_STATUS.WON
+		) {
+			entry.bestStatus = CHALLENGE_RUN_STATUS.LOST;
+		}
+	}
+
+	return stats;
+}
+
+/**
+ * Mark in-progress runs for a challenge as abandoned before starting a new one.
+ * @param {string} userId
+ * @param {string} challengeId
+ */
+export async function abandonInProgressRuns(userId, challengeId) {
+	await db
+		.update(table.challengeRun)
+		.set({
+			status: CHALLENGE_RUN_STATUS.ABANDONED,
+			finishedOn: new Date(),
+			updatedOn: new Date(),
+		})
+		.where(
+			and(
+				eq(table.challengeRun.userId, userId),
+				eq(table.challengeRun.challengeId, challengeId),
+				eq(table.challengeRun.status, CHALLENGE_RUN_STATUS.IN_PROGRESS)
+			)
+		);
+}
+
+/**
+ * Start a new challenge run for a user.
+ * @param {string} userId
+ * @param {string} challengeId
+ * @returns {Promise<{ id: string }>}
+ */
+export async function startChallengeRun(userId, challengeId) {
+	const challenge = getChallengeById(challengeId);
+	if (!challenge) {
+		throw new Error(`Unknown challenge: ${challengeId}`);
+	}
+
+	await abandonInProgressRuns(userId, challengeId);
+
+	const id = crypto.randomUUID();
+	const now = new Date();
+
+	await db.insert(table.challengeRun).values({
+		id,
+		challengeId,
+		userId,
+		status: CHALLENGE_RUN_STATUS.IN_PROGRESS,
+		score: 0,
+		metrics: {},
+		startedOn: now,
+		updatedOn: now,
+	});
+
+	return { id };
+}
+
+/**
+ * @param {string} runId
+ * @param {string} userId
+ */
+export function getChallengeRun(runId, userId) {
+	const run = db
+		.select()
+		.from(table.challengeRun)
+		.where(and(eq(table.challengeRun.id, runId), eq(table.challengeRun.userId, userId)))
+		.get();
+
+	return run ?? null;
+}
+
+/**
+ * Complete a challenge run with won/lost status.
+ *
+ * @param {string} runId
+ * @param {string} userId
+ * @param {{
+ *   status: typeof CHALLENGE_RUN_STATUS.WON | typeof CHALLENGE_RUN_STATUS.LOST;
+ *   score: number;
+ *   metrics?: Record<string, unknown>;
+ * }} result
+ */
+export async function completeChallengeRun(runId, userId, result) {
+	const run = getChallengeRun(runId, userId);
+	if (!run) {
+		throw new Error("Challenge run not found");
+	}
+	if (run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) {
+		return run;
+	}
+
+	if (result.status !== CHALLENGE_RUN_STATUS.WON && result.status !== CHALLENGE_RUN_STATUS.LOST) {
+		throw new Error("Invalid completion status");
+	}
+
+	const now = new Date();
+	await db
+		.update(table.challengeRun)
+		.set({
+			status: result.status,
+			score: result.score,
+			metrics: result.metrics ?? {},
+			finishedOn: now,
+			updatedOn: now,
+		})
+		.where(eq(table.challengeRun.id, runId));
+
+	return getChallengeRun(runId, userId);
+}
+
+/**
+ * Recent finished runs for a user (optional UI).
+ * @param {string} userId
+ * @param {number} [limit]
+ */
+export function getRecentChallengeRuns(userId, limit = 10) {
+	return db
+		.select()
+		.from(table.challengeRun)
+		.where(
+			and(
+				eq(table.challengeRun.userId, userId),
+				inArray(table.challengeRun.status, [CHALLENGE_RUN_STATUS.WON, CHALLENGE_RUN_STATUS.LOST])
+			)
+		)
+		.orderBy(desc(table.challengeRun.finishedOn))
+		.limit(limit)
+		.all();
+}

--- a/src/lib/server/db/schema/challengeSchemas.js
+++ b/src/lib/server/db/schema/challengeSchemas.js
@@ -1,0 +1,19 @@
+import { sqliteTable, integer, text } from "drizzle-orm/sqlite-core";
+
+import { user } from "./userSchemas.js";
+
+/** Challenge attempt / run attribution for logged-in Pro users */
+export const challengeRun = sqliteTable("challenge_run", {
+	id: text("id").primaryKey(),
+	challengeId: text("challenge_id").notNull(),
+	userId: text("user_id")
+		.notNull()
+		.references(() => user.id, { onDelete: "cascade" }),
+	status: text("status").notNull(),
+	score: integer("score").notNull().default(0),
+	/** Extra metrics JSON: elapsedMs, filledCells, moveCount, etc. */
+	metrics: text("metrics", { mode: "json" }),
+	startedOn: integer("started_on", { mode: "timestamp" }).notNull(),
+	finishedOn: integer("finished_on", { mode: "timestamp" }),
+	updatedOn: integer("updated_on", { mode: "timestamp" }).notNull(),
+});

--- a/src/lib/server/db/schema/index.js
+++ b/src/lib/server/db/schema/index.js
@@ -2,3 +2,4 @@ export * from "./authSchemas.js";
 export * from "./userSchemas.js";
 export * from "./stripeSchemas.js";
 export * from "./gameSchemas.js";
+export * from "./challengeSchemas.js";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,6 +50,8 @@ export interface GameOptions {
   startingTiles?: number;
   initialState?: GameState | null;
   seed?: number;
+  /** Tile value that counts as a win (default 4096). Used by recovery challenges. */
+  winTile?: number;
 }
 
 export interface GameUndoSnapshot {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,6 +47,7 @@
 				Upgrade to Pro
 			</Btn>
 		{/if}
+		<Btn href="/challenges" class="justify-center">Challenges</Btn>
 		<Btn href="/leaderboard" class="justify-center">View Leaderboard</Btn>
 	</div>
 

--- a/src/routes/FooterNav.svelte
+++ b/src/routes/FooterNav.svelte
@@ -1,6 +1,13 @@
 <script>
 	import { page } from "$app/state";
-	import { Grid2x2Icon, HouseIcon, TrophyIcon, HistoryIcon, UserIcon } from "@lucide/svelte";
+	import {
+		Grid2x2Icon,
+		HouseIcon,
+		TrophyIcon,
+		HistoryIcon,
+		UserIcon,
+		TargetIcon,
+	} from "@lucide/svelte";
 
 	const navItems = [
 		{
@@ -10,6 +17,10 @@
 		{
 			icon: Grid2x2Icon,
 			href: "/game",
+		},
+		{
+			icon: TargetIcon,
+			href: "/challenges",
 		},
 		{
 			icon: TrophyIcon,

--- a/src/routes/api/health/+server.js
+++ b/src/routes/api/health/+server.js
@@ -11,7 +11,7 @@ export async function GET() {
 	try {
 		db.run(sql`SELECT 1`);
 		checks.database = "ok";
-	} catch (err) {
+	} catch {
 		checks.database = "error";
 		return json(
 			{
@@ -19,7 +19,7 @@ export async function GET() {
 				version: buildVersion,
 				checks,
 			},
-			{ status: 503 },
+			{ status: 503 }
 		);
 	}
 

--- a/src/routes/challenges/+page.server.js
+++ b/src/routes/challenges/+page.server.js
@@ -1,0 +1,25 @@
+import { USER_LEVELS } from "$lib/constants.js";
+import { CHALLENGES } from "$lib/challenges.js";
+import { getChallengeStatsForUser } from "$lib/server/challenge.js";
+import { getUserProfile } from "$lib/server/user.js";
+
+/** @type {import("./$types").PageServerLoad} */
+export async function load({ locals }) {
+	let user = null;
+	/** @type {Record<string, { bestStatus: string | null; attempts: number; wins: number }> | null} */
+	let stats = null;
+
+	if (locals.user) {
+		user = getUserProfile(locals.user.id);
+		if (user?.level === USER_LEVELS.PRO) {
+			stats = getChallengeStatsForUser(user.id);
+		}
+	}
+
+	return {
+		user,
+		isPro: user?.level === USER_LEVELS.PRO,
+		challenges: CHALLENGES,
+		stats,
+	};
+}

--- a/src/routes/challenges/+page.svelte
+++ b/src/routes/challenges/+page.svelte
@@ -1,0 +1,102 @@
+<script>
+	import { page } from "$app/state";
+	import Btn from "$lib/components/Btn.svelte";
+	import {
+		CHALLENGE_RUN_STATUS,
+		CHALLENGE_TYPES,
+		formatChallengeObjective,
+	} from "$lib/challenges.js";
+	import { CrownIcon, TimerIcon, EraserIcon, LifeBuoyIcon } from "@lucide/svelte";
+
+	let { data } = $props();
+
+	/**
+	 * @param {string} type
+	 */
+	function typeIcon(type) {
+		if (type === CHALLENGE_TYPES.TIME) return TimerIcon;
+		if (type === CHALLENGE_TYPES.CLEAR) return EraserIcon;
+		return LifeBuoyIcon;
+	}
+
+	/**
+	 * @param {string} type
+	 */
+	function typeLabel(type) {
+		if (type === CHALLENGE_TYPES.TIME) return "Time";
+		if (type === CHALLENGE_TYPES.CLEAR) return "Clear";
+		return "Recovery";
+	}
+
+	/**
+	 * @param {string} challengeId
+	 */
+	function statusLabel(challengeId) {
+		const entry = data.stats?.[challengeId];
+		if (!entry || !entry.bestStatus) return null;
+		if (entry.bestStatus === CHALLENGE_RUN_STATUS.WON) {
+			return entry.wins > 1 ? `Cleared ×${entry.wins}` : "Cleared";
+		}
+		return `${entry.attempts} attempt${entry.attempts === 1 ? "" : "s"}`;
+	}
+</script>
+
+<svelte:head>
+	<title>Challenges - 4096</title>
+	<meta
+		name="description"
+		content="Pro challenge modes: race the clock, clear the board, or recover from a tough start."
+	/>
+</svelte:head>
+
+<main class="mx-auto mt-8 mb-[5rem] w-full max-w-lg p-6" style:color={page.data.theme?.text}>
+	<h1 class="text-3xl font-bold text-[var(--color-primary)]">Challenges</h1>
+	<p class="mb-6 text-sm text-gray-500">
+		Fixed starting setups with clear win/lose goals. A Pro feature.
+	</p>
+
+	{#if !data.isPro}
+		<div
+			class="mb-6 rounded-lg p-4 text-center"
+			style:background-color={page.data.theme?.boardBackground}
+		>
+			<p class="mb-3 text-sm" style:color={page.data.theme?.textDark}>
+				Browse the roster below. Starting a challenge requires Pro.
+			</p>
+			<Btn href="/stripe" class="justify-center gap-2">
+				<CrownIcon size={20} />
+				Upgrade to Pro
+			</Btn>
+		</div>
+	{/if}
+
+	<ul class="flex flex-col gap-3">
+		{#each data.challenges as challenge (challenge.id)}
+			{@const Icon = typeIcon(challenge.type)}
+			<li>
+				<a
+					href="/challenges/{challenge.id}"
+					class="block rounded-lg p-4 transition-opacity hover:opacity-90"
+					style:background-color={page.data.theme?.boardBackground}
+					style:color={page.data.theme?.textDark}
+				>
+					<div class="mb-1 flex items-center gap-2">
+						<Icon size={18} />
+						<span class="text-xs font-bold tracking-wide uppercase opacity-70">
+							{typeLabel(challenge.type)} · {challenge.difficulty}
+						</span>
+					</div>
+					<div class="flex items-start justify-between gap-2">
+						<div>
+							<h2 class="text-lg font-bold">{challenge.title}</h2>
+							<p class="text-sm opacity-80">{formatChallengeObjective(challenge)}</p>
+						</div>
+						{#if statusLabel(challenge.id)}
+							<span class="shrink-0 text-xs font-semibold">{statusLabel(challenge.id)}</span>
+						{/if}
+					</div>
+				</a>
+			</li>
+		{/each}
+	</ul>
+</main>

--- a/src/routes/challenges/[id]/+page.server.js
+++ b/src/routes/challenges/[id]/+page.server.js
@@ -1,0 +1,49 @@
+import { fail, redirect } from "@sveltejs/kit";
+import { USER_LEVELS } from "$lib/constants.js";
+import { getChallengeById, formatChallengeObjective } from "$lib/challenges.js";
+import { getChallengeStatsForUser, startChallengeRun } from "$lib/server/challenge.js";
+import { getUserProfile, requireLogin } from "$lib/server/user.js";
+
+/** @type {import("./$types").PageServerLoad} */
+export async function load({ locals, params }) {
+	const challenge = getChallengeById(params.id);
+	if (!challenge) {
+		redirect(302, "/challenges");
+	}
+
+	let user = null;
+	let stats = null;
+	if (locals.user) {
+		user = getUserProfile(locals.user.id);
+		if (user?.level === USER_LEVELS.PRO) {
+			stats = getChallengeStatsForUser(user.id)?.[challenge.id] ?? null;
+		}
+	}
+
+	return {
+		user,
+		isPro: user?.level === USER_LEVELS.PRO,
+		challenge,
+		objective: formatChallengeObjective(challenge),
+		stats,
+	};
+}
+
+/** @type {import("./$types").Actions} */
+export const actions = {
+	start: async ({ params }) => {
+		const user = requireLogin(`/challenges/${params.id}`);
+
+		if (user.level !== USER_LEVELS.PRO) {
+			redirect(303, "/stripe");
+		}
+
+		const challenge = getChallengeById(params.id);
+		if (!challenge) {
+			return fail(404, { error: "Challenge not found" });
+		}
+
+		const run = await startChallengeRun(user.id, challenge.id);
+		redirect(303, `/challenges/${challenge.id}/play?run=${run.id}`);
+	},
+};

--- a/src/routes/challenges/[id]/+page.svelte
+++ b/src/routes/challenges/[id]/+page.svelte
@@ -1,0 +1,139 @@
+<script>
+	import { enhance } from "$app/forms";
+	import { page } from "$app/state";
+	import Btn from "$lib/components/Btn.svelte";
+	import {
+		CHALLENGE_RUN_STATUS,
+		CHALLENGE_TYPES,
+		countFilledCells,
+		resolveClearTarget,
+	} from "$lib/challenges.js";
+	import { CrownIcon, ArrowLeftIcon } from "@lucide/svelte";
+
+	let { data } = $props();
+
+	let starting = $state(false);
+
+	const challenge = $derived(data.challenge);
+
+	const previewBoard = $derived(
+		"board" in challenge.params && Array.isArray(challenge.params.board)
+			? challenge.params.board
+			: null
+	);
+
+	/**
+	 * @param {any} event
+	 */
+	function onStart() {
+		starting = true;
+		return async ({ update }) => {
+			await update();
+			starting = false;
+		};
+	}
+</script>
+
+<svelte:head>
+	<title>{challenge.title} - Challenges - 4096</title>
+</svelte:head>
+
+<main class="mx-auto mt-8 mb-[5rem] w-full max-w-lg p-6" style:color={page.data.theme?.text}>
+	<a
+		href="/challenges"
+		class="mb-4 inline-flex items-center gap-1 text-sm text-[var(--color-primary)] hover:underline"
+	>
+		<ArrowLeftIcon size={16} />
+		All challenges
+	</a>
+
+	<h1 class="text-3xl font-bold text-[var(--color-primary)]">{challenge.title}</h1>
+	<p class="mb-1 text-sm text-gray-500">{challenge.difficulty} · {data.objective}</p>
+	<p class="mb-6">{challenge.description}</p>
+
+	{#if challenge.type === CHALLENGE_TYPES.TIME}
+		<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
+			<li>Target score: {challenge.params.targetScore.toLocaleString()}</li>
+			<li>Time limit: {challenge.params.durationSec}s</li>
+			<li>Fail if the timer runs out or you game over first</li>
+		</ul>
+	{:else if challenge.type === CHALLENGE_TYPES.CLEAR}
+		<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
+			<li>Starting tiles: {countFilledCells(challenge.params.board)}</li>
+			<li>Clear to ≤ {resolveClearTarget(challenge.params)} occupied cells</li>
+			<li>Fail on game over before reaching the target</li>
+		</ul>
+	{:else}
+		<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
+			<li>Goal tile: {challenge.params.winTile ?? 4096}</li>
+			<li>Start from the preset board below</li>
+			<li>Fail on game over</li>
+		</ul>
+	{/if}
+
+	{#if previewBoard}
+		<div class="mb-6">
+			<p class="mb-2 text-xs font-bold tracking-wide text-gray-500 uppercase">Starting board</p>
+			<div
+				class="grid aspect-square grid-cols-4 gap-2 rounded-lg p-2"
+				style:background-color={page.data.theme?.boardBackground}
+			>
+				{#each previewBoard as row, ri (ri)}
+					{#each row as cell, ci (ci)}
+						<div
+							class="flex items-center justify-center rounded text-sm font-bold"
+							style:background-color={cell
+								? (page.data.theme?.tiles?.[cell] ?? page.data.theme?.unknownTile)
+								: page.data.theme?.emptyTile}
+							style:color={page.data.theme?.textDark}
+						>
+							{cell || ""}
+						</div>
+					{/each}
+				{/each}
+			</div>
+		</div>
+	{/if}
+
+	{#if data.stats}
+		<p class="mb-4 text-sm text-gray-500">
+			{#if data.stats.bestStatus === CHALLENGE_RUN_STATUS.WON}
+				You've cleared this challenge {data.stats.wins} time{data.stats.wins === 1 ? "" : "s"}
+				({data.stats.attempts} attempt{data.stats.attempts === 1 ? "" : "s"}).
+			{:else if data.stats.attempts > 0}
+				{data.stats.attempts} attempt{data.stats.attempts === 1 ? "" : "s"} so far — keep going!
+			{:else}
+				No attempts yet.
+			{/if}
+		</p>
+	{/if}
+
+	{#if data.isPro}
+		<form method="POST" action="?/start" use:enhance={onStart}>
+			<Btn type="submit" class="w-full justify-center" disabled={starting}>
+				{starting ? "Starting…" : "Start Challenge"}
+			</Btn>
+		</form>
+	{:else}
+		<div
+			class="rounded-lg p-4 text-center"
+			style:background-color={page.data.theme?.boardBackground}
+		>
+			<p class="mb-3 text-sm" style:color={page.data.theme?.textDark}>
+				{#if data.user}
+					Upgrade to Pro to play this challenge.
+				{:else}
+					Log in and upgrade to Pro to play this challenge.
+				{/if}
+			</p>
+			{#if data.user}
+				<Btn href="/stripe" class="justify-center gap-2">
+					<CrownIcon size={20} />
+					Upgrade to Pro
+				</Btn>
+			{:else}
+				<Btn href="/login?redirectTo=/challenges/{challenge.id}" class="justify-center">Log in</Btn>
+			{/if}
+		</div>
+	{/if}
+</main>

--- a/src/routes/challenges/[id]/play/+page.server.js
+++ b/src/routes/challenges/[id]/play/+page.server.js
@@ -1,0 +1,91 @@
+import { error, fail, redirect } from "@sveltejs/kit";
+import { USER_LEVELS } from "$lib/constants.js";
+import {
+	CHALLENGE_RUN_STATUS,
+	formatChallengeObjective,
+	getChallengeById,
+} from "$lib/challenges.js";
+import { completeChallengeRun, getChallengeRun } from "$lib/server/challenge.js";
+import { requireLogin } from "$lib/server/user.js";
+
+/** @type {import("./$types").PageServerLoad} */
+export async function load({ params, url }) {
+	const user = requireLogin(`/challenges/${params.id}/play`);
+
+	if (user.level !== USER_LEVELS.PRO) {
+		redirect(302, "/stripe");
+	}
+
+	const challenge = getChallengeById(params.id);
+	if (!challenge) {
+		redirect(302, "/challenges");
+	}
+
+	const runId = url.searchParams.get("run");
+	if (!runId) {
+		redirect(302, `/challenges/${challenge.id}`);
+	}
+
+	const run = getChallengeRun(runId, user.id);
+	if (!run || run.challengeId !== challenge.id) {
+		error(404, "Challenge run not found");
+	}
+
+	return {
+		challenge,
+		objective: formatChallengeObjective(challenge),
+		run: {
+			id: run.id,
+			status: run.status,
+			score: run.score,
+			startedOn: run.startedOn instanceof Date ? run.startedOn.getTime() : Number(run.startedOn),
+			metrics: run.metrics ?? {},
+		},
+	};
+}
+
+/** @type {import("./$types").Actions} */
+export const actions = {
+	complete: async ({ request, params }) => {
+		const user = requireLogin(`/challenges/${params.id}/play`);
+
+		if (user.level !== USER_LEVELS.PRO) {
+			return fail(403, { error: "Pro required" });
+		}
+
+		const formData = await request.formData();
+		const runId = String(formData.get("runId") ?? "");
+		const status = String(formData.get("status") ?? "");
+		const score = Number(formData.get("score") ?? 0);
+		let metrics = {};
+		try {
+			metrics = JSON.parse(String(formData.get("metrics") ?? "{}"));
+		} catch {
+			metrics = {};
+		}
+
+		if (!runId) {
+			return fail(400, { error: "Missing run id" });
+		}
+
+		if (status !== CHALLENGE_RUN_STATUS.WON && status !== CHALLENGE_RUN_STATUS.LOST) {
+			return fail(400, { error: "Invalid status" });
+		}
+
+		const run = getChallengeRun(runId, user.id);
+		if (!run || run.challengeId !== params.id) {
+			return fail(404, { error: "Run not found" });
+		}
+
+		const updated = await completeChallengeRun(runId, user.id, {
+			status,
+			score: Number.isFinite(score) ? score : 0,
+			metrics,
+		});
+
+		return {
+			success: true,
+			status: updated?.status,
+		};
+	},
+};

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -23,7 +23,6 @@
 	let result = $state(/** @type {'won' | 'lost' | null} */ (null));
 	let remainingMs = $state(0);
 	let submitting = $state(false);
-	let now = $state(Date.now());
 
 	/** @type {HTMLFormElement | null} */
 	let completeForm = $state(null);
@@ -200,9 +199,8 @@
 		let timer = null;
 		if (isTime) {
 			timer = setInterval(() => {
-				now = Date.now();
 				const durationMs = challenge.params.durationSec * 1000;
-				remainingMs = Math.max(0, durationMs - (now - data.run.startedOn));
+				remainingMs = Math.max(0, durationMs - (Date.now() - data.run.startedOn));
 				checkOutcome();
 			}, 200);
 		}

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -1,0 +1,400 @@
+<script>
+	import { browser } from "$app/environment";
+	import { enhance } from "$app/forms";
+	import { onMount } from "svelte";
+	import { page } from "$app/state";
+	import { Game, getTileBackground, getTileColor } from "$lib/game.svelte.js";
+	import { DIRECTIONS } from "$lib/constants.js";
+	import {
+		CHALLENGE_RUN_STATUS,
+		CHALLENGE_TYPES,
+		countFilledCells,
+		evaluateChallenge,
+		resolveClearTarget,
+	} from "$lib/challenges.js";
+	import Btn from "$lib/components/Btn.svelte";
+
+	let { data } = $props();
+
+	const TOUCH_THRESHOLD = 5;
+
+	/** @type {Game | null} */
+	let game = $state(null);
+	let result = $state(/** @type {'won' | 'lost' | null} */ (null));
+	let remainingMs = $state(0);
+	let submitting = $state(false);
+	let now = $state(Date.now());
+
+	/** @type {HTMLFormElement | null} */
+	let completeForm = $state(null);
+
+	const challenge = $derived(data.challenge);
+	const isTime = $derived(challenge.type === CHALLENGE_TYPES.TIME);
+	const isClear = $derived(challenge.type === CHALLENGE_TYPES.CLEAR);
+
+	const clearTarget = $derived(
+		isClear ? resolveClearTarget(/** @type {any} */ (challenge.params)) : null
+	);
+
+	const filledCells = $derived(game ? countFilledCells(game.board) : 0);
+
+	/**
+	 * Build a Game from challenge params.
+	 * @returns {Game}
+	 */
+	function createChallengeGame() {
+		const params = challenge.params;
+		const seed = "seed" in params ? params.seed : undefined;
+		const winTile =
+			challenge.type === CHALLENGE_TYPES.RECOVERY && "winTile" in params
+				? params.winTile
+				: undefined;
+
+		if ("board" in params && params.board) {
+			return new Game({
+				seed,
+				winTile,
+				initialState: {
+					board: params.board.map((row) => [...row]),
+					score: 0,
+					seed,
+					moveCount: 0,
+					undoCooldownRemaining: 0,
+				},
+			});
+		}
+
+		return new Game({ seed, winTile });
+	}
+
+	function initGame() {
+		if (!browser) return;
+		game = createChallengeGame();
+		result = null;
+
+		if (isTime) {
+			const durationMs = challenge.params.durationSec * 1000;
+			const elapsed = Date.now() - data.run.startedOn;
+			remainingMs = Math.max(0, durationMs - elapsed);
+		}
+	}
+
+	/**
+	 * @param {number} ms
+	 */
+	function formatTime(ms) {
+		const totalSec = Math.max(0, Math.ceil(ms / 1000));
+		const m = Math.floor(totalSec / 60);
+		const s = totalSec % 60;
+		return `${m}:${s.toString().padStart(2, "0")}`;
+	}
+
+	/**
+	 * @param {'won' | 'lost'} status
+	 */
+	function finish(status) {
+		if (result || submitting || data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) return;
+		result = status;
+		submitting = true;
+		queueMicrotask(() => completeForm?.requestSubmit());
+	}
+
+	function checkOutcome() {
+		if (!game || result) return;
+
+		const elapsedMs = isTime ? Date.now() - data.run.startedOn : undefined;
+		const outcome = evaluateChallenge(challenge, {
+			board: game.board,
+			score: game.score,
+			gameOver: game.gameOver,
+			won: game.won,
+			elapsedMs,
+		});
+
+		if (outcome === "won" || outcome === "lost") {
+			finish(outcome);
+		}
+	}
+
+	/**
+	 * @param {number} direction
+	 */
+	function handleMove(direction) {
+		if (!game || result) return;
+		const events = game.moveTiles(direction);
+		if (events.length > 0) {
+			checkOutcome();
+		}
+	}
+
+	/**
+	 * @param {KeyboardEvent} event
+	 */
+	function handleKeydown(event) {
+		switch (event.key) {
+			case "ArrowLeft":
+				event.preventDefault();
+				handleMove(DIRECTIONS.LEFT);
+				break;
+			case "ArrowRight":
+				event.preventDefault();
+				handleMove(DIRECTIONS.RIGHT);
+				break;
+			case "ArrowUp":
+				event.preventDefault();
+				handleMove(DIRECTIONS.UP);
+				break;
+			case "ArrowDown":
+				event.preventDefault();
+				handleMove(DIRECTIONS.DOWN);
+				break;
+		}
+	}
+
+	let touchStartX = 0;
+	let touchStartY = 0;
+
+	/** @param {TouchEvent} event */
+	function handleTouchStart(event) {
+		touchStartX = event.touches[0].clientX;
+		touchStartY = event.touches[0].clientY;
+	}
+
+	/** @param {TouchEvent} event */
+	function handleTouchEnd(event) {
+		if (!touchStartX || !touchStartY) return;
+		const touchEndX = event.changedTouches[0].clientX;
+		const touchEndY = event.changedTouches[0].clientY;
+		const diffX = touchStartX - touchEndX;
+		const diffY = touchStartY - touchEndY;
+		if (Math.abs(diffX) < TOUCH_THRESHOLD && Math.abs(diffY) < TOUCH_THRESHOLD) return;
+		event.preventDefault();
+		if (Math.abs(diffX) > Math.abs(diffY)) {
+			if (diffX > 0) handleMove(DIRECTIONS.LEFT);
+			else handleMove(DIRECTIONS.RIGHT);
+		} else {
+			if (diffY > 0) handleMove(DIRECTIONS.UP);
+			else handleMove(DIRECTIONS.DOWN);
+		}
+		touchStartX = 0;
+		touchStartY = 0;
+	}
+
+	/** @param {TouchEvent} event */
+	function handleTouchMove(event) {
+		event.preventDefault();
+	}
+
+	onMount(() => {
+		if (data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) {
+			result = data.run.status === CHALLENGE_RUN_STATUS.WON ? "won" : "lost";
+			return;
+		}
+
+		initGame();
+		checkOutcome();
+
+		window.addEventListener("keydown", handleKeydown);
+
+		/** @type {ReturnType<typeof setInterval> | null} */
+		let timer = null;
+		if (isTime) {
+			timer = setInterval(() => {
+				now = Date.now();
+				const durationMs = challenge.params.durationSec * 1000;
+				remainingMs = Math.max(0, durationMs - (now - data.run.startedOn));
+				checkOutcome();
+			}, 200);
+		}
+
+		return () => {
+			window.removeEventListener("keydown", handleKeydown);
+			if (timer) clearInterval(timer);
+		};
+	});
+</script>
+
+<svelte:head>
+	<title>{challenge.title} - Play - 4096</title>
+</svelte:head>
+
+<form
+	bind:this={completeForm}
+	method="POST"
+	action="?/complete"
+	class="hidden"
+	use:enhance={() => {
+		return async ({ update }) => {
+			await update({ reset: false });
+			submitting = false;
+		};
+	}}
+>
+	<input type="hidden" name="runId" value={data.run.id} />
+	<input
+		type="hidden"
+		name="status"
+		value={result === "won" ? CHALLENGE_RUN_STATUS.WON : CHALLENGE_RUN_STATUS.LOST}
+	/>
+	<input type="hidden" name="score" value={game?.score ?? 0} />
+	<input
+		type="hidden"
+		name="metrics"
+		value={JSON.stringify({
+			moveCount: game?.moveCount ?? 0,
+			filledCells: game ? countFilledCells(game.board) : 0,
+			elapsedMs: isTime ? Date.now() - data.run.startedOn : undefined,
+		})}
+	/>
+</form>
+
+<div
+	class="challenge-play"
+	ontouchstart={handleTouchStart}
+	ontouchmove={handleTouchMove}
+	ontouchend={handleTouchEnd}
+	style:color={page.data.theme?.text}
+>
+	<div class="mb-3 flex items-start gap-2">
+		<div class="flex-1">
+			<p class="text-xs font-bold tracking-wide text-gray-500 uppercase">Challenge</p>
+			<h1 class="text-2xl font-bold text-[var(--color-primary)]">{challenge.title}</h1>
+			<p class="text-sm text-gray-500">{data.objective}</p>
+		</div>
+		<div class="flex gap-2">
+			<div
+				class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
+				style:background-color={page.data.theme?.boardBackground}
+				style:color={page.data.theme?.textDark}
+			>
+				<div class="text-xs font-bold uppercase">Score</div>
+				<div class="font-bold">{game?.score.toLocaleString() ?? "—"}</div>
+			</div>
+			{#if isTime}
+				<div
+					class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
+					style:background-color={page.data.theme?.boardBackground}
+					style:color={remainingMs <= 10000 ? "#b91c1c" : page.data.theme?.textDark}
+				>
+					<div class="text-xs font-bold uppercase">Time</div>
+					<div class="font-bold">{formatTime(remainingMs)}</div>
+				</div>
+			{:else if isClear}
+				<div
+					class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
+					style:background-color={page.data.theme?.boardBackground}
+					style:color={page.data.theme?.textDark}
+				>
+					<div class="text-xs font-bold uppercase">Tiles</div>
+					<div class="font-bold">{filledCells}/{clearTarget}</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	{#if game}
+		<div
+			class="mb-4 grid aspect-square grid-cols-4 gap-2.5 rounded-lg p-2.5"
+			style:background-color={page.data.theme?.boardBackground}
+		>
+			{#each game.board as row, ri (ri)}
+				{#each row as cell, ci (`${ri}-${ci}`)}
+					<div
+						class="flex items-center justify-center rounded-md text-xl font-extrabold sm:text-2xl"
+						style:background-color={cell
+							? getTileBackground(cell, page.data.theme)
+							: page.data.theme?.emptyTile}
+						style:color={cell ? getTileColor(cell, page.data.theme) : "transparent"}
+					>
+						{cell || ""}
+					</div>
+				{/each}
+			{/each}
+		</div>
+	{:else}
+		<div
+			class="mb-4 flex aspect-square items-center justify-center rounded-lg"
+			style:background-color={page.data.theme?.boardBackground}
+		>
+			Loading…
+		</div>
+	{/if}
+
+	<p class="text-center text-sm text-gray-500">
+		Arrow keys or swipe to move. Challenge progress is saved when you finish.
+	</p>
+
+	<p class="mt-3 text-center text-sm">
+		<a href="/challenges/{challenge.id}" class="text-[var(--color-primary)] hover:underline">
+			Abandon & back
+		</a>
+	</p>
+</div>
+
+{#if result}
+	<div class="overlay">
+		<div class="overlay-content">
+			<h2>{result === "won" ? "Challenge Cleared!" : "Challenge Failed"}</h2>
+			<p>
+				{#if result === "won"}
+					Nice work — {data.objective.toLowerCase()}.
+				{:else if isTime && game && game.score < challenge.params.targetScore}
+					Time's up (or game over) with {game.score.toLocaleString()} points.
+				{:else}
+					Game over before the objective was met.
+				{/if}
+			</p>
+			<p class="mb-4 text-sm text-gray-500">Score: {game?.score.toLocaleString() ?? 0}</p>
+			<div class="flex flex-wrap justify-center gap-2">
+				<form method="POST" action="/challenges/{challenge.id}?/start" use:enhance>
+					<Btn type="submit" class="justify-center">Retry</Btn>
+				</form>
+				<Btn href="/challenges" class="justify-center">All Challenges</Btn>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style lang="postcss">
+	.challenge-play {
+		max-width: 500px;
+		min-height: 100vh;
+		margin: 0 auto;
+		padding: 20px;
+		padding-bottom: 5rem;
+		user-select: none;
+		touch-action: manipulation;
+		overscroll-behavior: contain;
+	}
+
+	.overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.8);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+		padding: 1rem;
+	}
+
+	.overlay-content {
+		background: white;
+		padding: 2rem;
+		border-radius: 12px;
+		text-align: center;
+		max-width: 400px;
+		width: 100%;
+		color: #776e65;
+	}
+
+	.overlay-content h2 {
+		margin: 0 0 0.75rem;
+		font-size: 1.75rem;
+	}
+
+	.overlay-content p {
+		margin: 0 0 0.5rem;
+		font-size: 1.05rem;
+	}
+</style>

--- a/src/routes/stripe/+page.svelte
+++ b/src/routes/stripe/+page.svelte
@@ -45,7 +45,7 @@
 		},
 		{
 			name: "Challenges",
-			implemented: false,
+			implemented: true,
 		},
 	];
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #5 — structured **Challenge** modes as a Pro feature.

Rebased onto latest `main` (includes Game History & Replay). Challenge DB migration is now `0007_safe_bruce_banner` so it does not collide with Replay's `0006`.

## What's included
- **Three challenge types** with one shippable challenge each:
  - **Score Sprint** (time) — reach 500 points in 60s
  - **Space Maker** (clear) — reduce a packed board to ≤4 tiles
  - **Near Miss** (recovery) — reach 2048 from a tough preset board
- **Content model** — static challenge definitions in `src/lib/challenges.js`
- **Run tracking** — `challenge_run` table attributes attempts to logged-in Pro users (won/lost/abandoned)
- **Play flow** — `/challenges` → detail → start run → play with success/fail overlays and retry
- **Pro gating** — list/detail visible as teaser; starting/playing requires Pro (upgrade CTA)
- Reuses shared `Game` engine (optional `winTile` for recovery); does not fork merge logic
- Marks **Challenges** as implemented on `/stripe`
- Nav + home link to Challenges

## Notes
- Free/logged-out users can browse challenges; Start redirects to upgrade/login
- Casual game saves are untouched — challenge play uses its own run records only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f61ba-b90a-7f18-8e45-d68f5a09f411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f61ba-b90a-7f18-8e45-d68f5a09f411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

