### PR TITLE
Add Pro-only checkpoints (issue #2)

### DIFF
--- a/drizzle/0009_game_checkpoint.sql
+++ b/drizzle/0009_game_checkpoint.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `game_checkpoint` (
+	`id` text PRIMARY KEY NOT NULL,
+	`player_id` text NOT NULL,
+	`game_id` text NOT NULL,
+	`created_on` integer NOT NULL,
+	`is_active` integer DEFAULT true NOT NULL,
+	`board` text NOT NULL,
+	`score` integer NOT NULL,
+	`seed` integer,
+	`rng_state` integer,
+	`move_count` integer DEFAULT 0 NOT NULL,
+	`undo_cooldown_remaining` integer DEFAULT 0 NOT NULL,
+	`won` integer DEFAULT false NOT NULL,
+	FOREIGN KEY (`player_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`game_id`) REFERENCES `game`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,758 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "41c39a07-70dd-4236-a90f-9aed266afc2a",
+  "prevId": "aea96eea-db87-48fe-abc4-cb8c89f4bc01",
+  "tables": {
+    "email_verification_request": {
+      "name": "email_verification_request",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_verification_request_user_id_user_id_fk": {
+          "name": "email_verification_request_user_id_user_id_fk",
+          "tableFrom": "email_verification_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_session": {
+      "name": "password_reset_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_session_user_id_user_id_fk": {
+          "name": "password_reset_session_user_id_user_id_fk",
+          "tableFrom": "password_reset_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "challenge_run": {
+      "name": "challenge_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_on": {
+          "name": "started_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_on": {
+          "name": "finished_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "challenge_run_user_id_user_id_fk": {
+          "name": "challenge_run_user_id_user_id_fk",
+          "tableFrom": "challenge_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game": {
+      "name": "game",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_on": {
+          "name": "completed_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "won": {
+          "name": "won",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "complete": {
+          "name": "complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "board": {
+          "name": "board",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "moves": {
+          "name": "moves",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rng_state": {
+          "name": "rng_state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "move_count": {
+          "name": "move_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "undo_cooldown_remaining": {
+          "name": "undo_cooldown_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_player_id_user_id_fk": {
+          "name": "game_player_id_user_id_fk",
+          "tableFrom": "game",
+          "tableTo": "user",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin": {
+          "name": "admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profile": {
+      "name": "user_profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "best_score": {
+          "name": "best_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'classic'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profile_user_id_user_id_fk": {
+          "name": "user_profile_user_id_user_id_fk",
+          "tableFrom": "user_profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_session": {
+      "name": "stripe_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_on": {
+          "name": "updated_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_json": {
+          "name": "session_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stripe_session_user_id_user_id_fk": {
+          "name": "stripe_session_user_id_user_id_fk",
+          "tableFrom": "stripe_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_checkpoint": {
+      "name": "game_checkpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_on": {
+          "name": "created_on",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "board": {
+          "name": "board",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "seed": {
+          "name": "seed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rng_state": {
+          "name": "rng_state",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "move_count": {
+          "name": "move_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "undo_cooldown_remaining": {
+          "name": "undo_cooldown_remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "won": {
+          "name": "won",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_checkpoint_player_id_user_id_fk": {
+          "name": "game_checkpoint_player_id_user_id_fk",
+          "tableFrom": "game_checkpoint",
+          "tableTo": "user",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_checkpoint_game_id_game_id_fk": {
+          "name": "game_checkpoint_game_id_game_id_fk",
+          "tableFrom": "game_checkpoint",
+          "tableTo": "game",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1784074000000,
       "tag": "0008_add_theme_id",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1784075000000,
+      "tag": "0009_game_checkpoint",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/checkpoint.js
+++ b/src/lib/server/checkpoint.js
@@ -1,0 +1,195 @@
+import assert from "node:assert";
+import { and, desc, eq } from "drizzle-orm";
+
+import { USER_LEVELS } from "$lib/constants";
+import { db } from "$lib/server/db";
+import * as table from "$lib/server/db/schema";
+import { getUser } from "$lib/server/user";
+
+/**
+ * Ensure the user is Pro and return their user row.
+ * @param {string} userId
+ */
+function requireProUser(userId) {
+	const user = getUser(userId);
+	assert(user, "User not found");
+	if (user.level !== USER_LEVELS.PRO) {
+		const error = new Error("Checkpoints are a Pro feature");
+		// @ts-ignore attach status for API handlers
+		error.status = 403;
+		// @ts-ignore
+		error.code = "PRO_REQUIRED";
+		throw error;
+	}
+	return user;
+}
+
+/**
+ * Ensure the game exists and belongs to the user.
+ * @param {string} gameId
+ * @param {string} userId
+ */
+function requireOwnedGame(gameId, userId) {
+	const existingGame = db.select().from(table.game).where(eq(table.game.id, gameId)).get();
+	if (!existingGame || existingGame.playerId !== userId) {
+		const error = new Error("Game not found");
+		// @ts-ignore
+		error.status = 404;
+		throw error;
+	}
+	return existingGame;
+}
+
+/**
+ * Map a checkpoint row to client-facing metadata.
+ * @param {typeof table.gameCheckpoint.$inferSelect} row
+ * @returns {import("$lib/types").CheckpointInfo}
+ */
+function toCheckpointInfo(row) {
+	return {
+		id: row.id,
+		gameId: row.gameId,
+		createdOn: row.createdOn.getTime(),
+		score: row.score,
+		moveCount: row.moveCount,
+	};
+}
+
+/**
+ * Get the active (restorable) checkpoint for a game owned by the user.
+ * @param {string} userId
+ * @param {string} gameId
+ * @returns {import("$lib/types").CheckpointInfo | null}
+ */
+export function getActiveCheckpoint(userId, gameId) {
+	const row = db
+		.select()
+		.from(table.gameCheckpoint)
+		.where(
+			and(
+				eq(table.gameCheckpoint.playerId, userId),
+				eq(table.gameCheckpoint.gameId, gameId),
+				eq(table.gameCheckpoint.isActive, true)
+			)
+		)
+		.orderBy(desc(table.gameCheckpoint.createdOn))
+		.get();
+
+	return row ? toCheckpointInfo(row) : null;
+}
+
+/**
+ * Set a checkpoint for the current game. Marks any prior active checkpoint as inactive.
+ *
+ * @param {string} userId
+ * @param {import("$lib/types").CheckpointSaveData} snapshot
+ * @returns {Promise<import("$lib/types").CheckpointInfo>}
+ */
+export async function setCheckpoint(userId, snapshot) {
+	requireProUser(userId);
+	assert(snapshot?.gameId, "gameId is required");
+	assert(Array.isArray(snapshot.board), "board is required");
+	assert(typeof snapshot.score === "number", "score is required");
+
+	requireOwnedGame(snapshot.gameId, userId);
+
+	await db
+		.update(table.gameCheckpoint)
+		.set({ isActive: false })
+		.where(
+			and(
+				eq(table.gameCheckpoint.playerId, userId),
+				eq(table.gameCheckpoint.gameId, snapshot.gameId),
+				eq(table.gameCheckpoint.isActive, true)
+			)
+		);
+
+	const createdOn = new Date();
+	const inserted = db
+		.insert(table.gameCheckpoint)
+		.values({
+			id: crypto.randomUUID(),
+			playerId: userId,
+			gameId: snapshot.gameId,
+			createdOn,
+			isActive: true,
+			board: snapshot.board,
+			score: snapshot.score,
+			seed: snapshot.seed ?? null,
+			rngState: snapshot.rngState ?? null,
+			moveCount: snapshot.moveCount ?? 0,
+			undoCooldownRemaining: snapshot.undoCooldownRemaining ?? 0,
+			won: snapshot.won ?? false,
+		})
+		.returning()
+		.get();
+
+	return toCheckpointInfo(inserted);
+}
+
+/**
+ * Restore the active checkpoint into the current game row and return the restored state.
+ *
+ * @param {string} userId
+ * @param {string} gameId
+ * @returns {Promise<import("$lib/types").CheckpointRestoreState>}
+ */
+export async function restoreCheckpoint(userId, gameId) {
+	requireProUser(userId);
+	assert(gameId, "gameId is required");
+
+	requireOwnedGame(gameId, userId);
+
+	const checkpoint = db
+		.select()
+		.from(table.gameCheckpoint)
+		.where(
+			and(
+				eq(table.gameCheckpoint.playerId, userId),
+				eq(table.gameCheckpoint.gameId, gameId),
+				eq(table.gameCheckpoint.isActive, true)
+			)
+		)
+		.orderBy(desc(table.gameCheckpoint.createdOn))
+		.get();
+
+	if (!checkpoint) {
+		const error = new Error("No checkpoint found");
+		// @ts-ignore
+		error.status = 404;
+		// @ts-ignore
+		error.code = "NO_CHECKPOINT";
+		throw error;
+	}
+
+	// Restore into the same game (not a new slot). Always reopen as incomplete so play can continue.
+	// Invalidate recorded moves — checkpoints do not capture the direction history needed for replay.
+	await db
+		.update(table.game)
+		.set({
+			board: checkpoint.board,
+			score: checkpoint.score,
+			won: checkpoint.won,
+			complete: false,
+			seed: checkpoint.seed,
+			rngState: checkpoint.rngState,
+			moveCount: checkpoint.moveCount,
+			undoCooldownRemaining: checkpoint.undoCooldownRemaining,
+			moves: null,
+			updatedOn: new Date(),
+		})
+		.where(eq(table.game.id, gameId));
+
+	return {
+		id: gameId,
+		board: checkpoint.board,
+		score: checkpoint.score,
+		seed: checkpoint.seed ?? undefined,
+		rngState: checkpoint.rngState ?? undefined,
+		moveCount: checkpoint.moveCount,
+		undoCooldownRemaining: checkpoint.undoCooldownRemaining,
+		won: checkpoint.won,
+		complete: false,
+		moves: null,
+	};
+}

--- a/src/lib/server/db/schema/gameSchemas.ts
+++ b/src/lib/server/db/schema/gameSchemas.ts
@@ -22,3 +22,28 @@ export const game = sqliteTable("game", {
 	moveCount: integer("move_count").notNull().default(0),
 	undoCooldownRemaining: integer("undo_cooldown_remaining").notNull().default(0),
 });
+
+/**
+ * Checkpoint snapshots for a game run.
+ *
+ * Only one row per game should have isActive=true at a time (the restore target).
+ * Superseded rows are retained for analytics and are not restorable in the UI.
+ */
+export const gameCheckpoint = sqliteTable("game_checkpoint", {
+	id: text("id").primaryKey(),
+	playerId: text("player_id")
+		.notNull()
+		.references(() => user.id, { onDelete: "cascade" }),
+	gameId: text("game_id")
+		.notNull()
+		.references(() => game.id, { onDelete: "cascade" }),
+	createdOn: integer("created_on", { mode: "timestamp" }).notNull(),
+	isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
+	board: text("board", { mode: "json" }).$type<number[][]>().notNull(),
+	score: integer("score").notNull(),
+	seed: integer("seed"),
+	rngState: integer("rng_state"),
+	moveCount: integer("move_count").notNull().default(0),
+	undoCooldownRemaining: integer("undo_cooldown_remaining").notNull().default(0),
+	won: integer("won", { mode: "boolean" }).notNull().default(false),
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -105,3 +105,40 @@ export interface GameHistoryEntry {
 
 export type GameHistorySort = "date" | "score" | "moves";
 export type GameHistoryFilter = "all" | "won" | "lost";
+
+
+/** Snapshot payload used when setting a checkpoint */
+export interface CheckpointSaveData {
+  gameId: string;
+  board: number[][];
+  score: number;
+  seed?: number;
+  rngState?: number;
+  moveCount?: number;
+  undoCooldownRemaining?: number;
+  won?: boolean;
+}
+
+/** Active checkpoint metadata returned to the client */
+export interface CheckpointInfo {
+  id: string;
+  gameId: string;
+  createdOn: number;
+  score: number;
+  moveCount: number;
+}
+
+/** Full checkpoint state used when restoring into the current game */
+export interface CheckpointRestoreState {
+  id: string;
+  board: number[][];
+  score: number;
+  seed?: number;
+  rngState?: number;
+  moveCount: number;
+  undoCooldownRemaining: number;
+  won: boolean;
+  complete: boolean;
+  /** Always null after restore — direction history is not captured in checkpoints */
+  moves?: number[] | null;
+}

--- a/src/routes/api/game/checkpoint/+server.js
+++ b/src/routes/api/game/checkpoint/+server.js
@@ -1,0 +1,64 @@
+import { json } from "@sveltejs/kit";
+import { USER_LEVELS } from "$lib/constants";
+import { getActiveCheckpoint, setCheckpoint } from "$lib/server/checkpoint";
+import { getUser } from "$lib/server/user";
+
+/**
+ * @param {unknown} error
+ * @returns {{ message: string, status: number, code?: string }}
+ */
+function normalizeError(error) {
+	const status = /** @type {{ status?: number }} */ (error)?.status ?? 500;
+	const code = /** @type {{ code?: string }} */ (error)?.code;
+	const message = error instanceof Error ? error.message : "Failed to process checkpoint request";
+	return { message, status, code };
+}
+
+/** @type {import("./$types").RequestHandler} */
+export async function GET({ url, locals }) {
+	if (!locals.user) {
+		return json({ error: "Not logged in" }, { status: 401 });
+	}
+
+	const gameId = url.searchParams.get("gameId");
+	if (!gameId) {
+		return json({ error: "gameId is required" }, { status: 400 });
+	}
+
+	const checkpoint = getActiveCheckpoint(locals.user.id, gameId);
+	return json({ checkpoint });
+}
+
+/** @type {import("./$types").RequestHandler} */
+export async function POST({ request, locals }) {
+	if (!locals.user) {
+		return json({ error: "Not logged in" }, { status: 401 });
+	}
+
+	const user = getUser(locals.user.id);
+	if (!user || user.level !== USER_LEVELS.PRO) {
+		return json({ error: "Checkpoints are a Pro feature", code: "PRO_REQUIRED" }, { status: 403 });
+	}
+
+	const body = await request.json();
+	if (!body?.gameId || !body?.board || typeof body.score !== "number") {
+		return json({ error: "gameId, board, and score are required" }, { status: 400 });
+	}
+
+	try {
+		const checkpoint = await setCheckpoint(locals.user.id, {
+			gameId: body.gameId,
+			board: body.board,
+			score: body.score,
+			seed: body.seed,
+			rngState: body.rngState,
+			moveCount: body.moveCount,
+			undoCooldownRemaining: body.undoCooldownRemaining,
+			won: body.won,
+		});
+		return json({ success: true, checkpoint });
+	} catch (error) {
+		const { message, status, code } = normalizeError(error);
+		return json({ error: message, code }, { status });
+	}
+}

--- a/src/routes/api/game/checkpoint/restore/+server.js
+++ b/src/routes/api/game/checkpoint/restore/+server.js
@@ -1,0 +1,40 @@
+import { json } from "@sveltejs/kit";
+import { USER_LEVELS } from "$lib/constants";
+import { restoreCheckpoint } from "$lib/server/checkpoint";
+import { getUser } from "$lib/server/user";
+
+/**
+ * @param {unknown} error
+ * @returns {{ message: string, status: number, code?: string }}
+ */
+function normalizeError(error) {
+	const status = /** @type {{ status?: number }} */ (error)?.status ?? 500;
+	const code = /** @type {{ code?: string }} */ (error)?.code;
+	const message = error instanceof Error ? error.message : "Failed to restore checkpoint";
+	return { message, status, code };
+}
+
+/** @type {import("./$types").RequestHandler} */
+export async function POST({ request, locals }) {
+	if (!locals.user) {
+		return json({ error: "Not logged in" }, { status: 401 });
+	}
+
+	const user = getUser(locals.user.id);
+	if (!user || user.level !== USER_LEVELS.PRO) {
+		return json({ error: "Checkpoints are a Pro feature", code: "PRO_REQUIRED" }, { status: 403 });
+	}
+
+	const body = await request.json();
+	if (!body?.gameId) {
+		return json({ error: "gameId is required" }, { status: 400 });
+	}
+
+	try {
+		const game = await restoreCheckpoint(locals.user.id, body.gameId);
+		return json({ success: true, game });
+	} catch (error) {
+		const { message, status, code } = normalizeError(error);
+		return json({ error: message, code }, { status });
+	}
+}

--- a/src/routes/game/+page.server.js
+++ b/src/routes/game/+page.server.js
@@ -1,3 +1,5 @@
+import { USER_LEVELS } from "$lib/constants.js";
+import { getActiveCheckpoint } from "$lib/server/checkpoint";
 import { getCurrentGame, saveScore } from "$lib/server/game";
 import { getUserProfile } from "$lib/server/user.js";
 import { fail } from "@sveltejs/kit";
@@ -6,13 +8,15 @@ import { fail } from "@sveltejs/kit";
 export function load({ locals }) {
 	let user = null;
 	let dbGame = null;
+	let hasCheckpoint = false;
 
 	if (locals.user) {
 		user = getUserProfile(locals.user.id);
 		dbGame = getCurrentGame(locals.user.id);
 		if (dbGame) {
+			const gameId = dbGame.id;
 			dbGame = {
-				id: dbGame.id,
+				id: gameId,
 				board: dbGame.board,
 				score: dbGame.score ?? 0,
 				seed: dbGame.seed ?? undefined,
@@ -22,6 +26,10 @@ export function load({ locals }) {
 				moves: dbGame.moves ?? null,
 				lastUpdated: dbGame.updatedOn.getTime(),
 			};
+
+			if (user?.level === USER_LEVELS.PRO) {
+				hasCheckpoint = !!getActiveCheckpoint(locals.user.id, gameId);
+			}
 		}
 	}
 
@@ -29,6 +37,7 @@ export function load({ locals }) {
 		user,
 		/** @type {import("$lib/types").GameState & { lastUpdated: number } | null} */
 		dbGame,
+		hasCheckpoint,
 	};
 }
 

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -197,6 +197,90 @@
 		}
 	}
 
+	/**
+	 * Ensure the current game has a persisted id before checkpoint ops
+	 * @returns {Promise<string | null>}
+	 */
+	async function ensurePersistedGameId() {
+		const game = gameState.currentGame;
+		if (!game || !page.data.user) return null;
+
+		await flushSaveToServer();
+		if (game.id) return game.id;
+
+		await saveGameToServer(game);
+		return game.id ?? null;
+	}
+
+	/**
+	 * Capture the current board as the active checkpoint for this run
+	 */
+	async function handleSetCheckpoint() {
+		const game = gameState.currentGame;
+		if (!game || !page.data.user) return;
+
+		const gameId = await ensurePersistedGameId();
+		if (!gameId) {
+			console.error("Unable to set checkpoint: game is not saved");
+			return;
+		}
+
+		const snapshot = game.json();
+		try {
+			const response = await fetch("/api/game/checkpoint", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					gameId,
+					board: snapshot.board,
+					score: snapshot.score,
+					seed: snapshot.seed,
+					rngState: snapshot.rngState,
+					moveCount: snapshot.moveCount,
+					undoCooldownRemaining: snapshot.undoCooldownRemaining,
+					won: snapshot.won,
+				}),
+			});
+			const result = await response.json();
+			if (!response.ok || !result.success) {
+				throw new Error(result.error || "Failed to set checkpoint");
+			}
+			gameState.hasCheckpoint = true;
+		} catch (error) {
+			console.error("Failed to set checkpoint:", error);
+		}
+	}
+
+	/**
+	 * Restore the latest active checkpoint into the current game
+	 */
+	async function handleRestoreCheckpoint() {
+		const game = gameState.currentGame;
+		if (!game?.id || !page.data.user) return;
+
+		try {
+			const response = await fetch("/api/game/checkpoint/restore", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ gameId: game.id }),
+			});
+			const result = await response.json();
+			if (!response.ok || !result.success || !result.game) {
+				throw new Error(result.error || "Failed to restore checkpoint");
+			}
+
+			gameState.currentGame = new Game({
+				id: result.game.id,
+				initialState: result.game,
+			});
+			gameState.hasCheckpoint = true;
+			localSaveGame(gameState.currentGame.json());
+			queueMicrotask(() => flushSaveToServer());
+		} catch (error) {
+			console.error("Failed to restore checkpoint:", error);
+		}
+	}
+
 	// Update best score and save board to localstorage
 	$effect(() => {
 		if (!gameState.currentGame) return;
@@ -309,6 +393,7 @@
 
 	// Setup listeners on mount
 	onMount(() => {
+		gameState.hasCheckpoint = !!data.hasCheckpoint;
 		tryLoadGame();
 
 		window.addEventListener("keydown", handleKeydown);
@@ -368,7 +453,12 @@
 	ontouchend={handleTouchEnd}
 >
 	<!-- Game Board -->
-	<AnimatedBoard {pendingEvents} {popEvent} />
+	<AnimatedBoard
+		{pendingEvents}
+		{popEvent}
+		onSetCheckpoint={handleSetCheckpoint}
+		onRestoreCheckpoint={handleRestoreCheckpoint}
+	/>
 
 	<!-- Instructions -->
 	<div class="text-center text-sm" style:color={page.data.theme?.textLight}>

--- a/src/routes/game/components/AnimatedBoard.svelte
+++ b/src/routes/game/components/AnimatedBoard.svelte
@@ -17,6 +17,8 @@
 	 *   pendingEvents?: import("$lib/types").GameEvent[],
 	 *   popEvent: () => import("$lib/types").GameEvent | undefined,
 	 *   onUndo?: () => void,
+	 *   onSetCheckpoint?: () => void | Promise<void>,
+	 *   onRestoreCheckpoint?: () => void | Promise<void>,
 	 *   game?: import("$lib/game.svelte.js").Game | null,
 	 *   showControls?: boolean,
 	 *   speed?: number,
@@ -27,6 +29,8 @@
 		pendingEvents = [],
 		popEvent,
 		onUndo = undefined,
+		onSetCheckpoint = undefined,
+		onRestoreCheckpoint = undefined,
 		game: gameProp = undefined,
 		showControls = true,
 		speed = 1,
@@ -181,6 +185,22 @@
 	}
 
 	/**
+	 * Clear pending animations then restore from checkpoint
+	 */
+	async function handleRestoreCheckpoint() {
+		pendingEvents.splice(0, pendingEvents.length);
+		await onRestoreCheckpoint?.();
+
+		const current = gameProp !== undefined ? gameProp : gameState.currentGame;
+		if (current) {
+			animator.syncFromBoard(current.board);
+			boardSignature = JSON.stringify(current.board);
+			syncedGame = current;
+			frame += 1;
+		}
+	}
+
+	/**
 	 * Force visual resync from the current game board (used by replay reset/scrub)
 	 */
 	export function syncBoard() {
@@ -194,7 +214,12 @@
 </script>
 
 {#if showControls}
-	<GameControls {animationIdle} onUndo={handleUndo} />
+	<GameControls
+		{animationIdle}
+		onUndo={handleUndo}
+		{onSetCheckpoint}
+		onRestoreCheckpoint={handleRestoreCheckpoint}
+	/>
 {/if}
 
 <div class="board-container" bind:this={boardContainer}>

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -1,9 +1,13 @@
 <script>
 	import { page } from "$app/state";
 	import Menu from "$lib/components/Menu.svelte";
+	import { USER_LEVELS } from "$lib/constants.js";
 	import { Game } from "$lib/game.svelte.js";
 	import { gameState } from "../state.svelte.js";
 	import {
+		BookmarkIcon,
+		BookmarkPlusIcon,
+		CrownIcon,
 		LoaderCircleIcon,
 		MenuIcon,
 		MoveHorizontalIcon,
@@ -39,8 +43,24 @@
 	}
 
 	let game = $derived(gameState.currentGame);
+	let isPro = $derived(page.data.user?.level === USER_LEVELS.PRO);
+	let isLoggedIn = $derived(!!page.data.user);
 
-	let { animationIdle = true, onUndo = undefined } = $props();
+	/**
+	 * @typedef {Object} Props
+	 * @property {boolean} [animationIdle]
+	 * @property {(() => void) | undefined} [onUndo]
+	 * @property {(() => void | Promise<void>) | undefined} [onSetCheckpoint]
+	 * @property {(() => void | Promise<void>) | undefined} [onRestoreCheckpoint]
+	 */
+
+	/** @type {Props} */
+	let {
+		animationIdle = true,
+		onUndo = undefined,
+		onSetCheckpoint = undefined,
+		onRestoreCheckpoint = undefined,
+	} = $props();
 
 	const GAME_OVER_DELAY = 600;
 	const GAME_WIN_DELAY = 400;
@@ -50,6 +70,9 @@
 	let openMenu = $state(false);
 	/** True while waiting for move animations to finish before applying undo */
 	let undoQueued = $state(false);
+	/** True while waiting for animations before restoring a checkpoint */
+	let restoreQueued = $state(false);
+	let checkpointBusy = $state(false);
 
 	$effect(() => {
 		if (!game) return;
@@ -92,10 +115,27 @@
 		onUndo?.();
 	});
 
+	// Flush a queued checkpoint restore once animations settle
+	$effect(() => {
+		if (!restoreQueued) return;
+
+		if (!gameState.hasCheckpoint || !isPro) {
+			restoreQueued = false;
+			return;
+		}
+
+		if (!animationIdle || checkpointBusy) return;
+
+		restoreQueued = false;
+		void runRestoreCheckpoint();
+	});
+
 	function newGame() {
 		showGameOver = false;
 		showWin = false;
 		undoQueued = false;
+		restoreQueued = false;
+		gameState.hasCheckpoint = false;
 		gameState.currentGame = new Game();
 	}
 
@@ -135,6 +175,41 @@
 		onUndo?.();
 	}
 
+	async function runSetCheckpoint() {
+		if (!isPro || !game || checkpointBusy) return;
+		openMenu = false;
+		checkpointBusy = true;
+		try {
+			await onSetCheckpoint?.();
+		} finally {
+			checkpointBusy = false;
+		}
+	}
+
+	async function runRestoreCheckpoint() {
+		if (!isPro || !game || !gameState.hasCheckpoint || checkpointBusy) return;
+		openMenu = false;
+		checkpointBusy = true;
+		try {
+			await onRestoreCheckpoint?.();
+			showGameOver = false;
+			showWin = false;
+		} finally {
+			checkpointBusy = false;
+		}
+	}
+
+	function handleRestoreCheckpoint() {
+		if (!isPro || !gameState.hasCheckpoint || checkpointBusy || restoreQueued) return;
+
+		if (!animationIdle) {
+			restoreQueued = true;
+			return;
+		}
+
+		void runRestoreCheckpoint();
+	}
+
 	// Only disable for real undo unavailability (cooldown / no snapshot) — not mid-animation
 	let undoDisabled = $derived(!game?.canUndo);
 	let undoTitle = $derived(
@@ -148,6 +223,8 @@
 						? `Undo available in ${game.undoCooldownRemaining} move${game.undoCooldownRemaining === 1 ? "" : "s"}`
 						: "Nothing to undo"
 	);
+
+	let canRestoreCheckpoint = $derived(isPro && gameState.hasCheckpoint && !checkpointBusy);
 </script>
 
 <!-- Header -->
@@ -216,6 +293,47 @@
 				<PlusIcon size={18} />
 				New Game
 			</button>
+			{#if isPro}
+				<button
+					class="bg-primary hover:bg-primary-dark flex items-center gap-2 rounded-md p-2 text-nowrap text-white disabled:cursor-not-allowed disabled:opacity-40"
+					onclick={runSetCheckpoint}
+					disabled={!game || game.gameOver || checkpointBusy}
+					title={game?.gameOver
+						? "Checkpoints can only be set during an active game"
+						: "Save a restore point for this run"}
+				>
+					{#if checkpointBusy}
+						<LoaderCircleIcon class="animate-spin" size={18} />
+					{:else}
+						<BookmarkPlusIcon size={18} />
+					{/if}
+					Set Checkpoint
+				</button>
+				<button
+					class="bg-primary hover:bg-primary-dark flex items-center gap-2 rounded-md p-2 text-nowrap text-white disabled:cursor-not-allowed disabled:opacity-40"
+					onclick={handleRestoreCheckpoint}
+					disabled={!canRestoreCheckpoint && !restoreQueued}
+					title={gameState.hasCheckpoint ? "Restore to your last checkpoint" : "No checkpoint set"}
+				>
+					{#if restoreQueued || checkpointBusy}
+						<LoaderCircleIcon class="animate-spin" size={18} />
+					{:else}
+						<BookmarkIcon size={18} />
+					{/if}
+					Restore Checkpoint
+				</button>
+			{:else}
+				<a
+					href={isLoggedIn ? "/stripe" : "/login"}
+					class="bg-primary hover:bg-primary-dark flex items-center gap-2 rounded-md p-2 text-nowrap text-white"
+					onclick={() => {
+						openMenu = false;
+					}}
+				>
+					<CrownIcon size={18} />
+					Checkpoints (Pro)
+				</a>
+			{/if}
 		{/snippet}
 	</Menu>
 	<div class="flex-1"></div>
@@ -261,7 +379,28 @@
 			{#if game.canUndo}
 				<button class="overlay-btn" onclick={handleUndo}>Undo Last Move</button>
 			{/if}
-			<button class="overlay-btn" class:secondary={game.canUndo} onclick={newGame}>Try Again</button
+			{#if isPro && gameState.hasCheckpoint}
+				<button
+					class="overlay-btn"
+					class:secondary={game.canUndo}
+					onclick={handleRestoreCheckpoint}
+					disabled={checkpointBusy || restoreQueued}
+				>
+					{#if restoreQueued || checkpointBusy}
+						Restoring…
+					{:else}
+						Restore Checkpoint
+					{/if}
+				</button>
+			{:else if !isPro}
+				<a href={isLoggedIn ? "/stripe" : "/login"} class="overlay-btn secondary">
+					Checkpoints (Pro)
+				</a>
+			{/if}
+			<button
+				class="overlay-btn"
+				class:secondary={game.canUndo || (isPro && gameState.hasCheckpoint) || !isPro}
+				onclick={newGame}>Try Again</button
 			>
 		</div>
 	</div>
@@ -333,6 +472,8 @@
 		cursor: pointer;
 		margin: 0 10px 10px 0;
 		transition: background-color 0.2s;
+		display: inline-block;
+		text-decoration: none;
 	}
 
 	.overlay-btn:hover {

--- a/src/routes/game/state.svelte.js
+++ b/src/routes/game/state.svelte.js
@@ -4,6 +4,9 @@ export const gameState = $state({
 
 	/** @type {import("$lib/game.svelte.js").Game | null} */
 	currentGame: null,
+
+	/** Whether the current game has an active restorable checkpoint */
+	hasCheckpoint: false,
 });
 
 export const general = $state({

--- a/src/routes/stripe/+page.svelte
+++ b/src/routes/stripe/+page.svelte
@@ -32,8 +32,8 @@
 			implemented: true,
 		},
 		{
-			name: "Board Power Ups & Checkpoints",
-			implemented: false,
+			name: "Checkpoints",
+			implemented: true,
 		},
 		{
 			name: "Exclusive themes and customization",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#2](https://github.com/JoelYoung01/Play4096/issues/2): Pro-only **checkpoints** so a player can save one restore point during a run and jump back to it from the game UI or the game-over menu.

Rebased onto latest `main` (history/replay, challenges, themes).

## Behavior

- **Set checkpoint** (Pro): captures board, score, seed/rng state, move count, undo cooldown, and won flag
- Only **one active checkpoint** per game — setting a new one marks the previous as inactive (rows kept for analytics)
- **Restore checkpoint** (Pro): available in the menu and on game over; loads into the same game (does not create a new slot)
- Restoring invalidates recorded move history (`moves = null`) since checkpoints do not capture direction lists for replay
- **Free / logged-out** users see a Checkpoints (Pro) upgrade CTA instead
- Flip / rotate / mirror controls are unchanged

## Changes

- New `game_checkpoint` table + migration `0009_game_checkpoint`
- Server helpers + APIs:
  - `POST /api/game/checkpoint` — set (Pro + ownership)
  - `POST /api/game/checkpoint/restore` — restore latest active
  - `GET /api/game/checkpoint?gameId=` — active metadata
- Game menu + game-over UI wiring; Stripe feature list marks Checkpoints as implemented alongside History/Replay, themes, and Challenges

## Test plan

- [x] Pro user can set a checkpoint during play
- [x] Setting a new checkpoint makes only that one restorable (prior row retained, `is_active=false`)
- [x] Restore returns checkpoint board/score/rng into the same game, reopens `complete=false`, clears `moves`
- [x] Free user gets 403 / upgrade CTA on set
- [x] Migration `0009` applies cleanly on top of current main
- [ ] Manual UI: Set / Restore in menu; Restore on game over; free-user CTA
- [ ] Confirm flip/rotate unchanged
- [ ] Confirm Game History & Replay / Challenges / themes still work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f61ba-47d5-7296-950f-f6b29fe6cedf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f61ba-47d5-7296-950f-f6b29fe6cedf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

