### PR TITLE
Tighten challenge pregame overview copy

### DIFF
--- a/src/lib/challenges.js
+++ b/src/lib/challenges.js
@@ -207,7 +207,10 @@ export function generateDailyChallengeDefinition(dateStr) {
 			id,
 			type: CHALLENGE_TYPES.TIME,
 			title,
-			description: `Reach ${targetScore.toLocaleString()} points before the clock hits zero. Fresh board, fixed seed.`,
+			description: formatChallengeOverview({
+				type: CHALLENGE_TYPES.TIME,
+				params: { targetScore, durationSec },
+			}),
 			difficulty,
 			params: {
 				seed,
@@ -232,7 +235,10 @@ export function generateDailyChallengeDefinition(dateStr) {
 		id,
 		type: CHALLENGE_TYPES.RECOVERY,
 		title,
-		description: `Pull off a ${winTile} from this awkward high-tile scramble. Fewer moves is better.`,
+		description: formatChallengeOverview({
+			type: CHALLENGE_TYPES.RECOVERY,
+			params: { winTile, board },
+		}),
 		difficulty,
 		params: {
 			seed,
@@ -293,8 +299,8 @@ export function evaluateChallenge(challenge, state) {
 }
 
 /**
- * Human-readable objective line for UI.
- * @param {ChallengeDefinition} challenge
+ * Short goal line for HUD / calendar (no fail-rule noise).
+ * @param {Pick<ChallengeDefinition, 'type' | 'params'> & { description?: string }} challenge
  */
 export function formatChallengeObjective(challenge) {
 	const { type, params } = challenge;
@@ -306,10 +312,40 @@ export function formatChallengeObjective(challenge) {
 
 	if (type === CHALLENGE_TYPES.RECOVERY) {
 		const p = /** @type {RecoveryChallengeParams} */ (params);
-		return `Reach ${p.winTile ?? 4096} in as few moves as possible`;
+		return `Reach ${p.winTile ?? 4096} in fewest moves`;
 	}
 
-	return challenge.description;
+	return challenge.description ?? "";
+}
+
+/**
+ * One-line goal + rules overview for the pregame screen.
+ * @param {Pick<ChallengeDefinition, 'type' | 'params'> & { description?: string }} challenge
+ */
+export function formatChallengeOverview(challenge) {
+	const { type, params } = challenge;
+
+	if (type === CHALLENGE_TYPES.TIME) {
+		const p = /** @type {TimeChallengeParams} */ (params);
+		return `Score ${p.targetScore.toLocaleString()} in ${p.durationSec}s. Timeout or game over fails.`;
+	}
+
+	if (type === CHALLENGE_TYPES.RECOVERY) {
+		const p = /** @type {RecoveryChallengeParams} */ (params);
+		return `Reach ${p.winTile ?? 4096} in fewest moves. Game over fails.`;
+	}
+
+	return challenge.description ?? "";
+}
+
+/**
+ * Short label for challenge type (pregame / calendar meta).
+ * @param {typeof CHALLENGE_TYPES[keyof typeof CHALLENGE_TYPES]} type
+ */
+export function formatChallengeTypeLabel(type) {
+	if (type === CHALLENGE_TYPES.TIME) return "Time";
+	if (type === CHALLENGE_TYPES.RECOVERY) return "Recovery";
+	return type;
 }
 
 /**

--- a/src/routes/challenges/+page.svelte
+++ b/src/routes/challenges/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { page } from "$app/state";
 	import Btn from "$lib/components/Btn.svelte";
-	import { CHALLENGE_RUN_STATUS, CHALLENGE_TYPES } from "$lib/challenges.js";
+	import { CHALLENGE_RUN_STATUS, formatChallengeTypeLabel } from "$lib/challenges.js";
 	import { CrownIcon, ChevronLeftIcon, ChevronRightIcon } from "@lucide/svelte";
 
 	let { data } = $props();
@@ -39,14 +39,6 @@
 		}
 		return page.data.theme?.textDark;
 	}
-
-	/**
-	 * @param {string} type
-	 */
-	function typeLabel(type) {
-		if (type === CHALLENGE_TYPES.TIME) return "Time";
-		return "Recovery";
-	}
 </script>
 
 <svelte:head>
@@ -75,7 +67,7 @@
 			<p class="mb-1 text-xs font-bold tracking-wide uppercase opacity-70">Today · {data.today}</p>
 			<h2 class="text-xl font-bold">{data.todayChallenge.title}</h2>
 			<p class="mb-1 text-sm opacity-80">
-				{typeLabel(data.todayChallenge.type)} · {data.todayChallenge.difficulty}
+				{formatChallengeTypeLabel(data.todayChallenge.type)} · {data.todayChallenge.difficulty}
 			</p>
 			<p class="mb-3 text-sm opacity-90">{data.todayChallenge.objective}</p>
 			<Btn href="/challenges/{data.todayChallenge.id}" class="w-full justify-center">

--- a/src/routes/challenges/[id]/+page.server.js
+++ b/src/routes/challenges/[id]/+page.server.js
@@ -2,7 +2,7 @@ import { fail, redirect } from "@sveltejs/kit";
 import { USER_LEVELS } from "$lib/constants.js";
 import {
 	dateFromChallengeId,
-	formatChallengeObjective,
+	formatChallengeOverview,
 	getChallengeDateString,
 } from "$lib/challenges.js";
 import {
@@ -50,7 +50,7 @@ export async function load({ locals, params }) {
 				description: "Upgrade to Pro to play past daily challenges.",
 				params: {},
 			},
-			objective: "Pro archive",
+			overview: "Upgrade to Pro to open past daily challenges.",
 			dateStr,
 			stats: null,
 		};
@@ -62,7 +62,7 @@ export async function load({ locals, params }) {
 		locked: false,
 		isToday,
 		challenge,
-		objective: formatChallengeObjective(challenge),
+		overview: formatChallengeOverview(challenge),
 		dateStr,
 		stats,
 	};

--- a/src/routes/challenges/[id]/+page.svelte
+++ b/src/routes/challenges/[id]/+page.svelte
@@ -3,7 +3,11 @@
 	import { page } from "$app/state";
 	import Btn from "$lib/components/Btn.svelte";
 	import BoardPreview from "$lib/components/BoardPreview.svelte";
-	import { CHALLENGE_RUN_STATUS, CHALLENGE_TYPES } from "$lib/challenges.js";
+	import {
+		CHALLENGE_RUN_STATUS,
+		CHALLENGE_TYPES,
+		formatChallengeTypeLabel,
+	} from "$lib/challenges.js";
 	import { CrownIcon, ArrowLeftIcon } from "@lucide/svelte";
 
 	let { data } = $props();
@@ -11,6 +15,7 @@
 	let starting = $state(false);
 
 	const challenge = $derived(data.challenge);
+	const typeLabel = $derived(formatChallengeTypeLabel(challenge.type));
 
 	const previewBoard = $derived(
 		!data.locked && "board" in challenge.params && Array.isArray(challenge.params.board)
@@ -88,23 +93,8 @@
 			{/if}
 		</div>
 	{:else}
-		<p class="mb-1 text-sm text-gray-500">{challenge.difficulty} · {data.objective}</p>
-		<p class="mb-6">{challenge.description}</p>
-
-		{#if challenge.type === CHALLENGE_TYPES.TIME}
-			<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
-				<li>Target score: {challenge.params.targetScore.toLocaleString()}</li>
-				<li>Time limit: {challenge.params.durationSec}s</li>
-				<li>Fail if the timer runs out or you game over first</li>
-			</ul>
-		{:else}
-			<ul class="mb-6 list-inside list-disc text-sm text-gray-600">
-				<li>Goal tile: {challenge.params.winTile ?? 4096}</li>
-				<li>Fewer moves is better — beat your best clear</li>
-				<li>Start from the preset board below</li>
-				<li>Fail on game over</li>
-			</ul>
-		{/if}
+		<p class="mb-1 text-sm text-gray-500">{challenge.difficulty} · {typeLabel}</p>
+		<p class="mb-6 text-base">{data.overview}</p>
 
 		{#if previewBoard && page.data.theme}
 			<div class="mb-6">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Daily challenge pregame screens were noisy — title, objective, flavor description, and a bullet list all restated the same goal/rules.

## Changes
- Replace the stacked description + rules bullets with one terse overview line derived from challenge params
- Meta line is now `Difficulty · Type` (e.g. `Hard · Recovery`)
- Examples:
  - Time: `Score 1,500 in 45s. Timeout or game over fails.`
  - Recovery: `Reach 2048 in fewest moves. Game over fails.`
- Stored challenge descriptions for newly generated dailies use the same concise overview string

Recovery board preview, attempt stats, and the Start CTA are unchanged.

## Screenshot
[Cleaned challenge pregame screen](https://cursor.com/agents/bc-019f63b8-46f7-78df-90ca-1c7ae2fd1a17/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fchallenge-pregame.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f63b8-46f7-78df-90ca-1c7ae2fd1a17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f63b8-46f7-78df-90ca-1c7ae2fd1a17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

