### PR TITLE
Fix history missing games abandoned after Keep Playing

### DIFF
--- a/drizzle/0011_abandon_orphan_in_progress_games.sql
+++ b/drizzle/0011_abandon_orphan_in_progress_games.sql
@@ -1,0 +1,22 @@
+-- Promote abandoned in-progress rows into history, keeping only the latest
+-- incomplete game per player as the current run. Fixes games that were won
+-- (or otherwise left incomplete) then overwritten via New Game before the
+-- client finalized them.
+UPDATE game
+SET
+	complete = 1,
+	completed_on = COALESCE(completed_on, updated_on)
+WHERE complete = 0
+	AND id NOT IN (
+		SELECT id FROM (
+			SELECT
+				id,
+				ROW_NUMBER() OVER (
+					PARTITION BY player_id
+					ORDER BY updated_on DESC
+				) AS rn
+			FROM game
+			WHERE complete = 0
+		) AS ranked
+		WHERE rn = 1
+	);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1784076000000,
       "tag": "0010_daily_challenge",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1784077000000,
+      "tag": "0011_abandon_orphan_in_progress_games",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/game.svelte.js
+++ b/src/lib/game.svelte.js
@@ -607,7 +607,9 @@ export class Game {
 	}
 
 	/**
-	 * Get the game as a JSON object for saving to the db
+	 * Get the game as a JSON object for saving to the db.
+	 * Note: `complete` mirrors board-full game over only. A win with Keep Playing
+	 * stays incomplete until game over or the run is finalized (e.g. New Game).
 	 * @returns {Omit<import("./types").GameSaveData, "playerId">}
 	 */
 	json() {

--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -1,6 +1,6 @@
 import * as table from "$lib/server/db/schema";
 import { db } from "$lib/server/db";
-import { and, desc, eq, not, sql } from "drizzle-orm";
+import { and, desc, eq, ne, not, sql } from "drizzle-orm";
 import assert from "node:assert";
 
 /**
@@ -47,6 +47,35 @@ export function gameHasReplay(game) {
 		game.moves.length > 0 &&
 		game.moves.length === game.moveCount
 	);
+}
+
+/**
+ * Mark every other in-progress game for this user as complete.
+ *
+ * A player should only have one current (incomplete) run. Older incomplete rows
+ * (e.g. abandoned after Keep Playing → New Game) would otherwise never appear
+ * in history, which requires complete === true.
+ *
+ * Performance: one UPDATE by player_id; usually matches 0 rows.
+ *
+ * @param {string} userId
+ * @param {string} exceptGameId The game that should remain in progress
+ */
+export async function abandonOtherInProgressGames(userId, exceptGameId) {
+	await db
+		.update(table.game)
+		.set({
+			complete: true,
+			// Preserve win-time stamp when present; otherwise use last play time
+			completedOn: sql`coalesce(${table.game.completedOn}, ${table.game.updatedOn})`,
+		})
+		.where(
+			and(
+				eq(table.game.playerId, userId),
+				not(eq(table.game.complete, true)),
+				ne(table.game.id, exceptGameId)
+			)
+		);
 }
 
 /**
@@ -123,6 +152,11 @@ export async function saveGame(game) {
 			.get();
 
 		game.id = newGame.id;
+	}
+
+	// Keep a single current run: any other incomplete rows become history
+	if (game.id && !game.complete) {
+		await abandonOtherInProgressGames(game.playerId, game.id);
 	}
 
 	return game.id;

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -25,6 +25,8 @@
 	/** @type {import("$lib/game.svelte.js").Game | null} */
 	let pendingServerSave = null;
 	let lastServerSaveAt = 0;
+	/** @type {Promise<void> | null} */
+	let inflightSavePromise = null;
 
 	/**
 	 * Create a Game, preserving server id when local is missing one
@@ -106,49 +108,109 @@
 	}
 
 	/**
+	 * Persist a game save payload to the server
+	 * @param {Omit<import("$lib/types").GameSaveData, "playerId">} gameData
+	 * @param {{ keepalive?: boolean, game?: import("$lib/game.svelte.js").Game | null }} [options]
+	 */
+	async function persistGameDataToServer(gameData, { keepalive = false, game = null } = {}) {
+		if (!page.data.user) return;
+
+		const run = async () => {
+			try {
+				const response = await fetch("/api/game/save", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+					},
+					body: JSON.stringify(gameData),
+					keepalive,
+				});
+				if (!response.ok) {
+					throw new Error(`Failed to save game to server: ${response.statusText}`);
+				}
+				const result = await response.json();
+				if (!result.success) {
+					throw new Error(`Failed to save game to server: ${result.error}`);
+				}
+
+				if (result.id && game) {
+					game.id = result.id;
+					// Refresh local snapshot so id survives reloads before the next effect tick
+					localSaveGame(game.json());
+				}
+			} catch (error) {
+				// Keepalive / tab-hide flushes and superseded in-flight saves often abort — not actionable.
+				if (error instanceof DOMException && error.name === "AbortError") return;
+				if (
+					error instanceof TypeError &&
+					/failed to fetch/i.test(error.message) &&
+					(keepalive || document.visibilityState === "hidden")
+				) {
+					return;
+				}
+				console.error("Failed to save game to server:", error);
+			}
+		};
+
+		// Serialize saves so an older incomplete write cannot land after finalize
+		const previous = inflightSavePromise;
+		const promise = (async () => {
+			if (previous) await previous;
+			await run();
+		})();
+
+		inflightSavePromise = promise.finally(() => {
+			if (inflightSavePromise === promise) {
+				inflightSavePromise = null;
+			}
+		});
+		return inflightSavePromise;
+	}
+
+	/**
 	 * Persist current game snapshot to the server
 	 * @param {import("$lib/game.svelte.js").Game} game
 	 * @param {{ keepalive?: boolean }} [options]
 	 */
 	async function saveGameToServer(game, { keepalive = false } = {}) {
-		if (!page.data.user) return;
+		return persistGameDataToServer(game.json(), { keepalive, game });
+	}
 
-		const gameData = game.json();
-
-		try {
-			const response = await fetch("/api/game/save", {
-				method: "POST",
-				headers: {
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify(gameData),
-				keepalive,
-			});
-			if (!response.ok) {
-				throw new Error(`Failed to save game to server: ${response.statusText}`);
-			}
-			const result = await response.json();
-			if (!result.success) {
-				throw new Error(`Failed to save game to server: ${result.error}`);
-			}
-
-			if (result.id) {
-				game.id = result.id;
-				// Refresh local snapshot so id survives reloads before the next effect tick
-				localSaveGame(game.json());
-			}
-		} catch (error) {
-			// Keepalive / tab-hide flushes and superseded in-flight saves often abort — not actionable.
-			if (error instanceof DOMException && error.name === "AbortError") return;
-			if (
-				error instanceof TypeError &&
-				/failed to fetch/i.test(error.message) &&
-				(keepalive || document.visibilityState === "hidden")
-			) {
-				return;
-			}
-			console.error("Failed to save game to server:", error);
+	/**
+	 * Cancel any throttled (not yet sent) server save
+	 */
+	function cancelPendingServerSave() {
+		if (saveTimeout) {
+			clearTimeout(saveTimeout);
+			saveTimeout = null;
 		}
+		pendingServerSave = null;
+	}
+
+	/**
+	 * Finalize the current run for history, then start a fresh game.
+	 *
+	 * History only lists complete === true. Winning does not set complete (players
+	 * can keep playing), so New Game must mark the abandoned run complete or it
+	 * disappears from /replay.
+	 */
+	async function handleNewGame() {
+		const previous = gameState.currentGame;
+		cancelPendingServerSave();
+
+		// Let any in-flight incomplete save finish before writing complete:true
+		if (inflightSavePromise) {
+			await inflightSavePromise;
+		}
+
+		if (previous && previous.moveCount > 0 && page.data.user) {
+			const snapshot = { ...previous.json(), complete: true };
+			await persistGameDataToServer(snapshot);
+		}
+
+		pendingEvents.splice(0, pendingEvents.length);
+		gameState.hasCheckpoint = false;
+		gameState.currentGame = new Game();
 	}
 
 	/**
@@ -413,6 +475,7 @@
 	<AnimatedBoard
 		{pendingEvents}
 		{popEvent}
+		onNewGame={handleNewGame}
 		onSetCheckpoint={handleSetCheckpoint}
 		onRestoreCheckpoint={handleRestoreCheckpoint}
 	/>

--- a/src/routes/game/components/AnimatedBoard.svelte
+++ b/src/routes/game/components/AnimatedBoard.svelte
@@ -19,6 +19,7 @@
 	 *   pendingEvents?: import("$lib/types").GameEvent[],
 	 *   popEvent: () => import("$lib/types").GameEvent | undefined,
 	 *   onUndo?: () => void,
+	 *   onNewGame?: () => void | Promise<void>,
 	 *   onSetCheckpoint?: () => void | Promise<void>,
 	 *   onRestoreCheckpoint?: () => void | Promise<void>,
 	 *   game?: import("$lib/game.svelte.js").Game | null,
@@ -31,6 +32,7 @@
 		pendingEvents = [],
 		popEvent,
 		onUndo = undefined,
+		onNewGame = undefined,
 		onSetCheckpoint = undefined,
 		onRestoreCheckpoint = undefined,
 		game: gameProp = undefined,
@@ -219,6 +221,7 @@
 	<GameControls
 		{animationIdle}
 		onUndo={handleUndo}
+		{onNewGame}
 		{onSetCheckpoint}
 		onRestoreCheckpoint={handleRestoreCheckpoint}
 	/>

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -50,6 +50,7 @@
 	 * @typedef {Object} Props
 	 * @property {boolean} [animationIdle]
 	 * @property {(() => void) | undefined} [onUndo]
+	 * @property {(() => void | Promise<void>) | undefined} [onNewGame]
 	 * @property {(() => void | Promise<void>) | undefined} [onSetCheckpoint]
 	 * @property {(() => void | Promise<void>) | undefined} [onRestoreCheckpoint]
 	 */
@@ -58,6 +59,7 @@
 	let {
 		animationIdle = true,
 		onUndo = undefined,
+		onNewGame = undefined,
 		onSetCheckpoint = undefined,
 		onRestoreCheckpoint = undefined,
 	} = $props();
@@ -135,6 +137,10 @@
 		showWin = false;
 		undoQueued = false;
 		restoreQueued = false;
+		if (onNewGame) {
+			void onNewGame();
+			return;
+		}
 		gameState.hasCheckpoint = false;
 		gameState.currentGame = new Game();
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
If you won, chose **Keep Playing**, then started a **New Game**, the previous run vanished from History (`/replay`).

History only lists games with `complete === true`. Winning does **not** set `complete` (so Keep Playing can continue on the same run). `New Game` replaced the in-memory game without finalizing the prior row, leaving an orphan `won=true, complete=false` that never showed up in history.

## Fix
Two layers:

1. **Client:** Before starting a fresh game, finalize the previous run when it has progress — cancel pending saves, wait for in-flight ones, persist `{ ...json(), complete: true }`, then create the new game.

2. **Server guard (durable):** Whenever an incomplete game is saved, mark every *other* in-progress game for that player as complete (one `UPDATE` by `player_id` — typically 0 rows). So even if the client path fails, orphans cannot accumulate.

3. **Existing data:** Migration `0011_abandon_orphan_in_progress_games` promotes abandoned incomplete rows into history, keeping only each player's latest incomplete game as current. After deploy + migrate, past overwritten wins should appear in History.

## Test plan
- [ ] Log in as Pro, play until win, click Keep Playing, open menu → New Game
- [ ] Open History — prior game appears as a win
- [ ] Same path without Keep Playing (New Game on win dialog) — still listed as a win
- [ ] Play until lose → Try Again — still listed as a loss
- [ ] Mid-game New Game after some moves — abandoned run appears as a completed history entry
- [ ] After migrating existing DB, previously missing overwritten wins show up in History

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6391-9438-7e08-b64c-cb2daa99b04c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6391-9438-7e08-b64c-cb2daa99b04c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

