### PR TITLE
Wipe profile high scores; all-time leaderboard aggregates from games

### DIFF
--- a/drizzle/0013_wipe_profile_best_scores.sql
+++ b/drizzle/0013_wipe_profile_best_scores.sql
@@ -1,0 +1,4 @@
+-- Reset denormalized profile high scores. All-time classic leaderboard now
+-- aggregates from completed `game` rows instead of `user_profile.best_score`,
+-- which could be inflated via unvalidated client sync.
+UPDATE `user_profile` SET `best_score` = NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1784078000000,
       "tag": "0012_remove_clear_challenges",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1784079000000,
+      "tag": "0013_wipe_profile_best_scores",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/localStorage.svelte.js
+++ b/src/lib/localStorage.svelte.js
@@ -61,11 +61,12 @@ export function clearGame() {
 /**
  * Save the best score to local storage
  * @param {number} score
+ * @param {{ force?: boolean }} [options] When force is true, overwrite even if lower (e.g. after server wipe/resync)
  */
-export function saveBestScore(score) {
+export function saveBestScore(score, options = {}) {
 	if (!browser) return;
 	const current = loadBestScore();
-	if (score > current) {
+	if (options.force || score > current) {
 		localStorage.setItem(LOCAL_STORAGE_BEST_SCORE, `${score}`);
 	}
 }

--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -4,11 +4,16 @@ import { and, desc, eq, ne, not, sql } from "drizzle-orm";
 import assert from "node:assert";
 
 /**
- * Check if the score is the new best score and update the user profile if it is
- * @param {number} score
+ * Recompute `user_profile.best_score` from completed classic games.
+ *
+ * Profile best is a cache for personal UI only — all-time leaderboard aggregates
+ * from `game` rows. Never trust a client-submitted score here (that path used to
+ * allow inflated highs without a matching game).
+ *
  * @param {string} userId
+ * @returns {Promise<number | null>} The recomputed best score, or null if none
  */
-export async function saveScore(score, userId) {
+export async function syncBestScoreFromGames(userId) {
 	const userProfile = db
 		.select()
 		.from(table.userProfile)
@@ -17,12 +22,41 @@ export async function saveScore(score, userId) {
 
 	assert(userProfile, "User profile not found");
 
-	if (!userProfile.bestScore || score > userProfile.bestScore) {
-		await db
-			.update(table.userProfile)
-			.set({ bestScore: score })
-			.where(eq(table.userProfile.userId, userId));
-	}
+	const bestRow = db
+		.select({
+			bestScore: sql`max(${table.game.score})`,
+		})
+		.from(table.game)
+		.where(
+			and(
+				eq(table.game.playerId, userId),
+				eq(table.game.complete, true),
+				sql`${table.game.score} is not null`
+			)
+		)
+		.get();
+
+	const rawBest = bestRow?.bestScore;
+	const bestScore =
+		typeof rawBest === "number" && Number.isFinite(rawBest)
+			? rawBest
+			: typeof rawBest === "string" && rawBest !== "" && Number.isFinite(Number(rawBest))
+				? Number(rawBest)
+				: null;
+
+	await db.update(table.userProfile).set({ bestScore }).where(eq(table.userProfile.userId, userId));
+
+	return bestScore;
+}
+
+/**
+ * @deprecated Prefer syncBestScoreFromGames — client-submitted scores are ignored.
+ * Kept as the `/game?/saveScore` action target for older clients.
+ * @param {number} _score
+ * @param {string} userId
+ */
+export async function saveScore(_score, userId) {
+	await syncBestScoreFromGames(userId);
 }
 
 /**
@@ -157,6 +191,10 @@ export async function saveGame(game) {
 	// Keep a single current run: any other incomplete rows become history
 	if (game.id && !game.complete) {
 		await abandonOtherInProgressGames(game.playerId, game.id);
+		await syncBestScoreFromGames(game.playerId);
+	} else if (game.complete && typeof game.score === "number") {
+		// Refresh personal best cache from completed runs
+		await syncBestScoreFromGames(game.playerId);
 	}
 
 	return game.id;

--- a/src/lib/server/leaderboard.js
+++ b/src/lib/server/leaderboard.js
@@ -1,51 +1,8 @@
-import { eq, desc, count, and, gt, gte, lt, sql } from "drizzle-orm";
+import { eq, and, gte, lt, sql } from "drizzle-orm";
 import { CHALLENGE_RUN_STATUS, CHALLENGE_TYPES } from "$lib/challenges.js";
 import { USER_LEVELS } from "$lib/constants";
 import { db } from "$lib/server/db";
 import * as table from "$lib/server/db/schema";
-
-export async function getAllTimeLeaderboard() {
-	const leaderboard = await db
-		.select({
-			id: table.user.id,
-			username: table.user.username,
-			displayName: table.userProfile.displayName,
-			bestScore: table.userProfile.bestScore,
-		})
-		.from(table.user)
-		.innerJoin(table.userProfile, eq(table.user.id, table.userProfile.userId))
-		.where(eq(table.user.level, USER_LEVELS.PRO))
-		.orderBy(desc(table.userProfile.bestScore))
-		.limit(10);
-
-	return leaderboard;
-}
-
-/**
- * Get the rank of a user in the all time leaderboard
- * @param {string} userId
- */
-export async function getAllTimeUserRank(userId) {
-	const userResult = db
-		.select({
-			bestScore: table.userProfile.bestScore,
-		})
-		.from(table.userProfile)
-		.where(eq(table.userProfile.userId, userId))
-		.get();
-
-	const bestScore = userResult?.bestScore ?? 0;
-
-	const [{ count: betterUsersCount }] = await db
-		.select({
-			count: count(),
-		})
-		.from(table.user)
-		.innerJoin(table.userProfile, eq(table.user.id, table.userProfile.userId))
-		.where(and(eq(table.user.level, USER_LEVELS.PRO), gt(table.userProfile.bestScore, bestScore)));
-
-	return betterUsersCount + 1;
-}
 
 /**
  * Score attribution instant for a finished classic game.
@@ -54,16 +11,26 @@ export async function getAllTimeUserRank(userId) {
 const gameScoreAt = sql`coalesce(${table.game.completedOn}, ${table.game.updatedOn})`;
 
 /**
- * Best classic score per Pro user within a half-open time window [start, end).
- * Source: completed `game` rows (not all-time profile best).
+ * Best completed classic score per Pro user.
+ * Optional half-open time window [start, end). Omit both for all-time.
  *
- * @param {Date} start
- * @param {Date} end
+ * Source of truth: completed `game` rows (not denormalized profile best_score).
+ *
+ * @param {Date} [start]
+ * @param {Date} [end]
  * @returns {{ id: string; username: string; displayName: string | null; bestScore: number }[]}
  */
-function getClassicBestByUserInRange(start, end) {
-	const startMs = start.getTime();
-	const endMs = end.getTime();
+function getClassicBestByUser(start, end) {
+	/** @type {import("drizzle-orm").SQL[]} */
+	const conditions = [
+		eq(table.user.level, USER_LEVELS.PRO),
+		eq(table.game.complete, true),
+		sql`${table.game.score} is not null`,
+	];
+
+	if (start != null && end != null) {
+		conditions.push(gte(gameScoreAt, start.getTime()), lt(gameScoreAt, end.getTime()));
+	}
 
 	const rows = db
 		.select({
@@ -75,15 +42,7 @@ function getClassicBestByUserInRange(start, end) {
 		.from(table.game)
 		.innerJoin(table.user, eq(table.game.playerId, table.user.id))
 		.leftJoin(table.userProfile, eq(table.user.id, table.userProfile.userId))
-		.where(
-			and(
-				eq(table.user.level, USER_LEVELS.PRO),
-				eq(table.game.complete, true),
-				sql`${table.game.score} is not null`,
-				gte(gameScoreAt, startMs),
-				lt(gameScoreAt, endMs)
-			)
-		)
+		.where(and(...conditions))
 		.all();
 
 	/** @type {Map<string, { id: string; username: string; displayName: string | null; bestScore: number }>} */
@@ -107,13 +66,33 @@ function getClassicBestByUserInRange(start, end) {
 }
 
 /**
+ * All-time classic leaderboard from completed games (max score per Pro user).
+ * @param {number} [limit]
+ */
+export function getAllTimeLeaderboard(limit = 10) {
+	return getClassicBestByUser().slice(0, limit);
+}
+
+/**
+ * 1-based rank of a user on the all-time classic leaderboard, or null if no completed score.
+ * @param {string} userId
+ * @returns {{ rank: number; bestScore: number } | null}
+ */
+export function getAllTimeUserRank(userId) {
+	const ranked = getClassicBestByUser();
+	const index = ranked.findIndex((entry) => entry.id === userId);
+	if (index < 0) return null;
+	return { rank: index + 1, bestScore: ranked[index].bestScore };
+}
+
+/**
  * Classic high-score leaderboard for a time window.
  * @param {Date} start
  * @param {Date} end
  * @param {number} [limit]
  */
 export function getClassicPeriodLeaderboard(start, end, limit = 10) {
-	return getClassicBestByUserInRange(start, end).slice(0, limit);
+	return getClassicBestByUser(start, end).slice(0, limit);
 }
 
 /**
@@ -124,7 +103,7 @@ export function getClassicPeriodLeaderboard(start, end, limit = 10) {
  * @returns {{ rank: number; bestScore: number } | null}
  */
 export function getClassicPeriodUserRank(userId, start, end) {
-	const ranked = getClassicBestByUserInRange(start, end);
+	const ranked = getClassicBestByUser(start, end);
 	const index = ranked.findIndex((entry) => entry.id === userId);
 	if (index < 0) return null;
 	return { rank: index + 1, bestScore: ranked[index].bestScore };

--- a/src/routes/game/+page.js
+++ b/src/routes/game/+page.js
@@ -1,5 +1,6 @@
 import { browser } from "$app/environment";
-import { loadBestScore, loadGame } from "$lib/localStorage.svelte";
+import { deserialize } from "$app/forms";
+import { loadBestScore, loadGame, saveBestScore } from "$lib/localStorage.svelte";
 import { general, gameState } from "./state.svelte.js";
 
 /** @type {import("./$types").PageLoad} */
@@ -18,19 +19,29 @@ export async function load({ data, fetch }) {
 		// Load game from local storage
 		localGame = loadGame();
 
-		// Compare local vs db best score, take highest
-		const storageScore = loadBestScore();
-		gameState.bestScore = Math.max(gameState.bestScore, storageScore);
-		gameState.bestScore = Math.max(gameState.bestScore, bestScore);
-
-		// If the best score is higher than what came from the server, update the server
-		if (gameState.bestScore > bestScore) {
-			const form = new FormData();
-			form.append("score", `${gameState.bestScore}`);
-			await fetch("/game?/saveScore", {
+		if (user) {
+			// Authoritative personal best comes from completed games on the server.
+			// Resync (and overwrite inflated localStorage leftovers from old bugs).
+			const res = await fetch("/game?/saveScore", {
 				method: "POST",
-				body: form,
+				body: new FormData(),
 			});
+
+			if (res.ok) {
+				try {
+					const result = deserialize(await res.text());
+					if (result.type === "success" && typeof result.data?.bestScore === "number") {
+						bestScore = result.data.bestScore;
+					}
+				} catch {
+					// Fall back to profile bestScore from SSR
+				}
+			}
+
+			gameState.bestScore = Math.max(gameState.bestScore, bestScore);
+			saveBestScore(bestScore, { force: true });
+		} else {
+			gameState.bestScore = Math.max(gameState.bestScore, loadBestScore());
 		}
 	}
 

--- a/src/routes/game/+page.server.js
+++ b/src/routes/game/+page.server.js
@@ -1,6 +1,6 @@
 import { USER_LEVELS } from "$lib/constants.js";
 import { getActiveCheckpoint } from "$lib/server/checkpoint";
-import { getCurrentGame, saveScore } from "$lib/server/game";
+import { getCurrentGame, syncBestScoreFromGames } from "$lib/server/game";
 import { getUserProfile } from "$lib/server/user.js";
 import { fail } from "@sveltejs/kit";
 
@@ -43,15 +43,14 @@ export function load({ locals }) {
 
 /** @type {import("./$types").Actions} */
 export const actions = {
-	saveScore: async ({ request, locals }) => {
+	saveScore: async ({ locals }) => {
 		if (!locals.user) {
 			return fail(401, { message: "Not logged in." });
 		}
 
-		const formData = await request.formData();
-		const score = Number(formData.get("score"));
-		await saveScore(score, locals.user.id);
+		// Recompute personal best from completed games (ignore any client-submitted score).
+		const bestScore = await syncBestScoreFromGames(locals.user.id);
 
-		return { success: true };
+		return { success: true, bestScore: bestScore ?? 0 };
 	},
 };

--- a/src/routes/leaderboard/+page.server.js
+++ b/src/routes/leaderboard/+page.server.js
@@ -8,16 +8,23 @@ export async function load({ locals }) {
 		user = getUserProfile(locals.user.id);
 	}
 
-	const leaderboard = await getAllTimeLeaderboard();
+	const leaderboard = getAllTimeLeaderboard();
 	let userRank = null;
+	/** @type {number | null} */
+	let userBestScore = null;
 
 	if (user) {
-		userRank = await getAllTimeUserRank(user.id);
+		const rankInfo = getAllTimeUserRank(user.id);
+		if (rankInfo) {
+			userRank = rankInfo.rank;
+			userBestScore = rankInfo.bestScore;
+		}
 	}
 
 	return {
 		user,
 		userRank,
+		userBestScore,
 		leaderboard,
 	};
 }

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -6,9 +6,10 @@
 	let { data } = $props();
 
 	let showUserRow = $derived(
-		!!data.userRank &&
+		data.userRank != null &&
+			data.userBestScore != null &&
 			data.user?.level === USER_LEVELS.PRO &&
-			!data.leaderboard.some((l) => l.username === data.user?.username)
+			!data.leaderboard.some((l) => l.id === data.user?.id)
 	);
 </script>
 
@@ -25,7 +26,7 @@
 		</Table.Row>
 	</Table.Header>
 	<Table.Body>
-		{#each data.leaderboard as leaderboardItem, index (index)}
+		{#each data.leaderboard as leaderboardItem, index (leaderboardItem.id)}
 			<Table.Row class={index % 2 === 0 ? "bg-muted/60" : "bg-background"}>
 				<Table.Cell class="w-16 px-4 py-3 font-semibold text-foreground"># {index + 1}</Table.Cell>
 				<Table.Cell class="px-4 py-3 font-medium text-foreground">
@@ -53,7 +54,7 @@
 					{data.user?.displayName || data.user?.username}
 				</Table.Cell>
 				<Table.Cell class="px-4 py-3 text-end font-bold text-foreground">
-					{(data.user?.bestScore || 0).toLocaleString()}
+					{data.userBestScore?.toLocaleString()}
 				</Table.Cell>
 			</Table.Row>
 		{/if}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Your assumption that there is a separate “gains” ledger wasn’t quite right — validated and adjusted as follows:

**How it actually worked**
- Personal high score lived on `user_profile.best_score` (not on `user`)
- All-time `/leaderboard` ranked by that denormalized field
- Daily/weekly/monthly boards already used `MAX(score)` from completed `game` rows
- There is no gains table; the durable per-run scores are `game.score`
- `POST /game?/saveScore` previously accepted any client number with no game check — likely how inflated production highs got in

**What this PR does**
1. Migration `0013_wipe_profile_best_scores` sets all `user_profile.best_score` to `NULL`
2. All-time leaderboard now aggregates from completed Pro `game` rows (same pattern as period boards)
3. Personal best is recomputed from completed games (`syncBestScoreFromGames`); client-submitted scores are ignored
4. On `/game` load, logged-in users resync and force-overwrite inflated localStorage best scores

**Caveat:** if some of the buggy scores were also saved into `game` rows, those will still appear on the new all-time board. Only the unvalidated profile field is wiped. Period and challenge boards were already game/`challenge_run`-based and are unchanged.

## Test plan
- [x] `pnpm db:migrate` applies wipe migration
- [x] Seeded inflated `best_score=999999` with real game scores → `/leaderboard` shows game MAX (bob 800, alice 500, carol 450), not 999999
- [x] Free users excluded; users with no completed games omitted
- [x] `pnpm lint` passes
- [ ] Deploy + migrate production; spot-check all-time board vs a known completed game history

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6bab-02eb-7fd0-b3a6-f1a4074f5da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6bab-02eb-7fd0-b3a6-f1a4074f5da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

