### PR TITLE
Board preview component + recovery moves & calendar day colors

### DIFF
--- a/src/lib/boardConstants.js
+++ b/src/lib/boardConstants.js
@@ -1,4 +1,4 @@
-/** Shared geometry for AnimatedBoard and ThemePreview */
+/** Shared geometry for AnimatedBoard and BoardPreview */
 export const BOARD_GAP = 10;
 export const BOARD_PADDING = 10;
 export const TILE_BORDER_RADIUS = 6;

--- a/src/lib/challenges.js
+++ b/src/lib/challenges.js
@@ -273,7 +273,7 @@ export function generateDailyChallengeDefinition(dateStr) {
 		id,
 		type: CHALLENGE_TYPES.RECOVERY,
 		title,
-		description: `Pull off a ${winTile} from this awkward high-tile scramble.`,
+		description: `Pull off a ${winTile} from this awkward high-tile scramble. Fewer moves is better.`,
 		difficulty,
 		params: {
 			seed,
@@ -376,7 +376,7 @@ export function formatChallengeObjective(challenge) {
 
 	if (type === CHALLENGE_TYPES.RECOVERY) {
 		const p = /** @type {RecoveryChallengeParams} */ (params);
-		return `Reach ${p.winTile ?? 4096}`;
+		return `Reach ${p.winTile ?? 4096} in as few moves as possible`;
 	}
 
 	return challenge.description;

--- a/src/lib/components/BoardPreview.svelte
+++ b/src/lib/components/BoardPreview.svelte
@@ -1,0 +1,148 @@
+<script>
+	import { onMount } from "svelte";
+	import {
+		BOARD_BORDER_RADIUS,
+		BOARD_GAP,
+		BOARD_PADDING,
+		TILE_BORDER_RADIUS,
+	} from "$lib/boardConstants.js";
+	import { getTileBackground, getTileColor } from "$lib/game.svelte.js";
+
+	/**
+	 * Static board preview using the same geometry ratios as AnimatedBoard.
+	 * @typedef {Object} PreviewTheme
+	 * @property {string} boardBackground
+	 * @property {string} emptyTile
+	 * @property {string} [primary]
+	 * @property {Record<number, string>} [tiles]
+	 * @property {string} [unknownTile]
+	 * @property {string} [textDark]
+	 * @property {string} [textLight]
+	 * @property {number} [luminanceThreshold]
+	 * @property {number} [textScale]
+	 */
+
+	/**
+	 * @type {{
+	 *   theme: PreviewTheme;
+	 *   board: (number | null | undefined)[][];
+	 *   selected?: boolean;
+	 * }}
+	 */
+	let { theme, board, selected = false } = $props();
+
+	/** Typical mobile in-game board width (~390 viewport minus page padding) */
+	const REF_BOARD_WIDTH = 350;
+
+	const size = $derived(Math.max(board?.length ?? 4, 1));
+
+	/** @type {HTMLDivElement | null} */
+	let boardEl = $state(null);
+	let cellSize = $state(0);
+	let gap = $state(BOARD_GAP);
+	let padding = $state(BOARD_PADDING);
+	let tileRadius = $state(TILE_BORDER_RADIUS);
+	let boardRadius = $state(BOARD_BORDER_RADIUS);
+
+	/**
+	 * Match AnimatedBoard mobile font scaling, scaled to preview cell size.
+	 * AnimatedBoard uses 2.5rem base on mobile (viewport ≤600); theme.textScale
+	 * is a desktop rem base, not a multiplier.
+	 * @param {number} value
+	 */
+	function tileFontSize(value) {
+		if (!cellSize) return "0.65rem";
+		const fullBaseRem = 2.5;
+		const fullCellRef = (REF_BOARD_WIDTH - BOARD_PADDING * 2 - BOARD_GAP * (size - 1)) / size;
+		const scale = cellSize / fullCellRef;
+		const baseRem = fullBaseRem * scale;
+		const digits = value.toString().length;
+		const fontRem = Math.max(baseRem - (digits - 1) * 0.3 * scale, 0.4);
+		return `${fontRem}rem`;
+	}
+
+	onMount(() => {
+		if (!boardEl) return;
+
+		const update = () => {
+			if (!boardEl) return;
+			const width = boardEl.clientWidth;
+			const scale = width / REF_BOARD_WIDTH;
+			gap = Math.max(2, BOARD_GAP * scale);
+			padding = Math.max(2, BOARD_PADDING * scale);
+			tileRadius = Math.max(2, TILE_BORDER_RADIUS * scale);
+			boardRadius = Math.max(3, BOARD_BORDER_RADIUS * scale);
+			cellSize = (width - padding * 2 - gap * (size - 1)) / size;
+		};
+
+		update();
+		const observer = new ResizeObserver(update);
+		observer.observe(boardEl);
+		return () => observer.disconnect();
+	});
+</script>
+
+<div
+	bind:this={boardEl}
+	class="preview-board"
+	class:selected
+	style:background={theme.boardBackground}
+	style:gap={`${gap}px`}
+	style:padding={`${padding}px`}
+	style:border-radius={`${boardRadius}px`}
+	style:grid-template-columns={`repeat(${size}, 1fr)`}
+	style:grid-template-rows={`repeat(${size}, 1fr)`}
+	aria-hidden="true"
+>
+	{#each board as row, ri (ri)}
+		{#each row as cell, ci (`${ri}-${ci}`)}
+			{#if cell}
+				<div
+					class="preview-tile"
+					style:background={getTileBackground(cell, theme)}
+					style:color={getTileColor(cell, theme)}
+					style:border-radius={`${tileRadius}px`}
+					style:font-size={tileFontSize(cell)}
+				>
+					{cell}
+				</div>
+			{:else}
+				<div
+					class="preview-tile empty"
+					style:background={theme.emptyTile}
+					style:border-radius={`${tileRadius}px`}
+				></div>
+			{/if}
+		{/each}
+	{/each}
+</div>
+
+<style>
+	.preview-board {
+		display: grid;
+		width: 100%;
+		aspect-ratio: 1;
+		box-sizing: border-box;
+	}
+
+	.preview-board.selected {
+		outline: 3px solid var(--color-primary, #e88f4f);
+		outline-offset: 2px;
+	}
+
+	.preview-tile {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-weight: 800;
+		min-height: 0;
+		min-width: 0;
+		padding: 0.1em;
+		text-align: center;
+		line-height: 1;
+	}
+
+	.preview-tile.empty {
+		color: transparent;
+	}
+</style>

--- a/src/lib/components/ThemePreview.svelte
+++ b/src/lib/components/ThemePreview.svelte
@@ -1,19 +1,14 @@
 <script>
-	import { onMount } from "svelte";
-	import {
-		BOARD_BORDER_RADIUS,
-		BOARD_GAP,
-		BOARD_PADDING,
-		TILE_BORDER_RADIUS,
-	} from "$lib/boardConstants.js";
+	import BoardPreview from "$lib/components/BoardPreview.svelte";
 
 	/**
-	 * Mini board preview using the same geometry ratios as AnimatedBoard.
+	 * Theme picker mini-board using the shared BoardPreview geometry.
 	 * @typedef {Object} PreviewTheme
 	 * @property {string} boardBackground
 	 * @property {string} emptyTile
 	 * @property {string} [primary]
 	 * @property {Record<number, string>} [tiles]
+	 * @property {string} [unknownTile]
 	 * @property {string} [textDark]
 	 * @property {string} [textLight]
 	 * @property {number} [luminanceThreshold]
@@ -23,153 +18,12 @@
 	/** @type {{ theme: PreviewTheme, selected?: boolean }} */
 	let { theme, selected = false } = $props();
 
-	/** Typical mobile in-game board width (~390 viewport minus page padding) */
-	const REF_BOARD_WIDTH = 350;
-
-	const previewValues = [
-		2,
-		4,
-		8,
-		16,
-		null,
-		32,
-		64,
-		128,
-		null,
-		256,
-		512,
-		1024,
-		null,
-		2048,
-		4096,
-		null,
+	const sampleBoard = [
+		[2, 4, 8, 16],
+		[0, 32, 64, 128],
+		[0, 256, 512, 1024],
+		[0, 2048, 4096, 0],
 	];
-
-	/** @type {HTMLDivElement | null} */
-	let boardEl = $state(null);
-	let cellSize = $state(0);
-	let gap = $state(BOARD_GAP);
-	let padding = $state(BOARD_PADDING);
-	let tileRadius = $state(TILE_BORDER_RADIUS);
-	let boardRadius = $state(BOARD_BORDER_RADIUS);
-
-	/**
-	 * @param {number} value
-	 * @param {PreviewTheme} t
-	 */
-	function tileBg(value, t) {
-		return t.tiles?.[value] ?? t.primary ?? "#888";
-	}
-
-	/**
-	 * Rough luminance for preview text color
-	 * @param {string} hex
-	 */
-	function isLight(hex) {
-		const h = hex.replace("#", "");
-		if (h.length < 6) return true;
-		const r = parseInt(h.slice(0, 2), 16);
-		const g = parseInt(h.slice(2, 4), 16);
-		const b = parseInt(h.slice(4, 6), 16);
-		const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-		return lum > (theme.luminanceThreshold ?? 0.6);
-	}
-
-	/**
-	 * Match AnimatedBoard font scaling relative to cell size.
-	 * @param {number} value
-	 */
-	function tileFontSize(value) {
-		if (!cellSize) return "0.65rem";
-		const fullBaseRem = 2.5;
-		const fullCellRef = (REF_BOARD_WIDTH - BOARD_PADDING * 2 - BOARD_GAP * 3) / 4;
-		const baseRem = fullBaseRem * (cellSize / fullCellRef);
-		const digits = value.toString().length;
-		const fontRem = Math.max(baseRem - (digits - 1) * 0.3 * (cellSize / fullCellRef), 0.4);
-		return `${fontRem}rem`;
-	}
-
-	onMount(() => {
-		if (!boardEl) return;
-
-		const update = () => {
-			if (!boardEl) return;
-			const width = boardEl.clientWidth;
-			const scale = width / REF_BOARD_WIDTH;
-			gap = Math.max(2, BOARD_GAP * scale);
-			padding = Math.max(2, BOARD_PADDING * scale);
-			tileRadius = Math.max(2, TILE_BORDER_RADIUS * scale);
-			boardRadius = Math.max(3, BOARD_BORDER_RADIUS * scale);
-			cellSize = (width - padding * 2 - gap * 3) / 4;
-		};
-
-		update();
-		const observer = new ResizeObserver(update);
-		observer.observe(boardEl);
-		return () => observer.disconnect();
-	});
 </script>
 
-<div
-	bind:this={boardEl}
-	class="preview-board"
-	class:selected
-	style:background={theme.boardBackground}
-	style:gap={`${gap}px`}
-	style:padding={`${padding}px`}
-	style:border-radius={`${boardRadius}px`}
-	aria-hidden="true"
->
-	{#each previewValues as value, i (i)}
-		{#if value == null}
-			<div
-				class="preview-tile empty"
-				style:background={theme.emptyTile}
-				style:border-radius={`${tileRadius}px`}
-			></div>
-		{:else}
-			{@const bg = tileBg(value, theme)}
-			<div
-				class="preview-tile"
-				style:background={bg}
-				style:color={isLight(bg) ? (theme.textLight ?? "#333") : (theme.textDark ?? "#fff")}
-				style:border-radius={`${tileRadius}px`}
-				style:font-size={tileFontSize(value)}
-			>
-				{value}
-			</div>
-		{/if}
-	{/each}
-</div>
-
-<style>
-	.preview-board {
-		display: grid;
-		grid-template-columns: repeat(4, 1fr);
-		grid-template-rows: repeat(4, 1fr);
-		width: 100%;
-		aspect-ratio: 1;
-		box-sizing: border-box;
-	}
-
-	.preview-board.selected {
-		outline: 3px solid var(--color-primary, #e88f4f);
-		outline-offset: 2px;
-	}
-
-	.preview-tile {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		font-weight: 800;
-		min-height: 0;
-		min-width: 0;
-		padding: 0.1em;
-		text-align: center;
-		line-height: 1;
-	}
-
-	.preview-tile.empty {
-		color: transparent;
-	}
-</style>
+<BoardPreview {theme} board={sampleBoard} {selected} />

--- a/src/lib/server/challenge.js
+++ b/src/lib/server/challenge.js
@@ -95,30 +95,54 @@ export function getChallengeById(id) {
 }
 
 /**
+ * @param {unknown} metrics
+ * @returns {number | null}
+ */
+function moveCountFromMetrics(metrics) {
+	if (!metrics || typeof metrics !== "object") return null;
+	const value = /** @type {{ moveCount?: unknown }} */ (metrics).moveCount;
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
  * @param {string} userId
  * @param {string[]} challengeIds
- * @returns {Record<string, { bestStatus: string | null; attempts: number; wins: number }>}
+ * @returns {Record<string, { bestStatus: string | null; attempts: number; wins: number; bestMoveCount: number | null; bestScore: number | null }>}
  */
 export function getChallengeStatsForUser(userId, challengeIds = []) {
 	const runs = db
 		.select({
 			challengeId: table.challengeRun.challengeId,
 			status: table.challengeRun.status,
+			score: table.challengeRun.score,
+			metrics: table.challengeRun.metrics,
 		})
 		.from(table.challengeRun)
 		.where(eq(table.challengeRun.userId, userId))
 		.all();
 
-	/** @type {Record<string, { bestStatus: string | null; attempts: number; wins: number }>} */
+	/** @type {Record<string, { bestStatus: string | null; attempts: number; wins: number; bestMoveCount: number | null; bestScore: number | null }>} */
 	const stats = {};
 
 	for (const challengeId of challengeIds) {
-		stats[challengeId] = { bestStatus: null, attempts: 0, wins: 0 };
+		stats[challengeId] = {
+			bestStatus: null,
+			attempts: 0,
+			wins: 0,
+			bestMoveCount: null,
+			bestScore: null,
+		};
 	}
 
 	for (const run of runs) {
 		if (!stats[run.challengeId]) {
-			stats[run.challengeId] = { bestStatus: null, attempts: 0, wins: 0 };
+			stats[run.challengeId] = {
+				bestStatus: null,
+				attempts: 0,
+				wins: 0,
+				bestMoveCount: null,
+				bestScore: null,
+			};
 		}
 		const entry = stats[run.challengeId];
 		if (run.status !== CHALLENGE_RUN_STATUS.ABANDONED) {
@@ -127,6 +151,16 @@ export function getChallengeStatsForUser(userId, challengeIds = []) {
 		if (run.status === CHALLENGE_RUN_STATUS.WON) {
 			entry.wins += 1;
 			entry.bestStatus = CHALLENGE_RUN_STATUS.WON;
+			const moves = moveCountFromMetrics(run.metrics);
+			if (moves != null && (entry.bestMoveCount == null || moves < entry.bestMoveCount)) {
+				entry.bestMoveCount = moves;
+			}
+			if (
+				typeof run.score === "number" &&
+				(entry.bestScore == null || run.score > entry.bestScore)
+			) {
+				entry.bestScore = run.score;
+			}
 		} else if (
 			run.status === CHALLENGE_RUN_STATUS.LOST &&
 			entry.bestStatus !== CHALLENGE_RUN_STATUS.WON

--- a/src/routes/challenges/+page.svelte
+++ b/src/routes/challenges/+page.svelte
@@ -19,6 +19,28 @@
 	}
 
 	/**
+	 * Background for a calendar day cell. Status colors fill the whole day
+	 * so cleared/failed days stay readable on the brand primary (today).
+	 * @param {{ status: string | null; isToday: boolean }} day
+	 */
+	function dayBackground(day) {
+		if (day.status === CHALLENGE_RUN_STATUS.WON) return "#16a34a";
+		if (day.status === CHALLENGE_RUN_STATUS.LOST) return "#dc2626";
+		if (day.isToday) return page.data.theme?.primary;
+		return page.data.theme?.boardBackground;
+	}
+
+	/**
+	 * @param {{ status: string | null; isToday: boolean }} day
+	 */
+	function dayColor(day) {
+		if (day.status === CHALLENGE_RUN_STATUS.WON || day.status === CHALLENGE_RUN_STATUS.LOST) {
+			return "#ffffff";
+		}
+		return page.data.theme?.textDark;
+	}
+
+	/**
 	 * @param {string} type
 	 */
 	function typeLabel(type) {
@@ -147,28 +169,22 @@
 							day.status
 						)} flex aspect-square flex-col items-center justify-center rounded-lg text-sm font-semibold transition-opacity hover:opacity-90"
 						class:today={day.isToday}
-						style:background-color={day.isToday
-							? page.data.theme?.primary
-							: page.data.theme?.boardBackground}
-						style:color={day.isToday ? page.data.theme?.textDark : page.data.theme?.textDark}
+						style:background-color={dayBackground(day)}
+						style:color={dayColor(day)}
+						aria-label={`${day.dateStr}${day.status === CHALLENGE_RUN_STATUS.WON ? ", cleared" : day.status === CHALLENGE_RUN_STATUS.LOST ? ", failed" : ""}`}
 					>
 						<span>{day.day}</span>
-						{#if day.status === CHALLENGE_RUN_STATUS.WON}
-							<span class="dot won-dot"></span>
-						{:else if day.status === CHALLENGE_RUN_STATUS.LOST}
-							<span class="dot lost-dot"></span>
-						{/if}
 					</a>
 				{/if}
 			{/each}
 		</div>
 
 		<div class="mt-4 flex flex-wrap gap-3 text-xs text-gray-500">
-			<span class="inline-flex items-center gap-1">
-				<span class="dot won-dot inline-block"></span> Cleared
+			<span class="inline-flex items-center gap-1.5">
+				<span class="swatch won-swatch"></span> Cleared
 			</span>
-			<span class="inline-flex items-center gap-1">
-				<span class="dot lost-dot inline-block"></span> Attempted
+			<span class="inline-flex items-center gap-1.5">
+				<span class="swatch lost-swatch"></span> Failed
 			</span>
 			{#if !data.isPro}
 				<span class="inline-flex items-center gap-1">
@@ -180,22 +196,22 @@
 </main>
 
 <style>
-	.dot {
-		width: 6px;
-		height: 6px;
-		border-radius: 999px;
-		margin-top: 2px;
+	.swatch {
+		width: 12px;
+		height: 12px;
+		border-radius: 4px;
+		display: inline-block;
 	}
 
-	.won-dot {
+	.won-swatch {
 		background: #16a34a;
 	}
 
-	.lost-dot {
+	.lost-swatch {
 		background: #dc2626;
 	}
 
 	.day.today {
-		box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 40%, transparent);
+		box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-primary) 55%, transparent);
 	}
 </style>

--- a/src/routes/challenges/[id]/+page.svelte
+++ b/src/routes/challenges/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from "$app/forms";
 	import { page } from "$app/state";
 	import Btn from "$lib/components/Btn.svelte";
+	import BoardPreview from "$lib/components/BoardPreview.svelte";
 	import {
 		CHALLENGE_RUN_STATUS,
 		CHALLENGE_TYPES,
@@ -9,7 +10,6 @@
 		resolveClearTarget,
 	} from "$lib/challenges.js";
 	import { CrownIcon, ArrowLeftIcon } from "@lucide/svelte";
-	import { getTileBackground, getTileColor } from "$lib/game.svelte.js";
 
 	let { data } = $props();
 
@@ -111,32 +111,16 @@
 		{:else}
 			<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
 				<li>Goal tile: {challenge.params.winTile ?? 4096}</li>
+				<li>Fewer moves is better — beat your best clear</li>
 				<li>Start from the preset board below</li>
 				<li>Fail on game over</li>
 			</ul>
 		{/if}
 
-		{#if previewBoard}
+		{#if previewBoard && page.data.theme}
 			<div class="mb-6">
 				<p class="mb-2 text-xs font-bold tracking-wide text-gray-500 uppercase">Starting board</p>
-				<div
-					class="grid aspect-square grid-cols-4 gap-2.5 rounded-lg p-2.5"
-					style:background-color={page.data.theme?.boardBackground}
-				>
-					{#each previewBoard as row, ri (ri)}
-						{#each row as cell, ci (ci)}
-							<div
-								class="flex items-center justify-center rounded-md text-sm font-extrabold"
-								style:background-color={cell
-									? getTileBackground(cell, page.data.theme)
-									: page.data.theme?.emptyTile}
-								style:color={cell ? getTileColor(cell, page.data.theme) : "transparent"}
-							>
-								{cell || ""}
-							</div>
-						{/each}
-					{/each}
-				</div>
+				<BoardPreview theme={page.data.theme} board={previewBoard} />
 			</div>
 		{/if}
 
@@ -145,6 +129,11 @@
 				{#if data.stats.bestStatus === CHALLENGE_RUN_STATUS.WON}
 					You've cleared this challenge {data.stats.wins} time{data.stats.wins === 1 ? "" : "s"}
 					({data.stats.attempts} attempt{data.stats.attempts === 1 ? "" : "s"}).
+					{#if challenge.type === CHALLENGE_TYPES.RECOVERY && data.stats.bestMoveCount != null}
+						Best: {data.stats.bestMoveCount} move{data.stats.bestMoveCount === 1 ? "" : "s"}.
+					{:else if challenge.type === CHALLENGE_TYPES.TIME && data.stats.bestScore != null}
+						Best score: {data.stats.bestScore.toLocaleString()}.
+					{/if}
 				{:else if data.stats.attempts > 0}
 					{data.stats.attempts} attempt{data.stats.attempts === 1 ? "" : "s"} so far — keep going!
 				{:else}

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -33,12 +33,16 @@
 	const challenge = $derived(data.challenge);
 	const isTime = $derived(challenge.type === CHALLENGE_TYPES.TIME);
 	const isClear = $derived(challenge.type === CHALLENGE_TYPES.CLEAR);
+	const isRecovery = $derived(challenge.type === CHALLENGE_TYPES.RECOVERY);
 
 	const clearTarget = $derived(
 		isClear ? resolveClearTarget(/** @type {any} */ (challenge.params)) : null
 	);
 
 	const filledCells = $derived(game ? countFilledCells(game.board) : 0);
+	const winTile = $derived(
+		isRecovery && "winTile" in challenge.params ? challenge.params.winTile : null
+	);
 
 	/**
 	 * Build a Game from challenge params.
@@ -214,7 +218,11 @@
 		name="status"
 		value={result === "won" ? CHALLENGE_RUN_STATUS.WON : CHALLENGE_RUN_STATUS.LOST}
 	/>
-	<input type="hidden" name="score" value={game?.score ?? 0} />
+	<input
+		type="hidden"
+		name="score"
+		value={isRecovery ? (game?.moveCount ?? 0) : (game?.score ?? 0)}
+	/>
 	<input
 		type="hidden"
 		name="metrics"
@@ -222,6 +230,7 @@
 			moveCount: game?.moveCount ?? 0,
 			filledCells: game ? countFilledCells(game.board) : 0,
 			elapsedMs: isTime ? Date.now() - data.run.startedOn : undefined,
+			mergeScore: isRecovery ? (game?.score ?? 0) : undefined,
 		})}
 	/>
 </form>
@@ -240,32 +249,53 @@
 			<p class="text-sm text-gray-500">{data.objective}</p>
 		</div>
 		<div class="flex gap-2">
-			<div
-				class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
-				style:background-color={page.data.theme?.boardBackground}
-				style:color={page.data.theme?.textDark}
-			>
-				<div class="text-xs font-bold uppercase">Score</div>
-				<div class="font-bold">{game?.score.toLocaleString() ?? "—"}</div>
-			</div>
-			{#if isTime}
-				<div
-					class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
-					style:background-color={page.data.theme?.boardBackground}
-					style:color={remainingMs <= 10000 ? "#b91c1c" : page.data.theme?.textDark}
-				>
-					<div class="text-xs font-bold uppercase">Time</div>
-					<div class="font-bold">{formatTime(remainingMs)}</div>
-				</div>
-			{:else if isClear}
+			{#if isRecovery}
 				<div
 					class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
 					style:background-color={page.data.theme?.boardBackground}
 					style:color={page.data.theme?.textDark}
 				>
-					<div class="text-xs font-bold uppercase">Tiles</div>
-					<div class="font-bold">{filledCells}/{clearTarget}</div>
+					<div class="text-xs font-bold uppercase">Moves</div>
+					<div class="font-bold">{game?.moveCount ?? 0}</div>
 				</div>
+				{#if winTile}
+					<div
+						class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
+						style:background-color={page.data.theme?.boardBackground}
+						style:color={page.data.theme?.textDark}
+					>
+						<div class="text-xs font-bold uppercase">Goal</div>
+						<div class="font-bold">{winTile}</div>
+					</div>
+				{/if}
+			{:else}
+				<div
+					class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
+					style:background-color={page.data.theme?.boardBackground}
+					style:color={page.data.theme?.textDark}
+				>
+					<div class="text-xs font-bold uppercase">Score</div>
+					<div class="font-bold">{game?.score.toLocaleString() ?? "—"}</div>
+				</div>
+				{#if isTime}
+					<div
+						class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
+						style:background-color={page.data.theme?.boardBackground}
+						style:color={remainingMs <= 10000 ? "#b91c1c" : page.data.theme?.textDark}
+					>
+						<div class="text-xs font-bold uppercase">Time</div>
+						<div class="font-bold">{formatTime(remainingMs)}</div>
+					</div>
+				{:else if isClear}
+					<div
+						class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
+						style:background-color={page.data.theme?.boardBackground}
+						style:color={page.data.theme?.textDark}
+					>
+						<div class="text-xs font-bold uppercase">Tiles</div>
+						<div class="font-bold">{filledCells}/{clearTarget}</div>
+					</div>
+				{/if}
 			{/if}
 		</div>
 	</div>
@@ -305,7 +335,13 @@
 					Game over before the objective was met.
 				{/if}
 			</p>
-			<p class="mb-4 text-sm text-gray-500">Score: {game?.score.toLocaleString() ?? 0}</p>
+			<p class="mb-4 text-sm text-gray-500">
+				{#if isRecovery}
+					Moves: {game?.moveCount ?? 0}
+				{:else}
+					Score: {game?.score.toLocaleString() ?? 0}
+				{/if}
+			</p>
 			<div class="flex flex-wrap justify-center gap-2">
 				<form method="POST" action="/challenges/{challenge.id}?/start" use:enhance>
 					<Btn type="submit" class="justify-center">Retry</Btn>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds a shared `BoardPreview` component (same geometry/fonts/colors as the playable board) and uses it for challenge starting boards; `ThemePreview` now wraps it too.
- Recovery (“out of a pinch”) challenges track **moves** instead of score in the play HUD and results; fewer moves is better, with best move count on the detail page.
- Daily calendar marks cleared/failed days by coloring the **whole day cell** green/red (instead of hard-to-see dots).

## Test plan
- [ ] Open a Clear or Recovery challenge detail page — starting board should look like a real game board (equal cells, scaled tile fonts).
- [ ] Themes page — mini previews still look correct.
- [ ] Play a Recovery challenge — HUD shows Moves + Goal (not Score); completion overlay shows move count.
- [ ] After win/loss, calendar day cells are fully green (cleared) or red (failed), including when that day is today.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f638c-cef3-7c22-a4b3-fe8da512f143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f638c-cef3-7c22-a4b3-fe8da512f143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

