### PR TITLE
Remove clear-board challenge, keep timed + recovery

### DIFF
--- a/drizzle/0012_remove_clear_challenges.sql
+++ b/drizzle/0012_remove_clear_challenges.sql
@@ -1,0 +1,8 @@
+-- Remove legacy clear-board challenges (and their runs). Affected days will be
+-- regenerated as time or recovery challenges on next visit.
+DELETE FROM `challenge_run`
+WHERE `challenge_id` IN (
+	SELECT `id` FROM `daily_challenge` WHERE `type` = 'clear'
+);
+--> statement-breakpoint
+DELETE FROM `daily_challenge` WHERE `type` = 'clear';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1784077000000,
       "tag": "0011_abandon_orphan_in_progress_games",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1784078000000,
+      "tag": "0012_remove_clear_challenges",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/challenges.js
+++ b/src/lib/challenges.js
@@ -7,7 +7,6 @@ import { createSeededRng } from "$lib/rng.js";
 
 export const CHALLENGE_TYPES = {
 	TIME: "time",
-	CLEAR: "clear",
 	RECOVERY: "recovery",
 };
 
@@ -30,14 +29,6 @@ export const CHALLENGE_TIMEZONE = "America/Chicago";
  */
 
 /**
- * @typedef {Object} ClearChallengeParams
- * @property {number} [seed]
- * @property {number[][]} board
- * @property {number} [maxFilled] Success when occupied cells ≤ this
- * @property {number} [clearPercent] Success when occupied ≤ ceil(initial * (1 - percent/100))
- */
-
-/**
  * @typedef {Object} RecoveryChallengeParams
  * @property {number} [seed]
  * @property {number[][]} board
@@ -51,13 +42,12 @@ export const CHALLENGE_TIMEZONE = "America/Chicago";
  * @property {string} title
  * @property {string} description
  * @property {string} difficulty
- * @property {TimeChallengeParams | ClearChallengeParams | RecoveryChallengeParams} params
+ * @property {TimeChallengeParams | RecoveryChallengeParams} params
  */
 
 const DIFFICULTIES = ["Easy", "Medium", "Hard"];
 
 const TIME_TITLES = ["Score Sprint", "Point Rush", "Clock Race", "Quick Score"];
-const CLEAR_TITLES = ["Space Maker", "Board Cleaner", "Merge Down", "Clear Path"];
 const RECOVERY_TITLES = ["Near Miss", "Comeback", "High Wire", "Last Stand"];
 
 /**
@@ -197,7 +187,7 @@ export function generateDailyChallengeDefinition(dateStr) {
 	const seed = hashSeed(`play4096-daily-${dateStr}`);
 	const rng = createSeededRng(seed);
 
-	const typeRoll = rng.nextInt(3);
+	const typeRoll = rng.nextInt(2);
 	const difficulty = DIFFICULTIES[rng.nextInt(DIFFICULTIES.length)];
 
 	if (typeRoll === 0) {
@@ -223,37 +213,6 @@ export function generateDailyChallengeDefinition(dateStr) {
 				seed,
 				targetScore,
 				durationSec,
-			},
-		};
-	}
-
-	if (typeRoll === 1) {
-		const fill =
-			difficulty === "Easy"
-				? 10 + rng.nextInt(3)
-				: difficulty === "Medium"
-					? 12 + rng.nextInt(3)
-					: 14 + rng.nextInt(2);
-		const pool =
-			difficulty === "Easy"
-				? [2, 2, 4, 4, 8, 8, 16]
-				: difficulty === "Medium"
-					? [2, 4, 4, 8, 8, 16, 16, 32]
-					: [2, 4, 8, 16, 16, 32, 32, 64, 128];
-		const board = boardFromValues(rng, pickValues(rng, fill, pool));
-		const maxFilled = difficulty === "Easy" ? 4 : difficulty === "Medium" ? 3 : 2;
-		const title = CLEAR_TITLES[rng.nextInt(CLEAR_TITLES.length)];
-
-		return {
-			id,
-			type: CHALLENGE_TYPES.CLEAR,
-			title,
-			description: `This board is crowded. Merge until ${maxFilled} or fewer tiles remain.`,
-			difficulty,
-			params: {
-				seed,
-				board,
-				maxFilled,
 			},
 		};
 	}
@@ -298,21 +257,6 @@ export function countFilledCells(board) {
 }
 
 /**
- * Resolve the clear-board filled-cell target from challenge params.
- * @param {ClearChallengeParams} params
- */
-export function resolveClearTarget(params) {
-	const initialFilled = countFilledCells(params.board);
-	if (typeof params.maxFilled === "number") {
-		return params.maxFilled;
-	}
-	if (typeof params.clearPercent === "number") {
-		return Math.ceil(initialFilled * (1 - params.clearPercent / 100));
-	}
-	return 0;
-}
-
-/**
  * Evaluate whether a challenge run has succeeded or failed.
  *
  * @param {ChallengeDefinition} challenge
@@ -333,14 +277,6 @@ export function evaluateChallenge(challenge, state) {
 		const elapsedMs = state.elapsedMs ?? 0;
 		if (state.score >= targetScore) return "won";
 		if (elapsedMs >= durationSec * 1000) return "lost";
-		if (state.gameOver) return "lost";
-		return "ongoing";
-	}
-
-	if (type === CHALLENGE_TYPES.CLEAR) {
-		const clearParams = /** @type {ClearChallengeParams} */ (params);
-		const target = resolveClearTarget(clearParams);
-		if (countFilledCells(state.board) <= target) return "won";
 		if (state.gameOver) return "lost";
 		return "ongoing";
 	}
@@ -366,12 +302,6 @@ export function formatChallengeObjective(challenge) {
 	if (type === CHALLENGE_TYPES.TIME) {
 		const p = /** @type {TimeChallengeParams} */ (params);
 		return `Score ${p.targetScore.toLocaleString()} in ${p.durationSec}s`;
-	}
-
-	if (type === CHALLENGE_TYPES.CLEAR) {
-		const p = /** @type {ClearChallengeParams} */ (params);
-		const target = resolveClearTarget(p);
-		return `Reduce to ${target} or fewer tiles`;
 	}
 
 	if (type === CHALLENGE_TYPES.RECOVERY) {

--- a/src/lib/server/challenge.js
+++ b/src/lib/server/challenge.js
@@ -44,7 +44,11 @@ export function ensureDailyChallenge(dateStr = getChallengeDateString()) {
 		.where(eq(table.dailyChallenge.id, id))
 		.get();
 
-	if (existing) {
+	// Legacy clear-board challenges are removed; regenerate that day as time/recovery.
+	if (existing && existing.type === "clear") {
+		db.delete(table.challengeRun).where(eq(table.challengeRun.challengeId, id)).run();
+		db.delete(table.dailyChallenge).where(eq(table.dailyChallenge.id, id)).run();
+	} else if (existing) {
 		return rowToChallenge(existing);
 	}
 

--- a/src/routes/challenges/+page.svelte
+++ b/src/routes/challenges/+page.svelte
@@ -45,7 +45,6 @@
 	 */
 	function typeLabel(type) {
 		if (type === CHALLENGE_TYPES.TIME) return "Time";
-		if (type === CHALLENGE_TYPES.CLEAR) return "Clear";
 		return "Recovery";
 	}
 </script>

--- a/src/routes/challenges/[id]/+page.svelte
+++ b/src/routes/challenges/[id]/+page.svelte
@@ -3,12 +3,7 @@
 	import { page } from "$app/state";
 	import Btn from "$lib/components/Btn.svelte";
 	import BoardPreview from "$lib/components/BoardPreview.svelte";
-	import {
-		CHALLENGE_RUN_STATUS,
-		CHALLENGE_TYPES,
-		countFilledCells,
-		resolveClearTarget,
-	} from "$lib/challenges.js";
+	import { CHALLENGE_RUN_STATUS, CHALLENGE_TYPES } from "$lib/challenges.js";
 	import { CrownIcon, ArrowLeftIcon } from "@lucide/svelte";
 
 	let { data } = $props();
@@ -101,12 +96,6 @@
 				<li>Target score: {challenge.params.targetScore.toLocaleString()}</li>
 				<li>Time limit: {challenge.params.durationSec}s</li>
 				<li>Fail if the timer runs out or you game over first</li>
-			</ul>
-		{:else if challenge.type === CHALLENGE_TYPES.CLEAR}
-			<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
-				<li>Starting tiles: {countFilledCells(challenge.params.board)}</li>
-				<li>Clear to ≤ {resolveClearTarget(challenge.params)} occupied cells</li>
-				<li>Fail on game over before reaching the target</li>
 			</ul>
 		{:else}
 			<ul class="mb-6 list-inside list-disc text-sm text-gray-600">

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -11,7 +11,6 @@
 		CHALLENGE_TYPES,
 		countFilledCells,
 		evaluateChallenge,
-		resolveClearTarget,
 	} from "$lib/challenges.js";
 	import Btn from "$lib/components/Btn.svelte";
 	import AnimatedBoard from "../../../game/components/AnimatedBoard.svelte";
@@ -32,14 +31,8 @@
 
 	const challenge = $derived(data.challenge);
 	const isTime = $derived(challenge.type === CHALLENGE_TYPES.TIME);
-	const isClear = $derived(challenge.type === CHALLENGE_TYPES.CLEAR);
 	const isRecovery = $derived(challenge.type === CHALLENGE_TYPES.RECOVERY);
 
-	const clearTarget = $derived(
-		isClear ? resolveClearTarget(/** @type {any} */ (challenge.params)) : null
-	);
-
-	const filledCells = $derived(game ? countFilledCells(game.board) : 0);
 	const winTile = $derived(
 		isRecovery && "winTile" in challenge.params ? challenge.params.winTile : null
 	);
@@ -285,15 +278,6 @@
 					>
 						<div class="text-xs font-bold uppercase">Time</div>
 						<div class="font-bold">{formatTime(remainingMs)}</div>
-					</div>
-				{:else if isClear}
-					<div
-						class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
-						style:background-color={page.data.theme?.boardBackground}
-						style:color={page.data.theme?.textDark}
-					>
-						<div class="text-xs font-bold uppercase">Tiles</div>
-						<div class="font-bold">{filledCells}/{clearTarget}</div>
 					</div>
 				{/if}
 			{/if}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Daily challenges now rotate between only two modes: **timed score sprint** and **cluttered-board recovery** (reach a target tile).

### Why
Clear-board felt too similar to recovery and was nearly impossible to finish (hard to get below a few occupied tiles).

### Changes
- Dropped the `clear` challenge type from generation, evaluation, and UI
- Daily generation now picks time vs recovery (`rng.nextInt(2)`)
- Migration deletes existing clear-board challenge rows and their runs; those days regenerate as time/recovery on next visit
- Server also regenerates any leftover `clear` rows if migration hasn't run yet

Okay to lose clear-challenge history on this (recently deployed, low usage).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6398-2f73-7478-93e2-21be0ca962ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6398-2f73-7478-93e2-21be0ca962ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

