### PR TITLE
Fix challenge boards, daily calendar, scroll & theme previews

### DIFF
--- a/drizzle/0010_daily_challenge.sql
+++ b/drizzle/0010_daily_challenge.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `daily_challenge` (
+	`id` text PRIMARY KEY NOT NULL,
+	`challenge_date` text NOT NULL,
+	`type` text NOT NULL,
+	`title` text NOT NULL,
+	`description` text NOT NULL,
+	`difficulty` text NOT NULL,
+	`params` text NOT NULL,
+	`created_on` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `daily_challenge_date_uidx` ON `daily_challenge` (`challenge_date`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1784075000000,
       "tag": "0009_game_checkpoint",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1784076000000,
+      "tag": "0010_daily_challenge",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/assets/playSurface.css
+++ b/src/lib/assets/playSurface.css
@@ -1,0 +1,16 @@
+/** Shared CSS for swipe/gesture prevention on game play surfaces only. */
+.play-surface {
+	/* Prevent Chrome's pull-to-refresh and other touch gestures */
+	touch-action: none;
+	user-select: none;
+	overscroll-behavior: contain;
+	-webkit-touch-callout: none;
+	-webkit-user-select: none;
+	-webkit-overflow-scrolling: touch;
+	-webkit-overscroll-behavior: contain;
+	-webkit-tap-highlight-color: transparent;
+	-webkit-user-drag: none;
+	-khtml-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+}

--- a/src/lib/boardConstants.js
+++ b/src/lib/boardConstants.js
@@ -1,0 +1,5 @@
+/** Shared geometry for AnimatedBoard and ThemePreview */
+export const BOARD_GAP = 10;
+export const BOARD_PADDING = 10;
+export const TILE_BORDER_RADIUS = 6;
+export const BOARD_BORDER_RADIUS = 8;

--- a/src/lib/challenges.js
+++ b/src/lib/challenges.js
@@ -1,7 +1,9 @@
 /**
- * Challenge content definitions (static for v1).
- * Three types: time, clear, recovery — see issue #5.
+ * Challenge types, evaluation, and deterministic daily generation.
+ * Daily challenges resolve in America/Chicago (CST/CDT).
  */
+
+import { createSeededRng } from "$lib/rng.js";
 
 export const CHALLENGE_TYPES = {
 	TIME: "time",
@@ -15,6 +17,9 @@ export const CHALLENGE_RUN_STATUS = {
 	LOST: "lost",
 	ABANDONED: "abandoned",
 };
+
+/** IANA zone for daily challenge rollover (midnight Central Time) */
+export const CHALLENGE_TIMEZONE = "America/Chicago";
 
 /**
  * @typedef {Object} TimeChallengeParams
@@ -49,62 +54,233 @@ export const CHALLENGE_RUN_STATUS = {
  * @property {TimeChallengeParams | ClearChallengeParams | RecoveryChallengeParams} params
  */
 
-/** @type {ChallengeDefinition[]} */
-export const CHALLENGES = [
-	{
-		id: "sprint-500",
-		type: CHALLENGE_TYPES.TIME,
-		title: "Score Sprint",
-		description: "Reach 500 points before the clock hits zero. Starts from a fresh board.",
-		difficulty: "Easy",
-		params: {
-			seed: 2048,
-			targetScore: 500,
-			durationSec: 60,
-		},
-	},
-	{
-		id: "space-maker",
-		type: CHALLENGE_TYPES.CLEAR,
-		title: "Space Maker",
-		description: "This board is packed. Merge until 4 or fewer tiles remain.",
-		difficulty: "Medium",
-		params: {
-			seed: 4096,
-			board: [
-				[2, 2, 4, 4],
-				[8, 8, 16, 16],
-				[2, 2, 4, 4],
-				[8, 8, 0, 0],
-			],
-			maxFilled: 4,
-		},
-	},
-	{
-		id: "near-miss",
-		type: CHALLENGE_TYPES.RECOVERY,
-		title: "Near Miss",
-		description: "Pull off a 2048 from this awkward high-tile scramble.",
-		difficulty: "Hard",
-		params: {
-			seed: 1024,
-			winTile: 2048,
-			board: [
-				[1024, 512, 256, 128],
-				[4, 8, 16, 32],
-				[2, 64, 0, 0],
-				[0, 0, 0, 0],
-			],
-		},
-	},
-];
+const DIFFICULTIES = ["Easy", "Medium", "Hard"];
+
+const TIME_TITLES = ["Score Sprint", "Point Rush", "Clock Race", "Quick Score"];
+const CLEAR_TITLES = ["Space Maker", "Board Cleaner", "Merge Down", "Clear Path"];
+const RECOVERY_TITLES = ["Near Miss", "Comeback", "High Wire", "Last Stand"];
 
 /**
- * @param {string} id
- * @returns {ChallengeDefinition | undefined}
+ * Format a Date as YYYY-MM-DD in the challenge timezone.
+ * @param {Date} [date]
+ * @returns {string}
  */
-export function getChallengeById(id) {
-	return CHALLENGES.find((c) => c.id === id);
+export function getChallengeDateString(date = new Date()) {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: CHALLENGE_TIMEZONE,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(date);
+}
+
+/**
+ * Parse YYYY-MM-DD into calendar parts.
+ * @param {string} dateStr
+ * @returns {{ year: number; month: number; day: number } | null}
+ */
+export function parseChallengeDate(dateStr) {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+	if (!match) return null;
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	if (!Number.isFinite(year) || month < 1 || month > 12 || day < 1 || day > 31) return null;
+	return { year, month, day };
+}
+
+/**
+ * Build daily challenge id from a date string.
+ * @param {string} dateStr YYYY-MM-DD
+ */
+export function dailyChallengeId(dateStr) {
+	return `daily-${dateStr}`;
+}
+
+/**
+ * Extract YYYY-MM-DD from a daily challenge id.
+ * @param {string} id
+ * @returns {string | null}
+ */
+export function dateFromChallengeId(id) {
+	if (id.startsWith("daily-")) {
+		const dateStr = id.slice("daily-".length);
+		return parseChallengeDate(dateStr) ? dateStr : null;
+	}
+	return parseChallengeDate(id) ? id : null;
+}
+
+/**
+ * Compare two YYYY-MM-DD strings.
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function compareDateStrings(a, b) {
+	return a.localeCompare(b);
+}
+
+/**
+ * Hash a string into a uint32 seed.
+ * @param {string} input
+ */
+function hashSeed(input) {
+	let h = 2166136261;
+	for (let i = 0; i < input.length; i++) {
+		h ^= input.charCodeAt(i);
+		h = Math.imul(h, 16777619);
+	}
+	return h >>> 0;
+}
+
+/**
+ * Create an empty 4x4 board.
+ * @returns {number[][]}
+ */
+function emptyBoard() {
+	return Array.from({ length: 4 }, () => Array(4).fill(0));
+}
+
+/**
+ * Place values onto random empty cells.
+ * @param {ReturnType<typeof createSeededRng>} rng
+ * @param {number[]} values
+ * @returns {number[][]}
+ */
+function boardFromValues(rng, values) {
+	const board = emptyBoard();
+	const positions = [];
+	for (let r = 0; r < 4; r++) {
+		for (let c = 0; c < 4; c++) {
+			positions.push({ r, c });
+		}
+	}
+	for (let i = positions.length - 1; i > 0; i--) {
+		const j = rng.nextInt(i + 1);
+		const tmp = positions[i];
+		positions[i] = positions[j];
+		positions[j] = tmp;
+	}
+	for (let i = 0; i < values.length && i < positions.length; i++) {
+		const { r, c } = positions[i];
+		board[r][c] = values[i];
+	}
+	return board;
+}
+
+/**
+ * @param {ReturnType<typeof createSeededRng>} rng
+ * @param {number} count
+ * @param {number[]} pool
+ */
+function pickValues(rng, count, pool) {
+	/** @type {number[]} */
+	const values = [];
+	for (let i = 0; i < count; i++) {
+		values.push(pool[rng.nextInt(pool.length)]);
+	}
+	return values;
+}
+
+/**
+ * Deterministically generate a daily challenge definition for a Central-Time date.
+ * @param {string} dateStr YYYY-MM-DD
+ * @returns {ChallengeDefinition}
+ */
+export function generateDailyChallengeDefinition(dateStr) {
+	const parsed = parseChallengeDate(dateStr);
+	if (!parsed) {
+		throw new Error(`Invalid challenge date: ${dateStr}`);
+	}
+
+	const id = dailyChallengeId(dateStr);
+	const seed = hashSeed(`play4096-daily-${dateStr}`);
+	const rng = createSeededRng(seed);
+
+	const typeRoll = rng.nextInt(3);
+	const difficulty = DIFFICULTIES[rng.nextInt(DIFFICULTIES.length)];
+
+	if (typeRoll === 0) {
+		const durationOptions =
+			difficulty === "Easy" ? [90, 75] : difficulty === "Medium" ? [60, 50] : [45, 40];
+		const scoreOptions =
+			difficulty === "Easy"
+				? [300, 400, 500]
+				: difficulty === "Medium"
+					? [600, 800, 1000]
+					: [1200, 1500, 2000];
+		const durationSec = durationOptions[rng.nextInt(durationOptions.length)];
+		const targetScore = scoreOptions[rng.nextInt(scoreOptions.length)];
+		const title = TIME_TITLES[rng.nextInt(TIME_TITLES.length)];
+
+		return {
+			id,
+			type: CHALLENGE_TYPES.TIME,
+			title,
+			description: `Reach ${targetScore.toLocaleString()} points before the clock hits zero. Fresh board, fixed seed.`,
+			difficulty,
+			params: {
+				seed,
+				targetScore,
+				durationSec,
+			},
+		};
+	}
+
+	if (typeRoll === 1) {
+		const fill =
+			difficulty === "Easy"
+				? 10 + rng.nextInt(3)
+				: difficulty === "Medium"
+					? 12 + rng.nextInt(3)
+					: 14 + rng.nextInt(2);
+		const pool =
+			difficulty === "Easy"
+				? [2, 2, 4, 4, 8, 8, 16]
+				: difficulty === "Medium"
+					? [2, 4, 4, 8, 8, 16, 16, 32]
+					: [2, 4, 8, 16, 16, 32, 32, 64, 128];
+		const board = boardFromValues(rng, pickValues(rng, fill, pool));
+		const maxFilled = difficulty === "Easy" ? 4 : difficulty === "Medium" ? 3 : 2;
+		const title = CLEAR_TITLES[rng.nextInt(CLEAR_TITLES.length)];
+
+		return {
+			id,
+			type: CHALLENGE_TYPES.CLEAR,
+			title,
+			description: `This board is crowded. Merge until ${maxFilled} or fewer tiles remain.`,
+			difficulty,
+			params: {
+				seed,
+				board,
+				maxFilled,
+			},
+		};
+	}
+
+	const winTile = difficulty === "Easy" ? 512 : difficulty === "Medium" ? 1024 : 2048;
+	const highValues =
+		difficulty === "Easy"
+			? [256, 128, 64, 32, 16, 8, 4, 2]
+			: difficulty === "Medium"
+				? [512, 256, 128, 64, 32, 16, 8, 4]
+				: [1024, 512, 256, 128, 64, 32, 16, 8];
+	const extras = pickValues(rng, 2 + rng.nextInt(3), [2, 4, 8, 16]);
+	const board = boardFromValues(rng, [...highValues.slice(0, 6 + rng.nextInt(3)), ...extras]);
+	const title = RECOVERY_TITLES[rng.nextInt(RECOVERY_TITLES.length)];
+
+	return {
+		id,
+		type: CHALLENGE_TYPES.RECOVERY,
+		title,
+		description: `Pull off a ${winTile} from this awkward high-tile scramble.`,
+		difficulty,
+		params: {
+			seed,
+			winTile,
+			board,
+		},
+	};
 }
 
 /**
@@ -204,4 +380,31 @@ export function formatChallengeObjective(challenge) {
 	}
 
 	return challenge.description;
+}
+
+/**
+ * Days in a calendar month (1-indexed month).
+ * @param {number} year
+ * @param {number} month
+ */
+export function daysInMonth(year, month) {
+	return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+/**
+ * Weekday of the 1st of the month in CST (0=Sun … 6=Sat).
+ * Uses noon UTC on that calendar day as a stable anchor.
+ * @param {number} year
+ * @param {number} month
+ */
+export function weekdayOfMonthStart(year, month) {
+	const dateStr = `${year}-${String(month).padStart(2, "0")}-01`;
+	// Format weekday in Challenge TZ for that civil date at midday UTC
+	const probe = new Date(`${dateStr}T18:00:00.000Z`);
+	const weekday = new Intl.DateTimeFormat("en-US", {
+		timeZone: CHALLENGE_TIMEZONE,
+		weekday: "short",
+	}).format(probe);
+	const map = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+	return map[/** @type {keyof typeof map} */ (weekday)] ?? 0;
 }

--- a/src/lib/components/ThemePreview.svelte
+++ b/src/lib/components/ThemePreview.svelte
@@ -23,8 +23,8 @@
 	/** @type {{ theme: PreviewTheme, selected?: boolean }} */
 	let { theme, selected = false } = $props();
 
-	/** Typical in-game board width used to scale gap/padding */
-	const REF_BOARD_WIDTH = 400;
+	/** Typical mobile in-game board width (~390 viewport minus page padding) */
+	const REF_BOARD_WIDTH = 350;
 
 	const previewValues = [
 		2,

--- a/src/lib/components/ThemePreview.svelte
+++ b/src/lib/components/ThemePreview.svelte
@@ -1,6 +1,14 @@
 <script>
+	import { onMount } from "svelte";
+	import {
+		BOARD_BORDER_RADIUS,
+		BOARD_GAP,
+		BOARD_PADDING,
+		TILE_BORDER_RADIUS,
+	} from "$lib/boardConstants.js";
+
 	/**
-	 * Mini board preview using theme tokens.
+	 * Mini board preview using the same geometry ratios as AnimatedBoard.
 	 * @typedef {Object} PreviewTheme
 	 * @property {string} boardBackground
 	 * @property {string} emptyTile
@@ -9,10 +17,14 @@
 	 * @property {string} [textDark]
 	 * @property {string} [textLight]
 	 * @property {number} [luminanceThreshold]
+	 * @property {number} [textScale]
 	 */
 
 	/** @type {{ theme: PreviewTheme, selected?: boolean }} */
 	let { theme, selected = false } = $props();
+
+	/** Typical in-game board width used to scale gap/padding */
+	const REF_BOARD_WIDTH = 400;
 
 	const previewValues = [
 		2,
@@ -32,6 +44,14 @@
 		4096,
 		null,
 	];
+
+	/** @type {HTMLDivElement | null} */
+	let boardEl = $state(null);
+	let cellSize = $state(0);
+	let gap = $state(BOARD_GAP);
+	let padding = $state(BOARD_PADDING);
+	let tileRadius = $state(TILE_BORDER_RADIUS);
+	let boardRadius = $state(BOARD_BORDER_RADIUS);
 
 	/**
 	 * @param {number} value
@@ -54,23 +74,67 @@
 		const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
 		return lum > (theme.luminanceThreshold ?? 0.6);
 	}
+
+	/**
+	 * Match AnimatedBoard font scaling relative to cell size.
+	 * @param {number} value
+	 */
+	function tileFontSize(value) {
+		if (!cellSize) return "0.65rem";
+		const fullBaseRem = 2.5;
+		const fullCellRef = (REF_BOARD_WIDTH - BOARD_PADDING * 2 - BOARD_GAP * 3) / 4;
+		const baseRem = fullBaseRem * (cellSize / fullCellRef);
+		const digits = value.toString().length;
+		const fontRem = Math.max(baseRem - (digits - 1) * 0.3 * (cellSize / fullCellRef), 0.4);
+		return `${fontRem}rem`;
+	}
+
+	onMount(() => {
+		if (!boardEl) return;
+
+		const update = () => {
+			if (!boardEl) return;
+			const width = boardEl.clientWidth;
+			const scale = width / REF_BOARD_WIDTH;
+			gap = Math.max(2, BOARD_GAP * scale);
+			padding = Math.max(2, BOARD_PADDING * scale);
+			tileRadius = Math.max(2, TILE_BORDER_RADIUS * scale);
+			boardRadius = Math.max(3, BOARD_BORDER_RADIUS * scale);
+			cellSize = (width - padding * 2 - gap * 3) / 4;
+		};
+
+		update();
+		const observer = new ResizeObserver(update);
+		observer.observe(boardEl);
+		return () => observer.disconnect();
+	});
 </script>
 
 <div
+	bind:this={boardEl}
 	class="preview-board"
 	class:selected
 	style:background={theme.boardBackground}
+	style:gap={`${gap}px`}
+	style:padding={`${padding}px`}
+	style:border-radius={`${boardRadius}px`}
 	aria-hidden="true"
 >
 	{#each previewValues as value, i (i)}
 		{#if value == null}
-			<div class="preview-tile empty" style:background={theme.emptyTile}></div>
+			<div
+				class="preview-tile empty"
+				style:background={theme.emptyTile}
+				style:border-radius={`${tileRadius}px`}
+			></div>
 		{:else}
 			{@const bg = tileBg(value, theme)}
 			<div
 				class="preview-tile"
 				style:background={bg}
 				style:color={isLight(bg) ? (theme.textLight ?? "#333") : (theme.textDark ?? "#fff")}
+				style:border-radius={`${tileRadius}px`}
+				style:font-size={tileFontSize(value)}
 			>
 				{value}
 			</div>
@@ -82,9 +146,7 @@
 	.preview-board {
 		display: grid;
 		grid-template-columns: repeat(4, 1fr);
-		gap: 4px;
-		padding: 6px;
-		border-radius: 8px;
+		grid-template-rows: repeat(4, 1fr);
 		width: 100%;
 		aspect-ratio: 1;
 		box-sizing: border-box;
@@ -99,10 +161,12 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		border-radius: 4px;
-		font-size: 0.55rem;
-		font-weight: 700;
+		font-weight: 800;
 		min-height: 0;
+		min-width: 0;
+		padding: 0.1em;
+		text-align: center;
+		line-height: 1;
 	}
 
 	.preview-tile.empty {

--- a/src/lib/game.svelte.js
+++ b/src/lib/game.svelte.js
@@ -30,7 +30,7 @@ export function getTileBackground(value, theme = defaultTheme) {
  */
 export function getTileColor(value, theme = defaultTheme) {
 	// Get the background color for this tile
-	const bg = getTileBackground(value);
+	const bg = getTileBackground(value, theme);
 
 	/**
 	 * Helper to parse hex color to RGB

--- a/src/lib/server/challenge.js
+++ b/src/lib/server/challenge.js
@@ -1,13 +1,105 @@
 import * as table from "$lib/server/db/schema";
 import { db } from "$lib/server/db";
-import { and, desc, eq, inArray } from "drizzle-orm";
-import { CHALLENGE_RUN_STATUS, CHALLENGES, getChallengeById } from "$lib/challenges.js";
+import { and, desc, eq, gte, inArray, lte } from "drizzle-orm";
+import {
+	CHALLENGE_RUN_STATUS,
+	dailyChallengeId,
+	dateFromChallengeId,
+	generateDailyChallengeDefinition,
+	getChallengeDateString,
+	parseChallengeDate,
+} from "$lib/challenges.js";
+
+/**
+ * @param {typeof table.dailyChallenge.$inferSelect} row
+ * @returns {import("$lib/challenges.js").ChallengeDefinition}
+ */
+function rowToChallenge(row) {
+	return {
+		id: row.id,
+		type: /** @type {import("$lib/challenges.js").ChallengeDefinition["type"]} */ (row.type),
+		title: row.title,
+		description: row.description,
+		difficulty: row.difficulty,
+		params: /** @type {import("$lib/challenges.js").ChallengeDefinition["params"]} */ (row.params),
+	};
+}
+
+/**
+ * Ensure a daily challenge exists for the given YYYY-MM-DD (CST civil date).
+ * Creates it deterministically if missing — safe to call on every request.
+ * @param {string} [dateStr]
+ * @returns {import("$lib/challenges.js").ChallengeDefinition}
+ */
+export function ensureDailyChallenge(dateStr = getChallengeDateString()) {
+	const parsed = parseChallengeDate(dateStr);
+	if (!parsed) {
+		throw new Error(`Invalid challenge date: ${dateStr}`);
+	}
+
+	const id = dailyChallengeId(dateStr);
+	const existing = db
+		.select()
+		.from(table.dailyChallenge)
+		.where(eq(table.dailyChallenge.id, id))
+		.get();
+
+	if (existing) {
+		return rowToChallenge(existing);
+	}
+
+	const definition = generateDailyChallengeDefinition(dateStr);
+	const now = new Date();
+
+	try {
+		db.insert(table.dailyChallenge)
+			.values({
+				id: definition.id,
+				challengeDate: dateStr,
+				type: definition.type,
+				title: definition.title,
+				description: definition.description,
+				difficulty: definition.difficulty,
+				params: definition.params,
+				createdOn: now,
+			})
+			.run();
+	} catch {
+		// Race: another request inserted first
+		const raced = db
+			.select()
+			.from(table.dailyChallenge)
+			.where(eq(table.dailyChallenge.id, id))
+			.get();
+		if (raced) return rowToChallenge(raced);
+		throw new Error(`Failed to create daily challenge for ${dateStr}`);
+	}
+
+	return definition;
+}
+
+/**
+ * Load a challenge by id (daily-YYYY-MM-DD or legacy lookup via date).
+ * Ensures the row exists when the date is today or in the past (CST).
+ * @param {string} id
+ * @returns {import("$lib/challenges.js").ChallengeDefinition | null}
+ */
+export function getChallengeById(id) {
+	const dateStr = dateFromChallengeId(id);
+	if (!dateStr) return null;
+
+	const today = getChallengeDateString();
+	if (dateStr > today) return null;
+
+	return ensureDailyChallenge(dateStr);
+}
 
 /**
  * @param {string} userId
+ * @param {string[]} challengeIds
  * @returns {Record<string, { bestStatus: string | null; attempts: number; wins: number }>}
  */
-export function getChallengeStatsForUser(userId) {
+export function getChallengeStatsForUser(userId, challengeIds = []) {
 	const runs = db
 		.select({
 			challengeId: table.challengeRun.challengeId,
@@ -20,8 +112,8 @@ export function getChallengeStatsForUser(userId) {
 	/** @type {Record<string, { bestStatus: string | null; attempts: number; wins: number }>} */
 	const stats = {};
 
-	for (const challenge of CHALLENGES) {
-		stats[challenge.id] = { bestStatus: null, attempts: 0, wins: 0 };
+	for (const challengeId of challengeIds) {
+		stats[challengeId] = { bestStatus: null, attempts: 0, wins: 0 };
 	}
 
 	for (const run of runs) {
@@ -44,6 +136,50 @@ export function getChallengeStatsForUser(userId) {
 	}
 
 	return stats;
+}
+
+/**
+ * Calendar day statuses for a user within a YYYY-MM range (inclusive days).
+ * @param {string} userId
+ * @param {string} startDate YYYY-MM-DD
+ * @param {string} endDate YYYY-MM-DD
+ */
+export function getChallengeDayStatuses(userId, startDate, endDate) {
+	const startId = dailyChallengeId(startDate);
+	const endId = dailyChallengeId(endDate);
+
+	const runs = db
+		.select({
+			challengeId: table.challengeRun.challengeId,
+			status: table.challengeRun.status,
+		})
+		.from(table.challengeRun)
+		.where(
+			and(
+				eq(table.challengeRun.userId, userId),
+				gte(table.challengeRun.challengeId, startId),
+				lte(table.challengeRun.challengeId, endId)
+			)
+		)
+		.all();
+
+	/** @type {Record<string, string>} */
+	const byDate = {};
+
+	for (const run of runs) {
+		const dateStr = dateFromChallengeId(run.challengeId);
+		if (!dateStr) continue;
+		const prev = byDate[dateStr];
+		if (run.status === CHALLENGE_RUN_STATUS.WON) {
+			byDate[dateStr] = CHALLENGE_RUN_STATUS.WON;
+		} else if (run.status === CHALLENGE_RUN_STATUS.LOST && prev !== CHALLENGE_RUN_STATUS.WON) {
+			byDate[dateStr] = CHALLENGE_RUN_STATUS.LOST;
+		} else if (run.status === CHALLENGE_RUN_STATUS.IN_PROGRESS && !prev) {
+			byDate[dateStr] = CHALLENGE_RUN_STATUS.IN_PROGRESS;
+		}
+	}
+
+	return byDate;
 }
 
 /**

--- a/src/lib/server/db/schema/challengeSchemas.js
+++ b/src/lib/server/db/schema/challengeSchemas.js
@@ -1,6 +1,26 @@
-import { sqliteTable, integer, text } from "drizzle-orm/sqlite-core";
+import { sqliteTable, integer, text, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 import { user } from "./userSchemas.js";
+
+/**
+ * Persisted daily challenge definitions (one per Central-Time calendar day).
+ * `id` is `daily-YYYY-MM-DD`.
+ */
+export const dailyChallenge = sqliteTable(
+	"daily_challenge",
+	{
+		id: text("id").primaryKey(),
+		/** YYYY-MM-DD in America/Chicago */
+		challengeDate: text("challenge_date").notNull(),
+		type: text("type").notNull(),
+		title: text("title").notNull(),
+		description: text("description").notNull(),
+		difficulty: text("difficulty").notNull(),
+		params: text("params", { mode: "json" }).notNull(),
+		createdOn: integer("created_on", { mode: "timestamp" }).notNull(),
+	},
+	(t) => [uniqueIndex("daily_challenge_date_uidx").on(t.challengeDate)]
+);
 
 /** Challenge attempt / run attribution for logged-in Pro users */
 export const challengeRun = sqliteTable("challenge_run", {

--- a/src/lib/swipe.js
+++ b/src/lib/swipe.js
@@ -1,0 +1,58 @@
+import { DIRECTIONS } from "$lib/constants.js";
+
+/**
+ * Create touch swipe handlers that map gestures to DIRECTIONS.
+ * @param {(direction: number) => void} onMove
+ * @param {number} [threshold]
+ */
+export function createSwipeHandlers(onMove, threshold = 5) {
+	let touchStartX = 0;
+	let touchStartY = 0;
+
+	/**
+	 * @param {TouchEvent} event
+	 */
+	function handleTouchStart(event) {
+		touchStartX = event.touches[0].clientX;
+		touchStartY = event.touches[0].clientY;
+	}
+
+	/**
+	 * @param {TouchEvent} event
+	 */
+	function handleTouchEnd(event) {
+		if (!touchStartX || !touchStartY) return;
+
+		const touchEndX = event.changedTouches[0].clientX;
+		const touchEndY = event.changedTouches[0].clientY;
+
+		const diffX = touchStartX - touchEndX;
+		const diffY = touchStartY - touchEndY;
+
+		if (Math.abs(diffX) < threshold && Math.abs(diffY) < threshold) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		if (Math.abs(diffX) > Math.abs(diffY)) {
+			if (diffX > 0) onMove(DIRECTIONS.LEFT);
+			else onMove(DIRECTIONS.RIGHT);
+		} else {
+			if (diffY > 0) onMove(DIRECTIONS.UP);
+			else onMove(DIRECTIONS.DOWN);
+		}
+
+		touchStartX = 0;
+		touchStartY = 0;
+	}
+
+	/**
+	 * @param {TouchEvent} event
+	 */
+	function handleTouchMove(event) {
+		event.preventDefault();
+		event.stopPropagation();
+	}
+
+	return { handleTouchStart, handleTouchEnd, handleTouchMove };
+}

--- a/src/routes/challenges/+page.server.js
+++ b/src/routes/challenges/+page.server.js
@@ -1,25 +1,100 @@
 import { USER_LEVELS } from "$lib/constants.js";
-import { CHALLENGES } from "$lib/challenges.js";
-import { getChallengeStatsForUser } from "$lib/server/challenge.js";
+import {
+	CHALLENGE_TIMEZONE,
+	dailyChallengeId,
+	daysInMonth,
+	formatChallengeObjective,
+	getChallengeDateString,
+	parseChallengeDate,
+	weekdayOfMonthStart,
+} from "$lib/challenges.js";
+import { ensureDailyChallenge, getChallengeDayStatuses } from "$lib/server/challenge.js";
 import { getUserProfile } from "$lib/server/user.js";
 
 /** @type {import("./$types").PageServerLoad} */
-export async function load({ locals }) {
-	let user = null;
-	/** @type {Record<string, { bestStatus: string | null; attempts: number; wins: number }> | null} */
-	let stats = null;
+export async function load({ locals, url }) {
+	const today = getChallengeDateString();
+	const todayParsed = parseChallengeDate(today);
 
-	if (locals.user) {
-		user = getUserProfile(locals.user.id);
-		if (user?.level === USER_LEVELS.PRO) {
-			stats = getChallengeStatsForUser(user.id);
+	const monthParam = url.searchParams.get("month");
+	let year = todayParsed?.year ?? new Date().getFullYear();
+	let month = todayParsed?.month ?? new Date().getMonth() + 1;
+
+	if (monthParam) {
+		const m = parseChallengeDate(`${monthParam}-01`);
+		if (m) {
+			year = m.year;
+			month = m.month;
 		}
 	}
 
+	const todayChallenge = ensureDailyChallenge(today);
+
+	let user = null;
+	/** @type {Record<string, string>} */
+	let dayStatuses = {};
+	if (locals.user) {
+		user = getUserProfile(locals.user.id);
+		if (user?.level === USER_LEVELS.PRO) {
+			const start = `${year}-${String(month).padStart(2, "0")}-01`;
+			const end = `${year}-${String(month).padStart(2, "0")}-${String(daysInMonth(year, month)).padStart(2, "0")}`;
+			dayStatuses = getChallengeDayStatuses(user.id, start, end);
+		}
+	}
+
+	const isPro = user?.level === USER_LEVELS.PRO;
+	const dim = daysInMonth(year, month);
+	const startWeekday = weekdayOfMonthStart(year, month);
+
+	/** @type {Array<{ day: number; dateStr: string; id: string; isToday: boolean; isFuture: boolean; isPast: boolean; status: string | null; locked: boolean }>} */
+	const days = [];
+	for (let day = 1; day <= dim; day++) {
+		const dateStr = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+		const isToday = dateStr === today;
+		const isFuture = dateStr > today;
+		const isPast = dateStr < today;
+		days.push({
+			day,
+			dateStr,
+			id: dailyChallengeId(dateStr),
+			isToday,
+			isFuture,
+			isPast,
+			status: dayStatuses[dateStr] ?? null,
+			locked: isPast && !isPro,
+		});
+	}
+
+	const monthLabel = new Intl.DateTimeFormat("en-US", {
+		timeZone: CHALLENGE_TIMEZONE,
+		month: "long",
+		year: "numeric",
+	}).format(new Date(`${year}-${String(month).padStart(2, "0")}-15T18:00:00.000Z`));
+
+	const prevMonth = month === 1 ? { year: year - 1, month: 12 } : { year, month: month - 1 };
+	const nextMonth = month === 12 ? { year: year + 1, month: 1 } : { year, month: month + 1 };
+	const nextMonthStr = `${nextMonth.year}-${String(nextMonth.month).padStart(2, "0")}`;
+	const canGoNext =
+		nextMonthStr <= `${todayParsed?.year}-${String(todayParsed?.month).padStart(2, "0")}`;
+
 	return {
 		user,
-		isPro: user?.level === USER_LEVELS.PRO,
-		challenges: CHALLENGES,
-		stats,
+		isPro,
+		today,
+		timezone: CHALLENGE_TIMEZONE,
+		todayChallenge: {
+			...todayChallenge,
+			objective: formatChallengeObjective(todayChallenge),
+			dateStr: today,
+		},
+		calendar: {
+			year,
+			month,
+			monthLabel,
+			startWeekday,
+			days,
+			prevHref: `/challenges?month=${prevMonth.year}-${String(prevMonth.month).padStart(2, "0")}`,
+			nextHref: canGoNext ? `/challenges?month=${nextMonthStr}` : null,
+		},
 	};
 }

--- a/src/routes/challenges/+page.svelte
+++ b/src/routes/challenges/+page.svelte
@@ -1,22 +1,21 @@
 <script>
 	import { page } from "$app/state";
 	import Btn from "$lib/components/Btn.svelte";
-	import {
-		CHALLENGE_RUN_STATUS,
-		CHALLENGE_TYPES,
-		formatChallengeObjective,
-	} from "$lib/challenges.js";
-	import { CrownIcon, TimerIcon, EraserIcon, LifeBuoyIcon } from "@lucide/svelte";
+	import { CHALLENGE_RUN_STATUS, CHALLENGE_TYPES } from "$lib/challenges.js";
+	import { CrownIcon, ChevronLeftIcon, ChevronRightIcon } from "@lucide/svelte";
 
 	let { data } = $props();
 
+	const weekdays = ["S", "M", "T", "W", "T", "F", "S"];
+
 	/**
-	 * @param {string} type
+	 * @param {string | null} status
 	 */
-	function typeIcon(type) {
-		if (type === CHALLENGE_TYPES.TIME) return TimerIcon;
-		if (type === CHALLENGE_TYPES.CLEAR) return EraserIcon;
-		return LifeBuoyIcon;
+	function statusClass(status) {
+		if (status === CHALLENGE_RUN_STATUS.WON) return "won";
+		if (status === CHALLENGE_RUN_STATUS.LOST) return "lost";
+		if (status === CHALLENGE_RUN_STATUS.IN_PROGRESS) return "progress";
+		return "";
 	}
 
 	/**
@@ -27,41 +26,51 @@
 		if (type === CHALLENGE_TYPES.CLEAR) return "Clear";
 		return "Recovery";
 	}
-
-	/**
-	 * @param {string} challengeId
-	 */
-	function statusLabel(challengeId) {
-		const entry = data.stats?.[challengeId];
-		if (!entry || !entry.bestStatus) return null;
-		if (entry.bestStatus === CHALLENGE_RUN_STATUS.WON) {
-			return entry.wins > 1 ? `Cleared ×${entry.wins}` : "Cleared";
-		}
-		return `${entry.attempts} attempt${entry.attempts === 1 ? "" : "s"}`;
-	}
 </script>
 
 <svelte:head>
-	<title>Challenges - 4096</title>
+	<title>Daily Challenges - 4096</title>
 	<meta
 		name="description"
-		content="Pro challenge modes: race the clock, clear the board, or recover from a tough start."
+		content="A new daily challenge every midnight Central Time. Pro unlocks the calendar archive."
 	/>
 </svelte:head>
 
-<main class="mx-auto mt-8 mb-[5rem] w-full max-w-lg p-6" style:color={page.data.theme?.text}>
-	<h1 class="text-3xl font-bold text-[var(--color-primary)]">Challenges</h1>
-	<p class="mb-6 text-sm text-gray-500">
-		Fixed starting setups with clear win/lose goals. A Pro feature.
+<main
+	class="mx-auto h-full w-full max-w-lg overflow-y-auto px-4 pt-8 pb-28"
+	style:color={page.data.theme?.text}
+>
+	<h1 class="text-3xl font-bold text-[var(--color-primary)]">Daily Challenges</h1>
+	<p class="mb-5 text-sm text-gray-500">
+		A fresh challenge every midnight Central Time ({data.timezone.replace("_", " ")}).
 	</p>
+
+	{#if data.todayChallenge}
+		<section
+			class="mb-6 rounded-xl p-4"
+			style:background-color={page.data.theme?.boardBackground}
+			style:color={page.data.theme?.textDark}
+		>
+			<p class="mb-1 text-xs font-bold tracking-wide uppercase opacity-70">Today · {data.today}</p>
+			<h2 class="text-xl font-bold">{data.todayChallenge.title}</h2>
+			<p class="mb-1 text-sm opacity-80">
+				{typeLabel(data.todayChallenge.type)} · {data.todayChallenge.difficulty}
+			</p>
+			<p class="mb-3 text-sm opacity-90">{data.todayChallenge.objective}</p>
+			<Btn href="/challenges/{data.todayChallenge.id}" class="w-full justify-center">
+				{data.isPro ? "Play today's challenge" : "View today's challenge"}
+			</Btn>
+		</section>
+	{/if}
 
 	{#if !data.isPro}
 		<div
-			class="mb-6 rounded-lg p-4 text-center"
+			class="mb-5 rounded-lg p-4 text-center"
 			style:background-color={page.data.theme?.boardBackground}
 		>
 			<p class="mb-3 text-sm" style:color={page.data.theme?.textDark}>
-				Browse the roster below. Starting a challenge requires Pro.
+				Browse today's challenge below. Starting any challenge — and opening past days — requires
+				Pro.
 			</p>
 			<Btn href="/stripe" class="justify-center gap-2">
 				<CrownIcon size={20} />
@@ -70,33 +79,123 @@
 		</div>
 	{/if}
 
-	<ul class="flex flex-col gap-3">
-		{#each data.challenges as challenge (challenge.id)}
-			{@const Icon = typeIcon(challenge.type)}
-			<li>
+	<section class="calendar">
+		<div class="mb-3 flex items-center justify-between">
+			<a
+				href={data.calendar.prevHref}
+				class="inline-flex rounded-md p-2 hover:opacity-80"
+				style:background-color={page.data.theme?.boardBackground}
+				aria-label="Previous month"
+			>
+				<ChevronLeftIcon size={20} />
+			</a>
+			<h2 class="text-lg font-bold">{data.calendar.monthLabel}</h2>
+			{#if data.calendar.nextHref}
 				<a
-					href="/challenges/{challenge.id}"
-					class="block rounded-lg p-4 transition-opacity hover:opacity-90"
+					href={data.calendar.nextHref}
+					class="inline-flex rounded-md p-2 hover:opacity-80"
 					style:background-color={page.data.theme?.boardBackground}
-					style:color={page.data.theme?.textDark}
+					aria-label="Next month"
 				>
-					<div class="mb-1 flex items-center gap-2">
-						<Icon size={18} />
-						<span class="text-xs font-bold tracking-wide uppercase opacity-70">
-							{typeLabel(challenge.type)} · {challenge.difficulty}
-						</span>
-					</div>
-					<div class="flex items-start justify-between gap-2">
-						<div>
-							<h2 class="text-lg font-bold">{challenge.title}</h2>
-							<p class="text-sm opacity-80">{formatChallengeObjective(challenge)}</p>
-						</div>
-						{#if statusLabel(challenge.id)}
-							<span class="shrink-0 text-xs font-semibold">{statusLabel(challenge.id)}</span>
-						{/if}
-					</div>
+					<ChevronRightIcon size={20} />
 				</a>
-			</li>
-		{/each}
-	</ul>
+			{:else}
+				<span class="inline-flex rounded-md p-2 opacity-30" aria-hidden="true">
+					<ChevronRightIcon size={20} />
+				</span>
+			{/if}
+		</div>
+
+		<div
+			class="weekday-row mb-1 grid grid-cols-7 gap-1 text-center text-xs font-bold text-gray-500"
+		>
+			{#each weekdays as label, i (i)}
+				<span>{label}</span>
+			{/each}
+		</div>
+
+		<div
+			class="grid grid-cols-7 gap-1"
+			style:grid-template-rows={`repeat(${Math.ceil((data.calendar.startWeekday + data.calendar.days.length) / 7)}, minmax(0, 1fr))`}
+		>
+			{#each Array.from({ length: data.calendar.startWeekday }, (_, i) => i) as blankIndex (blankIndex)}
+				<span class="aspect-square"></span>
+			{/each}
+
+			{#each data.calendar.days as day (day.dateStr)}
+				{#if day.isFuture}
+					<span
+						class="day future flex aspect-square flex-col items-center justify-center rounded-lg text-sm text-gray-400"
+					>
+						{day.day}
+					</span>
+				{:else if day.locked}
+					<a
+						href="/stripe"
+						class="day locked flex aspect-square flex-col items-center justify-center rounded-lg text-sm"
+						style:background-color={page.data.theme?.boardBackground}
+						style:color={page.data.theme?.textDark}
+						title="Pro unlocks past challenges"
+					>
+						<span class="font-semibold">{day.day}</span>
+						<CrownIcon size={12} class="opacity-70" />
+					</a>
+				{:else}
+					<a
+						href="/challenges/{day.id}"
+						class="day {statusClass(
+							day.status
+						)} flex aspect-square flex-col items-center justify-center rounded-lg text-sm font-semibold transition-opacity hover:opacity-90"
+						class:today={day.isToday}
+						style:background-color={day.isToday
+							? page.data.theme?.primary
+							: page.data.theme?.boardBackground}
+						style:color={day.isToday ? page.data.theme?.textDark : page.data.theme?.textDark}
+					>
+						<span>{day.day}</span>
+						{#if day.status === CHALLENGE_RUN_STATUS.WON}
+							<span class="dot won-dot"></span>
+						{:else if day.status === CHALLENGE_RUN_STATUS.LOST}
+							<span class="dot lost-dot"></span>
+						{/if}
+					</a>
+				{/if}
+			{/each}
+		</div>
+
+		<div class="mt-4 flex flex-wrap gap-3 text-xs text-gray-500">
+			<span class="inline-flex items-center gap-1">
+				<span class="dot won-dot inline-block"></span> Cleared
+			</span>
+			<span class="inline-flex items-center gap-1">
+				<span class="dot lost-dot inline-block"></span> Attempted
+			</span>
+			{#if !data.isPro}
+				<span class="inline-flex items-center gap-1">
+					<CrownIcon size={12} /> Past days (Pro)
+				</span>
+			{/if}
+		</div>
+	</section>
 </main>
+
+<style>
+	.dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 999px;
+		margin-top: 2px;
+	}
+
+	.won-dot {
+		background: #16a34a;
+	}
+
+	.lost-dot {
+		background: #dc2626;
+	}
+
+	.day.today {
+		box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 40%, transparent);
+	}
+</style>

--- a/src/routes/challenges/[id]/+page.server.js
+++ b/src/routes/challenges/[id]/+page.server.js
@@ -1,7 +1,15 @@
 import { fail, redirect } from "@sveltejs/kit";
 import { USER_LEVELS } from "$lib/constants.js";
-import { getChallengeById, formatChallengeObjective } from "$lib/challenges.js";
-import { getChallengeStatsForUser, startChallengeRun } from "$lib/server/challenge.js";
+import {
+	dateFromChallengeId,
+	formatChallengeObjective,
+	getChallengeDateString,
+} from "$lib/challenges.js";
+import {
+	getChallengeById,
+	getChallengeStatsForUser,
+	startChallengeRun,
+} from "$lib/server/challenge.js";
 import { getUserProfile, requireLogin } from "$lib/server/user.js";
 
 /** @type {import("./$types").PageServerLoad} */
@@ -11,20 +19,51 @@ export async function load({ locals, params }) {
 		redirect(302, "/challenges");
 	}
 
+	const dateStr = dateFromChallengeId(challenge.id);
+	const today = getChallengeDateString();
+	const isToday = dateStr === today;
+	const isPast = dateStr != null && dateStr < today;
+
 	let user = null;
 	let stats = null;
 	if (locals.user) {
 		user = getUserProfile(locals.user.id);
 		if (user?.level === USER_LEVELS.PRO) {
-			stats = getChallengeStatsForUser(user.id)?.[challenge.id] ?? null;
+			stats = getChallengeStatsForUser(user.id, [challenge.id])?.[challenge.id] ?? null;
 		}
+	}
+
+	const isPro = user?.level === USER_LEVELS.PRO;
+
+	// Past days are a Pro archive — free users get the same lock pattern as history.
+	if (isPast && !isPro) {
+		return {
+			user,
+			isPro: false,
+			locked: true,
+			isToday: false,
+			challenge: {
+				id: challenge.id,
+				title: challenge.title,
+				type: challenge.type,
+				difficulty: challenge.difficulty,
+				description: "Upgrade to Pro to play past daily challenges.",
+				params: {},
+			},
+			objective: "Pro archive",
+			dateStr,
+			stats: null,
+		};
 	}
 
 	return {
 		user,
-		isPro: user?.level === USER_LEVELS.PRO,
+		isPro,
+		locked: false,
+		isToday,
 		challenge,
 		objective: formatChallengeObjective(challenge),
+		dateStr,
 		stats,
 	};
 }
@@ -41,6 +80,12 @@ export const actions = {
 		const challenge = getChallengeById(params.id);
 		if (!challenge) {
 			return fail(404, { error: "Challenge not found" });
+		}
+
+		const dateStr = dateFromChallengeId(challenge.id);
+		const today = getChallengeDateString();
+		if (dateStr && dateStr > today) {
+			return fail(400, { error: "Challenge not available yet" });
 		}
 
 		const run = await startChallengeRun(user.id, challenge.id);

--- a/src/routes/challenges/[id]/+page.svelte
+++ b/src/routes/challenges/[id]/+page.svelte
@@ -9,6 +9,7 @@
 		resolveClearTarget,
 	} from "$lib/challenges.js";
 	import { CrownIcon, ArrowLeftIcon } from "@lucide/svelte";
+	import { getTileBackground, getTileColor } from "$lib/game.svelte.js";
 
 	let { data } = $props();
 
@@ -17,14 +18,11 @@
 	const challenge = $derived(data.challenge);
 
 	const previewBoard = $derived(
-		"board" in challenge.params && Array.isArray(challenge.params.board)
+		!data.locked && "board" in challenge.params && Array.isArray(challenge.params.board)
 			? challenge.params.board
 			: null
 	);
 
-	/**
-	 * @param {any} event
-	 */
 	function onStart() {
 		starting = true;
 		return async ({ update }) => {
@@ -32,99 +30,58 @@
 			starting = false;
 		};
 	}
+
+	/**
+	 * @param {string | null | undefined} dateStr
+	 */
+	function formatDate(dateStr) {
+		if (!dateStr) return "";
+		const [y, m, d] = dateStr.split("-").map(Number);
+		return new Date(Date.UTC(y, m - 1, d, 18)).toLocaleDateString(undefined, {
+			weekday: "long",
+			month: "long",
+			day: "numeric",
+			year: "numeric",
+			timeZone: "UTC",
+		});
+	}
 </script>
 
 <svelte:head>
 	<title>{challenge.title} - Challenges - 4096</title>
 </svelte:head>
 
-<main class="mx-auto mt-8 mb-[5rem] w-full max-w-lg p-6" style:color={page.data.theme?.text}>
+<main
+	class="mx-auto h-full w-full max-w-lg overflow-y-auto px-4 pt-8 pb-28"
+	style:color={page.data.theme?.text}
+>
 	<a
 		href="/challenges"
 		class="mb-4 inline-flex items-center gap-1 text-sm text-[var(--color-primary)] hover:underline"
 	>
 		<ArrowLeftIcon size={16} />
-		All challenges
+		Calendar
 	</a>
 
+	<p class="mb-1 text-xs font-bold tracking-wide text-gray-500 uppercase">
+		{#if data.isToday}
+			Today's challenge
+		{:else}
+			Daily challenge
+		{/if}
+		{#if data.dateStr}
+			· {formatDate(data.dateStr)}
+		{/if}
+	</p>
 	<h1 class="text-3xl font-bold text-[var(--color-primary)]">{challenge.title}</h1>
-	<p class="mb-1 text-sm text-gray-500">{challenge.difficulty} · {data.objective}</p>
-	<p class="mb-6">{challenge.description}</p>
 
-	{#if challenge.type === CHALLENGE_TYPES.TIME}
-		<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
-			<li>Target score: {challenge.params.targetScore.toLocaleString()}</li>
-			<li>Time limit: {challenge.params.durationSec}s</li>
-			<li>Fail if the timer runs out or you game over first</li>
-		</ul>
-	{:else if challenge.type === CHALLENGE_TYPES.CLEAR}
-		<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
-			<li>Starting tiles: {countFilledCells(challenge.params.board)}</li>
-			<li>Clear to ≤ {resolveClearTarget(challenge.params)} occupied cells</li>
-			<li>Fail on game over before reaching the target</li>
-		</ul>
-	{:else}
-		<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
-			<li>Goal tile: {challenge.params.winTile ?? 4096}</li>
-			<li>Start from the preset board below</li>
-			<li>Fail on game over</li>
-		</ul>
-	{/if}
-
-	{#if previewBoard}
-		<div class="mb-6">
-			<p class="mb-2 text-xs font-bold tracking-wide text-gray-500 uppercase">Starting board</p>
-			<div
-				class="grid aspect-square grid-cols-4 gap-2 rounded-lg p-2"
-				style:background-color={page.data.theme?.boardBackground}
-			>
-				{#each previewBoard as row, ri (ri)}
-					{#each row as cell, ci (ci)}
-						<div
-							class="flex items-center justify-center rounded text-sm font-bold"
-							style:background-color={cell
-								? (page.data.theme?.tiles?.[cell] ?? page.data.theme?.unknownTile)
-								: page.data.theme?.emptyTile}
-							style:color={page.data.theme?.textDark}
-						>
-							{cell || ""}
-						</div>
-					{/each}
-				{/each}
-			</div>
-		</div>
-	{/if}
-
-	{#if data.stats}
-		<p class="mb-4 text-sm text-gray-500">
-			{#if data.stats.bestStatus === CHALLENGE_RUN_STATUS.WON}
-				You've cleared this challenge {data.stats.wins} time{data.stats.wins === 1 ? "" : "s"}
-				({data.stats.attempts} attempt{data.stats.attempts === 1 ? "" : "s"}).
-			{:else if data.stats.attempts > 0}
-				{data.stats.attempts} attempt{data.stats.attempts === 1 ? "" : "s"} so far — keep going!
-			{:else}
-				No attempts yet.
-			{/if}
-		</p>
-	{/if}
-
-	{#if data.isPro}
-		<form method="POST" action="?/start" use:enhance={onStart}>
-			<Btn type="submit" class="w-full justify-center" disabled={starting}>
-				{starting ? "Starting…" : "Start Challenge"}
-			</Btn>
-		</form>
-	{:else}
+	{#if data.locked}
 		<div
-			class="rounded-lg p-4 text-center"
+			class="mt-6 rounded-lg p-4 text-center"
 			style:background-color={page.data.theme?.boardBackground}
 		>
 			<p class="mb-3 text-sm" style:color={page.data.theme?.textDark}>
-				{#if data.user}
-					Upgrade to Pro to play this challenge.
-				{:else}
-					Log in and upgrade to Pro to play this challenge.
-				{/if}
+				Past daily challenges are a Pro feature — same archive pattern as game history.
 			</p>
 			{#if data.user}
 				<Btn href="/stripe" class="justify-center gap-2">
@@ -135,5 +92,96 @@
 				<Btn href="/login?redirectTo=/challenges/{challenge.id}" class="justify-center">Log in</Btn>
 			{/if}
 		</div>
+	{:else}
+		<p class="mb-1 text-sm text-gray-500">{challenge.difficulty} · {data.objective}</p>
+		<p class="mb-6">{challenge.description}</p>
+
+		{#if challenge.type === CHALLENGE_TYPES.TIME}
+			<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
+				<li>Target score: {challenge.params.targetScore.toLocaleString()}</li>
+				<li>Time limit: {challenge.params.durationSec}s</li>
+				<li>Fail if the timer runs out or you game over first</li>
+			</ul>
+		{:else if challenge.type === CHALLENGE_TYPES.CLEAR}
+			<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
+				<li>Starting tiles: {countFilledCells(challenge.params.board)}</li>
+				<li>Clear to ≤ {resolveClearTarget(challenge.params)} occupied cells</li>
+				<li>Fail on game over before reaching the target</li>
+			</ul>
+		{:else}
+			<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
+				<li>Goal tile: {challenge.params.winTile ?? 4096}</li>
+				<li>Start from the preset board below</li>
+				<li>Fail on game over</li>
+			</ul>
+		{/if}
+
+		{#if previewBoard}
+			<div class="mb-6">
+				<p class="mb-2 text-xs font-bold tracking-wide text-gray-500 uppercase">Starting board</p>
+				<div
+					class="grid aspect-square grid-cols-4 gap-2.5 rounded-lg p-2.5"
+					style:background-color={page.data.theme?.boardBackground}
+				>
+					{#each previewBoard as row, ri (ri)}
+						{#each row as cell, ci (ci)}
+							<div
+								class="flex items-center justify-center rounded-md text-sm font-extrabold"
+								style:background-color={cell
+									? getTileBackground(cell, page.data.theme)
+									: page.data.theme?.emptyTile}
+								style:color={cell ? getTileColor(cell, page.data.theme) : "transparent"}
+							>
+								{cell || ""}
+							</div>
+						{/each}
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		{#if data.stats}
+			<p class="mb-4 text-sm text-gray-500">
+				{#if data.stats.bestStatus === CHALLENGE_RUN_STATUS.WON}
+					You've cleared this challenge {data.stats.wins} time{data.stats.wins === 1 ? "" : "s"}
+					({data.stats.attempts} attempt{data.stats.attempts === 1 ? "" : "s"}).
+				{:else if data.stats.attempts > 0}
+					{data.stats.attempts} attempt{data.stats.attempts === 1 ? "" : "s"} so far — keep going!
+				{:else}
+					No attempts yet.
+				{/if}
+			</p>
+		{/if}
+
+		{#if data.isPro}
+			<form method="POST" action="?/start" use:enhance={onStart}>
+				<Btn type="submit" class="w-full justify-center" disabled={starting}>
+					{starting ? "Starting…" : "Start Challenge"}
+				</Btn>
+			</form>
+		{:else}
+			<div
+				class="rounded-lg p-4 text-center"
+				style:background-color={page.data.theme?.boardBackground}
+			>
+				<p class="mb-3 text-sm" style:color={page.data.theme?.textDark}>
+					{#if data.user}
+						Upgrade to Pro to play daily challenges.
+					{:else}
+						Log in and upgrade to Pro to play daily challenges.
+					{/if}
+				</p>
+				{#if data.user}
+					<Btn href="/stripe" class="justify-center gap-2">
+						<CrownIcon size={20} />
+						Upgrade to Pro
+					</Btn>
+				{:else}
+					<Btn href="/login?redirectTo=/challenges/{challenge.id}" class="justify-center"
+						>Log in</Btn
+					>
+				{/if}
+			</div>
+		{/if}
 	{/if}
 </main>

--- a/src/routes/challenges/[id]/play/+layout.svelte
+++ b/src/routes/challenges/[id]/play/+layout.svelte
@@ -1,0 +1,9 @@
+<script>
+	import "$lib/assets/playSurface.css";
+
+	let { children } = $props();
+</script>
+
+<div class="play-surface h-full">
+	{@render children?.()}
+</div>

--- a/src/routes/challenges/[id]/play/+page.server.js
+++ b/src/routes/challenges/[id]/play/+page.server.js
@@ -1,11 +1,7 @@
 import { error, fail, redirect } from "@sveltejs/kit";
 import { USER_LEVELS } from "$lib/constants.js";
-import {
-	CHALLENGE_RUN_STATUS,
-	formatChallengeObjective,
-	getChallengeById,
-} from "$lib/challenges.js";
-import { completeChallengeRun, getChallengeRun } from "$lib/server/challenge.js";
+import { CHALLENGE_RUN_STATUS, formatChallengeObjective } from "$lib/challenges.js";
+import { completeChallengeRun, getChallengeById, getChallengeRun } from "$lib/server/challenge.js";
 import { requireLogin } from "$lib/server/user.js";
 
 /** @type {import("./$types").PageServerLoad} */

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -3,8 +3,9 @@
 	import { enhance } from "$app/forms";
 	import { onMount } from "svelte";
 	import { page } from "$app/state";
-	import { Game, getTileBackground, getTileColor } from "$lib/game.svelte.js";
+	import { Game } from "$lib/game.svelte.js";
 	import { DIRECTIONS } from "$lib/constants.js";
+	import { createSwipeHandlers } from "$lib/swipe.js";
 	import {
 		CHALLENGE_RUN_STATUS,
 		CHALLENGE_TYPES,
@@ -13,16 +14,18 @@
 		resolveClearTarget,
 	} from "$lib/challenges.js";
 	import Btn from "$lib/components/Btn.svelte";
+	import AnimatedBoard from "../../../game/components/AnimatedBoard.svelte";
 
 	let { data } = $props();
-
-	const TOUCH_THRESHOLD = 5;
 
 	/** @type {Game | null} */
 	let game = $state(null);
 	let result = $state(/** @type {'won' | 'lost' | null} */ (null));
 	let remainingMs = $state(0);
 	let submitting = $state(false);
+
+	/** @type {import("$lib/types").GameEvent[]} */
+	let pendingEvents = $state([]);
 
 	/** @type {HTMLFormElement | null} */
 	let completeForm = $state(null);
@@ -68,6 +71,7 @@
 
 	function initGame() {
 		if (!browser) return;
+		pendingEvents = [];
 		game = createChallengeGame();
 		result = null;
 
@@ -116,12 +120,20 @@
 	}
 
 	/**
+	 * @returns {import("$lib/types").GameEvent | undefined}
+	 */
+	function popEvent() {
+		return pendingEvents.shift();
+	}
+
+	/**
 	 * @param {number} direction
 	 */
 	function handleMove(direction) {
 		if (!game || result) return;
 		const events = game.moveTiles(direction);
 		if (events.length > 0) {
+			pendingEvents.push(...events);
 			checkOutcome();
 		}
 	}
@@ -150,39 +162,7 @@
 		}
 	}
 
-	let touchStartX = 0;
-	let touchStartY = 0;
-
-	/** @param {TouchEvent} event */
-	function handleTouchStart(event) {
-		touchStartX = event.touches[0].clientX;
-		touchStartY = event.touches[0].clientY;
-	}
-
-	/** @param {TouchEvent} event */
-	function handleTouchEnd(event) {
-		if (!touchStartX || !touchStartY) return;
-		const touchEndX = event.changedTouches[0].clientX;
-		const touchEndY = event.changedTouches[0].clientY;
-		const diffX = touchStartX - touchEndX;
-		const diffY = touchStartY - touchEndY;
-		if (Math.abs(diffX) < TOUCH_THRESHOLD && Math.abs(diffY) < TOUCH_THRESHOLD) return;
-		event.preventDefault();
-		if (Math.abs(diffX) > Math.abs(diffY)) {
-			if (diffX > 0) handleMove(DIRECTIONS.LEFT);
-			else handleMove(DIRECTIONS.RIGHT);
-		} else {
-			if (diffY > 0) handleMove(DIRECTIONS.UP);
-			else handleMove(DIRECTIONS.DOWN);
-		}
-		touchStartX = 0;
-		touchStartY = 0;
-	}
-
-	/** @param {TouchEvent} event */
-	function handleTouchMove(event) {
-		event.preventDefault();
-	}
+	const { handleTouchStart, handleTouchEnd, handleTouchMove } = createSwipeHandlers(handleMove);
 
 	onMount(() => {
 		if (data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) {
@@ -255,7 +235,7 @@
 >
 	<div class="mb-3 flex items-start gap-2">
 		<div class="flex-1">
-			<p class="text-xs font-bold tracking-wide text-gray-500 uppercase">Challenge</p>
+			<p class="text-xs font-bold tracking-wide text-gray-500 uppercase">Daily Challenge</p>
 			<h1 class="text-2xl font-bold text-[var(--color-primary)]">{challenge.title}</h1>
 			<p class="text-sm text-gray-500">{data.objective}</p>
 		</div>
@@ -291,24 +271,7 @@
 	</div>
 
 	{#if game}
-		<div
-			class="mb-4 grid aspect-square grid-cols-4 gap-2.5 rounded-lg p-2.5"
-			style:background-color={page.data.theme?.boardBackground}
-		>
-			{#each game.board as row, ri (ri)}
-				{#each row as cell, ci (`${ri}-${ci}`)}
-					<div
-						class="flex items-center justify-center rounded-md text-xl font-extrabold sm:text-2xl"
-						style:background-color={cell
-							? getTileBackground(cell, page.data.theme)
-							: page.data.theme?.emptyTile}
-						style:color={cell ? getTileColor(cell, page.data.theme) : "transparent"}
-					>
-						{cell || ""}
-					</div>
-				{/each}
-			{/each}
-		</div>
+		<AnimatedBoard {game} {pendingEvents} {popEvent} showControls={false} />
 	{:else}
 		<div
 			class="mb-4 flex aspect-square items-center justify-center rounded-lg"
@@ -347,7 +310,7 @@
 				<form method="POST" action="/challenges/{challenge.id}?/start" use:enhance>
 					<Btn type="submit" class="justify-center">Retry</Btn>
 				</form>
-				<Btn href="/challenges" class="justify-center">All Challenges</Btn>
+				<Btn href="/challenges" class="justify-center">Calendar</Btn>
 			</div>
 		</div>
 	</div>
@@ -356,7 +319,7 @@
 <style lang="postcss">
 	.challenge-play {
 		max-width: 500px;
-		min-height: 100vh;
+		min-height: 100%;
 		margin: 0 auto;
 		padding: 20px;
 		padding-bottom: 5rem;

--- a/src/routes/game/+layout.svelte
+++ b/src/routes/game/+layout.svelte
@@ -1,4 +1,5 @@
 <script>
+	import "$lib/assets/playSurface.css";
 	import { saveBestScore } from "$lib/localStorage.svelte";
 	import { gameState } from "./state.svelte";
 
@@ -10,29 +11,6 @@
 	});
 </script>
 
-<div class="game-container">
+<div class="play-surface h-full">
 	{@render children?.()}
 </div>
-
-<style>
-	.game-container {
-		/* Prevent Chrome's pull-to-refresh and other touch gestures */
-		touch-action: none;
-		user-select: none;
-		overscroll-behavior: contain;
-		/* Additional gesture prevention */
-		-webkit-touch-callout: none;
-		-webkit-user-select: none;
-		-webkit-overflow-scrolling: touch;
-		-webkit-overscroll-behavior: contain;
-		-webkit-tap-highlight-color: transparent;
-		-webkit-touch-callout: none;
-		-webkit-user-drag: none;
-		-khtml-user-select: none;
-		-moz-user-select: none;
-		-ms-user-select: none;
-		-khtml-user-drag: none;
-		-moz-user-drag: none;
-		-o-user-drag: none;
-	}
-</style>

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -10,10 +10,9 @@
 	import { browser } from "$app/environment";
 	import { gameState } from "./state.svelte";
 	import Overlay from "$lib/components/Overlay.svelte";
+	import { createSwipeHandlers } from "$lib/swipe.js";
 
 	const { data } = $props();
-
-	const TOUCH_THRESHOLD = 5;
 	/** Max staleness for server saves while actively playing */
 	const SAVE_THROTTLE_MS = 1000;
 	let conflict = $state(false);
@@ -347,58 +346,7 @@
 		}
 	}
 
-	// Handle touch/swipe events for mobile
-	let touchStartX = 0;
-	let touchStartY = 0;
-
-	/**
-	 * Handle touch/swipe events for mobile
-	 * @param {TouchEvent} event
-	 */
-	function handleTouchStart(event) {
-		touchStartX = event.touches[0].clientX;
-		touchStartY = event.touches[0].clientY;
-	}
-
-	/**
-	 * Handle touch/swipe events for mobile
-	 * @param {TouchEvent} event
-	 */
-	function handleTouchEnd(event) {
-		if (!touchStartX || !touchStartY) return;
-
-		const touchEndX = event.changedTouches[0].clientX;
-		const touchEndY = event.changedTouches[0].clientY;
-
-		const diffX = touchStartX - touchEndX;
-		const diffY = touchStartY - touchEndY;
-
-		if (Math.abs(diffX) < TOUCH_THRESHOLD && Math.abs(diffY) < TOUCH_THRESHOLD) return;
-
-		// Prevent default behavior
-		event.preventDefault();
-		event.stopPropagation();
-
-		if (Math.abs(diffX) > Math.abs(diffY)) {
-			if (diffX > 0) handleMove(DIRECTIONS.LEFT);
-			else handleMove(DIRECTIONS.RIGHT);
-		} else {
-			if (diffY > 0) handleMove(DIRECTIONS.UP);
-			else handleMove(DIRECTIONS.DOWN);
-		}
-
-		touchStartX = 0;
-		touchStartY = 0;
-	}
-
-	/**
-	 * Handle touch move events to prevent scrolling during swipe
-	 * @param {TouchEvent} event
-	 */
-	function handleTouchMove(event) {
-		event.preventDefault();
-		event.stopPropagation();
-	}
+	const { handleTouchStart, handleTouchEnd, handleTouchMove } = createSwipeHandlers(handleMove);
 
 	// Setup listeners on mount
 	onMount(() => {

--- a/src/routes/game/components/AnimatedBoard.svelte
+++ b/src/routes/game/components/AnimatedBoard.svelte
@@ -7,10 +7,12 @@
 
 	import GameControls from "./GameControls.svelte";
 	import { gameState } from "../state.svelte.js";
-
-	const GAP = 10;
-	const PADDING = 10;
-	const TILE_BORDER_RADIUS = 6;
+	import {
+		BOARD_GAP as GAP,
+		BOARD_PADDING as PADDING,
+		TILE_BORDER_RADIUS,
+		BOARD_BORDER_RADIUS,
+	} from "$lib/boardConstants.js";
 
 	/**
 	 * @type {{
@@ -222,7 +224,11 @@
 	/>
 {/if}
 
-<div class="board-container" bind:this={boardContainer}>
+<div
+	class="board-container"
+	bind:this={boardContainer}
+	style:--board-radius={`${BOARD_BORDER_RADIUS}px`}
+>
 	<div
 		class="game-board"
 		style:background={theme.boardBackground}
@@ -255,7 +261,7 @@
 	.game-board {
 		display: grid;
 		aspect-ratio: 1;
-		border-radius: 8px;
+		border-radius: var(--board-radius, 8px);
 		position: relative;
 		z-index: 1;
 	}

--- a/src/routes/replay/+page.svelte
+++ b/src/routes/replay/+page.svelte
@@ -37,7 +37,10 @@
 	<meta name="description" content="Browse and replay your completed 4096 games." />
 </svelte:head>
 
-<main class="mx-auto mt-10 mb-[5rem] w-full max-w-lg p-8" style:color={page.data.theme?.primary}>
+<main
+	class="mx-auto h-full w-full max-w-lg overflow-y-auto px-6 pt-10 pb-28"
+	style:color={page.data.theme?.primary}
+>
 	<h1 class="text-3xl font-bold">Game History</h1>
 	<p class="mb-4 text-sm text-gray-500">
 		Completed games only — replay wins and losses move by move.

--- a/src/routes/replay/[id]/+page.svelte
+++ b/src/routes/replay/[id]/+page.svelte
@@ -116,7 +116,7 @@
 </svelte:head>
 
 <main
-	class="game-container mx-auto mt-6 mb-[8rem] w-full max-w-lg px-4"
+	class="mx-auto h-full w-full max-w-lg overflow-y-auto px-4 pt-6 pb-28"
 	style:color={page.data.theme?.primary}
 >
 	<div class="mb-3 flex items-center gap-2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Challenge play now uses the same `AnimatedBoard`, animations, and play-surface swipe/gesture CSS as the main game.
- Challenges are daily (midnight America/Chicago): persisted in `daily_challenge`, calendar UI on `/challenges`, Pro unlocks past days (same archive pattern as history).
- History and replay pages scroll again under the locked root layout (`overflow-y-auto`).
- Theme previews use shared board geometry (scaled gap/padding/radius/fonts) so they match the real board.

## Test plan
- [x] Mobile viewport: `/game` board vs `/challenges/.../play` share gap/padding 10 and animated tile layer
- [x] `/challenges` calendar shows today; past days locked (crown) for free, open for Pro
- [x] Daily id format `daily-YYYY-MM-DD` (Central Time); today generated on load
- [x] `/replay` scrolls with many games (`overflow-y: auto`, no `play-surface` leak)
- [x] `/themes` preview gap ratio matches live board (~10/350)

Verified with Playwright at 390×844.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f632d-d3f8-7af3-95d8-bf8cd0140be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f632d-d3f8-7af3-95d8-bf8cd0140be9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

