### PR TITLE
Fix challenge mini-game Retry button

### DIFF
--- a/src/routes/challenges/[id]/play/+page.server.js
+++ b/src/routes/challenges/[id]/play/+page.server.js
@@ -1,7 +1,17 @@
 import { error, fail, redirect } from "@sveltejs/kit";
 import { USER_LEVELS } from "$lib/constants.js";
-import { CHALLENGE_RUN_STATUS, formatChallengeObjective } from "$lib/challenges.js";
-import { completeChallengeRun, getChallengeById, getChallengeRun } from "$lib/server/challenge.js";
+import {
+	CHALLENGE_RUN_STATUS,
+	dateFromChallengeId,
+	formatChallengeObjective,
+	getChallengeDateString,
+} from "$lib/challenges.js";
+import {
+	completeChallengeRun,
+	getChallengeById,
+	getChallengeRun,
+	startChallengeRun,
+} from "$lib/server/challenge.js";
 import { requireLogin } from "$lib/server/user.js";
 
 /** @type {import("./$types").PageServerLoad} */
@@ -42,6 +52,29 @@ export async function load({ params, url }) {
 
 /** @type {import("./$types").Actions} */
 export const actions = {
+	/** Start a fresh run (Retry) — redirects to this play page with the new run id. */
+	start: async ({ params }) => {
+		const user = requireLogin(`/challenges/${params.id}/play`);
+
+		if (user.level !== USER_LEVELS.PRO) {
+			redirect(303, "/stripe");
+		}
+
+		const challenge = getChallengeById(params.id);
+		if (!challenge) {
+			return fail(404, { error: "Challenge not found" });
+		}
+
+		const dateStr = dateFromChallengeId(challenge.id);
+		const today = getChallengeDateString();
+		if (dateStr && dateStr > today) {
+			return fail(400, { error: "Challenge not available yet" });
+		}
+
+		const run = await startChallengeRun(user.id, challenge.id);
+		redirect(303, `/challenges/${challenge.id}/play?run=${run.id}`);
+	},
+
 	complete: async ({ request, params }) => {
 		const user = requireLogin(`/challenges/${params.id}/play`);
 

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -1,7 +1,7 @@
 <script>
-	import { browser } from "$app/environment";
-	import { enhance } from "$app/forms";
-	import { onMount } from "svelte";
+	import { applyAction, enhance } from "$app/forms";
+	import { goto } from "$app/navigation";
+	import { untrack } from "svelte";
 	import { page } from "$app/state";
 	import { Game } from "$lib/game.svelte.js";
 	import { DIRECTIONS } from "$lib/constants.js";
@@ -22,6 +22,7 @@
 	let result = $state(/** @type {'won' | 'lost' | null} */ (null));
 	let remainingMs = $state(0);
 	let submitting = $state(false);
+	let retrying = $state(false);
 
 	/** @type {import("$lib/types").GameEvent[]} */
 	let pendingEvents = $state([]);
@@ -66,16 +67,19 @@
 		return new Game({ seed, winTile });
 	}
 
-	function initGame() {
-		if (!browser) return;
+	/**
+	 * @param {number} startedOn
+	 */
+	function initGame(startedOn) {
 		pendingEvents = [];
 		game = createChallengeGame();
 		result = null;
+		submitting = false;
+		retrying = false;
 
-		if (isTime) {
+		if (isTime && "durationSec" in challenge.params) {
 			const durationMs = challenge.params.durationSec * 1000;
-			const elapsed = Date.now() - data.run.startedOn;
-			remainingMs = Math.max(0, durationMs - elapsed);
+			remainingMs = Math.max(0, durationMs - (Date.now() - startedOn));
 		}
 	}
 
@@ -99,10 +103,13 @@
 		queueMicrotask(() => completeForm?.requestSubmit());
 	}
 
-	function checkOutcome() {
+	/**
+	 * @param {number} [startedOn]
+	 */
+	function checkOutcome(startedOn = data.run.startedOn) {
 		if (!game || result) return;
 
-		const elapsedMs = isTime ? Date.now() - data.run.startedOn : undefined;
+		const elapsedMs = isTime ? Date.now() - startedOn : undefined;
 		const outcome = evaluateChallenge(challenge, {
 			board: game.board,
 			score: game.score,
@@ -161,24 +168,36 @@
 
 	const { handleTouchStart, handleTouchEnd, handleTouchMove } = createSwipeHandlers(handleMove);
 
-	onMount(() => {
-		if (data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) {
-			result = data.run.status === CHALLENGE_RUN_STATUS.WON ? "won" : "lost";
+	// Re-init when Retry starts a new run on the same play route (no remount).
+	$effect(() => {
+		const runId = data.run.id;
+		const status = data.run.status;
+		const startedOn = data.run.startedOn;
+		void runId;
+
+		if (status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) {
+			result = status === CHALLENGE_RUN_STATUS.WON ? "won" : "lost";
 			return;
 		}
 
-		initGame();
-		checkOutcome();
+		const timed = untrack(() => isTime);
+		const durationSec = untrack(() =>
+			"durationSec" in challenge.params ? challenge.params.durationSec : null
+		);
+		untrack(() => {
+			initGame(startedOn);
+			checkOutcome(startedOn);
+		});
 
 		window.addEventListener("keydown", handleKeydown);
 
 		/** @type {ReturnType<typeof setInterval> | null} */
 		let timer = null;
-		if (isTime) {
+		if (timed && durationSec != null) {
+			const durationMs = durationSec * 1000;
 			timer = setInterval(() => {
-				const durationMs = challenge.params.durationSec * 1000;
-				remainingMs = Math.max(0, durationMs - (Date.now() - data.run.startedOn));
-				checkOutcome();
+				remainingMs = Math.max(0, durationMs - (Date.now() - startedOn));
+				checkOutcome(startedOn);
 			}, 200);
 		}
 
@@ -187,6 +206,19 @@
 			if (timer) clearInterval(timer);
 		};
 	});
+
+	/** @type {import("@sveltejs/kit").SubmitFunction} */
+	const onRetry = () => {
+		retrying = true;
+		return async ({ result: actionResult }) => {
+			if (actionResult.type === "redirect") {
+				await goto(actionResult.location);
+				return;
+			}
+			retrying = false;
+			await applyAction(actionResult);
+		};
+	};
 </script>
 
 <svelte:head>
@@ -313,7 +345,7 @@
 			<p>
 				{#if result === "won"}
 					Nice work — {data.objective.toLowerCase()}.
-				{:else if isTime && game && game.score < challenge.params.targetScore}
+				{:else if isTime && game && "targetScore" in challenge.params && game.score < challenge.params.targetScore}
 					Time's up (or game over) with {game.score.toLocaleString()} points.
 				{:else}
 					Game over before the objective was met.
@@ -327,8 +359,10 @@
 				{/if}
 			</p>
 			<div class="flex flex-wrap justify-center gap-2">
-				<form method="POST" action="/challenges/{challenge.id}?/start" use:enhance>
-					<Btn type="submit" class="justify-center">Retry</Btn>
+				<form method="POST" action="?/start" use:enhance={onRetry}>
+					<Btn type="submit" class="justify-center" disabled={retrying || submitting}>
+						{retrying ? "Starting…" : "Retry"}
+					</Btn>
 				</form>
 				<Btn href="/challenges" class="justify-center">Calendar</Btn>
 			</div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Retry on daily challenge play started a new run and redirected back to `/challenges/[id]/play?run=…`, but the page component never remounted. Game-over state from `onMount` stayed put, so the overlay never cleared and Retry looked broken.

## Fix
- Reinitialize the challenge game whenever `data.run.id` / status changes (covers same-route Retry navigation)
- Add a local `?/start` action on the play page and wire Retry to it with proper redirect handling

## Test plan
- [ ] Start a Pro daily challenge and play until win or loss
- [ ] Click **Retry** — overlay should dismiss and a fresh run should begin
- [ ] Confirm a timed challenge timer resets on Retry
- [ ] Confirm Calendar navigation still works from the overlay
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f63c0-735b-7519-86bd-2d37348d267f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f63c0-735b-7519-86bd-2d37348d267f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

