### PR TITLE
Rank time challenges by completion speed instead of points

### DIFF
--- a/src/lib/challenges.js
+++ b/src/lib/challenges.js
@@ -307,7 +307,7 @@ export function formatChallengeObjective(challenge) {
 
 	if (type === CHALLENGE_TYPES.TIME) {
 		const p = /** @type {TimeChallengeParams} */ (params);
-		return `Score ${p.targetScore.toLocaleString()} in ${p.durationSec}s`;
+		return `Score ${p.targetScore.toLocaleString()} as fast as you can (${p.durationSec}s limit)`;
 	}
 
 	if (type === CHALLENGE_TYPES.RECOVERY) {
@@ -327,7 +327,7 @@ export function formatChallengeOverview(challenge) {
 
 	if (type === CHALLENGE_TYPES.TIME) {
 		const p = /** @type {TimeChallengeParams} */ (params);
-		return `Score ${p.targetScore.toLocaleString()} in ${p.durationSec}s. Timeout or game over fails.`;
+		return `Score ${p.targetScore.toLocaleString()} as fast as you can within ${p.durationSec}s. Faster clears rank higher. Timeout or game over fails.`;
 	}
 
 	if (type === CHALLENGE_TYPES.RECOVERY) {
@@ -336,6 +336,35 @@ export function formatChallengeOverview(challenge) {
 	}
 
 	return challenge.description ?? "";
+}
+
+/**
+ * Format a challenge completion time for leaderboards and stats.
+ * @param {number | null | undefined} ms
+ * @returns {string}
+ */
+export function formatChallengeElapsedMs(ms) {
+	if (typeof ms !== "number" || !Number.isFinite(ms) || ms < 0) return "—";
+	const totalSec = ms / 1000;
+	if (totalSec < 60) {
+		return `${totalSec.toFixed(1)}s`;
+	}
+	const minutes = Math.floor(totalSec / 60);
+	const seconds = totalSec - minutes * 60;
+	return `${minutes}:${seconds.toFixed(1).padStart(4, "0")}`;
+}
+
+/**
+ * Format a daily-challenge leaderboard / rank metric for display.
+ * @param {typeof CHALLENGE_TYPES[keyof typeof CHALLENGE_TYPES]} type
+ * @param {number | null | undefined} value elapsed ms (time) or move count (recovery)
+ */
+export function formatChallengeRankValue(type, value) {
+	if (type === CHALLENGE_TYPES.TIME) {
+		return formatChallengeElapsedMs(value);
+	}
+	if (typeof value !== "number" || !Number.isFinite(value)) return "—";
+	return value.toLocaleString();
 }
 
 /**

--- a/src/lib/server/challenge.js
+++ b/src/lib/server/challenge.js
@@ -109,9 +109,19 @@ function moveCountFromMetrics(metrics) {
 }
 
 /**
+ * @param {unknown} metrics
+ * @returns {number | null}
+ */
+function elapsedMsFromMetrics(metrics) {
+	if (!metrics || typeof metrics !== "object") return null;
+	const value = /** @type {{ elapsedMs?: unknown }} */ (metrics).elapsedMs;
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+/**
  * @param {string} userId
  * @param {string[]} challengeIds
- * @returns {Record<string, { bestStatus: string | null; attempts: number; wins: number; bestMoveCount: number | null; bestScore: number | null }>}
+ * @returns {Record<string, { bestStatus: string | null; attempts: number; wins: number; bestMoveCount: number | null; bestElapsedMs: number | null; bestScore: number | null }>}
  */
 export function getChallengeStatsForUser(userId, challengeIds = []) {
 	const runs = db
@@ -125,7 +135,7 @@ export function getChallengeStatsForUser(userId, challengeIds = []) {
 		.where(eq(table.challengeRun.userId, userId))
 		.all();
 
-	/** @type {Record<string, { bestStatus: string | null; attempts: number; wins: number; bestMoveCount: number | null; bestScore: number | null }>} */
+	/** @type {Record<string, { bestStatus: string | null; attempts: number; wins: number; bestMoveCount: number | null; bestElapsedMs: number | null; bestScore: number | null }>} */
 	const stats = {};
 
 	for (const challengeId of challengeIds) {
@@ -134,6 +144,7 @@ export function getChallengeStatsForUser(userId, challengeIds = []) {
 			attempts: 0,
 			wins: 0,
 			bestMoveCount: null,
+			bestElapsedMs: null,
 			bestScore: null,
 		};
 	}
@@ -145,6 +156,7 @@ export function getChallengeStatsForUser(userId, challengeIds = []) {
 				attempts: 0,
 				wins: 0,
 				bestMoveCount: null,
+				bestElapsedMs: null,
 				bestScore: null,
 			};
 		}
@@ -158,6 +170,10 @@ export function getChallengeStatsForUser(userId, challengeIds = []) {
 			const moves = moveCountFromMetrics(run.metrics);
 			if (moves != null && (entry.bestMoveCount == null || moves < entry.bestMoveCount)) {
 				entry.bestMoveCount = moves;
+			}
+			const elapsed = elapsedMsFromMetrics(run.metrics);
+			if (elapsed != null && (entry.bestElapsedMs == null || elapsed < entry.bestElapsedMs)) {
+				entry.bestElapsedMs = elapsed;
 			}
 			if (
 				typeof run.score === "number" &&

--- a/src/lib/server/db/schema/challengeSchemas.js
+++ b/src/lib/server/db/schema/challengeSchemas.js
@@ -30,8 +30,12 @@ export const challengeRun = sqliteTable("challenge_run", {
 		.notNull()
 		.references(() => user.id, { onDelete: "cascade" }),
 	status: text("status").notNull(),
+	/**
+	 * Ranking metric for wins: elapsed ms for time challenges, move count for recovery.
+	 * Merge points live in metrics.mergeScore.
+	 */
 	score: integer("score").notNull().default(0),
-	/** Extra metrics JSON: elapsedMs, filledCells, moveCount, etc. */
+	/** Extra metrics JSON: elapsedMs, filledCells, moveCount, mergeScore, etc. */
 	metrics: text("metrics", { mode: "json" }),
 	startedOn: integer("started_on", { mode: "timestamp" }).notNull(),
 	finishedOn: integer("finished_on", { mode: "timestamp" }),

--- a/src/lib/server/leaderboard.js
+++ b/src/lib/server/leaderboard.js
@@ -131,16 +131,37 @@ export function getClassicPeriodUserRank(userId, start, end) {
 }
 
 /**
- * Whether lower scores rank better for this challenge type.
- * Time challenges store points (higher better); recovery stores move count (lower better).
+ * Ranking value for a winning challenge run.
+ * Time challenges rank by elapsed ms (prefer metrics.elapsedMs; score stores ms on new clears).
+ * Recovery challenges rank by move count stored in score.
+ *
+ * @param {{ score: number | null; metrics: unknown }} win
  * @param {string} challengeType
+ * @returns {number | null}
  */
-function isLowerBetter(challengeType) {
-	return challengeType === CHALLENGE_TYPES.RECOVERY;
+function rankingValueFromWin(win, challengeType) {
+	if (challengeType === CHALLENGE_TYPES.TIME) {
+		if (win.metrics && typeof win.metrics === "object") {
+			const elapsed = /** @type {{ elapsedMs?: unknown }} */ (win.metrics).elapsedMs;
+			if (typeof elapsed === "number" && Number.isFinite(elapsed) && elapsed >= 0) {
+				return elapsed;
+			}
+		}
+		if (typeof win.score === "number" && Number.isFinite(win.score) && win.score >= 0) {
+			return win.score;
+		}
+		return null;
+	}
+
+	if (typeof win.score !== "number" || !Number.isFinite(win.score)) return null;
+	return win.score;
 }
 
 /**
- * Best winning score per user for a daily challenge, ordered for the leaderboard.
+ * Best winning run per user for a daily challenge, ordered for the leaderboard.
+ * Both time (elapsed ms) and recovery (move count) rank lower-is-better.
+ * `bestScore` is the ranking metric value (ms or moves).
+ *
  * @param {string} challengeId
  * @param {string} challengeType
  * @returns {{ id: string; username: string; displayName: string | null; bestScore: number }[]}
@@ -150,6 +171,7 @@ function getBestWinsByUser(challengeId, challengeType) {
 		.select({
 			userId: table.challengeRun.userId,
 			score: table.challengeRun.score,
+			metrics: table.challengeRun.metrics,
 			username: table.user.username,
 			displayName: table.userProfile.displayName,
 		})
@@ -164,27 +186,26 @@ function getBestWinsByUser(challengeId, challengeType) {
 		)
 		.all();
 
-	const lowerBetter = isLowerBetter(challengeType);
 	/** @type {Map<string, { id: string; username: string; displayName: string | null; bestScore: number }>} */
 	const bestByUser = new Map();
 
 	for (const win of wins) {
-		if (typeof win.score !== "number" || !Number.isFinite(win.score)) continue;
+		const value = rankingValueFromWin(win, challengeType);
+		if (value == null) continue;
 		const existing = bestByUser.get(win.userId);
-		const isBetter =
-			!existing || (lowerBetter ? win.score < existing.bestScore : win.score > existing.bestScore);
+		const isBetter = !existing || value < existing.bestScore;
 		if (isBetter) {
 			bestByUser.set(win.userId, {
 				id: win.userId,
 				username: win.username,
 				displayName: win.displayName ?? null,
-				bestScore: win.score,
+				bestScore: value,
 			});
 		}
 	}
 
 	const ranked = [...bestByUser.values()];
-	ranked.sort((a, b) => (lowerBetter ? a.bestScore - b.bestScore : b.bestScore - a.bestScore));
+	ranked.sort((a, b) => a.bestScore - b.bestScore);
 	return ranked;
 }
 

--- a/src/routes/challenges/[id]/+page.svelte
+++ b/src/routes/challenges/[id]/+page.svelte
@@ -5,6 +5,8 @@
 	import {
 		CHALLENGE_RUN_STATUS,
 		CHALLENGE_TYPES,
+		formatChallengeElapsedMs,
+		formatChallengeRankValue,
 		formatChallengeTypeLabel,
 	} from "$lib/challenges.js";
 	import { Button } from "$lib/components/ui/button/index.js";
@@ -24,8 +26,6 @@
 	);
 
 	const leaderboardHref = $derived(`/challenges/${challenge.id}/leaderboard`);
-
-	const scoreUnit = $derived(challenge.type === CHALLENGE_TYPES.RECOVERY ? "moves" : "pts");
 
 	function onStart() {
 		starting = true;
@@ -115,8 +115,8 @@
 					({data.stats.attempts} attempt{data.stats.attempts === 1 ? "" : "s"}).
 					{#if challenge.type === CHALLENGE_TYPES.RECOVERY && data.stats.bestMoveCount != null}
 						Best: {data.stats.bestMoveCount} move{data.stats.bestMoveCount === 1 ? "" : "s"}.
-					{:else if challenge.type === CHALLENGE_TYPES.TIME && data.stats.bestScore != null}
-						Best score: {data.stats.bestScore.toLocaleString()}.
+					{:else if challenge.type === CHALLENGE_TYPES.TIME && data.stats.bestElapsedMs != null}
+						Best time: {formatChallengeElapsedMs(data.stats.bestElapsedMs)}.
 					{/if}
 				{:else if data.stats.attempts > 0}
 					{data.stats.attempts} attempt{data.stats.attempts === 1 ? "" : "s"} so far — keep going!
@@ -179,8 +179,10 @@
 							<span class="font-normal opacity-80">of {data.entryCount}</span>
 						{/if}
 						<span class="font-normal opacity-80">
-							· {data.userBestScore.toLocaleString()}
-							{scoreUnit}
+							· {formatChallengeRankValue(challenge.type, data.userBestScore)}
+							{#if challenge.type === CHALLENGE_TYPES.RECOVERY}
+								moves
+							{/if}
 						</span>
 					</span>
 				{:else if data.entryCount > 0}

--- a/src/routes/challenges/[id]/leaderboard/+page.svelte
+++ b/src/routes/challenges/[id]/leaderboard/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { CHALLENGE_TYPES } from "$lib/challenges.js";
+	import { CHALLENGE_TYPES, formatChallengeRankValue } from "$lib/challenges.js";
 	import { Badge } from "$lib/components/ui/badge/index.js";
 	import * as Table from "$lib/components/ui/table/index.js";
 	import { ArrowLeftIcon } from "@lucide/svelte";
@@ -7,7 +7,7 @@
 	let { data } = $props();
 
 	const challenge = $derived(data.challenge);
-	const scoreLabel = $derived(challenge.type === CHALLENGE_TYPES.RECOVERY ? "Moves" : "Score");
+	const scoreLabel = $derived(challenge.type === CHALLENGE_TYPES.RECOVERY ? "Moves" : "Time");
 
 	const showUserRow = $derived(
 		data.userRank != null &&
@@ -61,7 +61,7 @@
 		{#if challenge.type === CHALLENGE_TYPES.RECOVERY}
 			· fewer moves ranks higher
 		{:else}
-			· higher score ranks higher
+			· faster time ranks higher
 		{/if}
 	</p>
 	<p class="mb-6 text-sm text-muted-foreground">{data.overview}</p>
@@ -98,7 +98,7 @@
 							{/if}
 						</Table.Cell>
 						<Table.Cell class="px-4 py-3 text-end font-bold text-foreground">
-							{leaderboardItem.bestScore?.toLocaleString()}
+							{formatChallengeRankValue(challenge.type, leaderboardItem.bestScore)}
 						</Table.Cell>
 					</Table.Row>
 				{/each}
@@ -116,7 +116,7 @@
 							{data.user?.displayName || data.user?.username}
 						</Table.Cell>
 						<Table.Cell class="px-4 py-3 text-end font-bold text-foreground">
-							{data.userBestScore?.toLocaleString()}
+							{formatChallengeRankValue(challenge.type, data.userBestScore)}
 						</Table.Cell>
 					</Table.Row>
 				{/if}

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -11,6 +11,7 @@
 		CHALLENGE_TYPES,
 		countFilledCells,
 		evaluateChallenge,
+		formatChallengeElapsedMs,
 	} from "$lib/challenges.js";
 	import { Button } from "$lib/components/ui/button/index.js";
 	import AnimatedBoard from "../../../game/components/AnimatedBoard.svelte";
@@ -21,6 +22,8 @@
 	let game = $state(null);
 	let result = $state(/** @type {'won' | 'lost' | null} */ (null));
 	let remainingMs = $state(0);
+	/** Elapsed ms captured when the run finishes (time challenges). */
+	let finishedElapsedMs = $state(/** @type {number | null} */ (null));
 	let submitting = $state(false);
 	let retrying = $state(false);
 
@@ -74,6 +77,7 @@
 		pendingEvents = [];
 		game = createChallengeGame();
 		result = null;
+		finishedElapsedMs = null;
 		submitting = false;
 		retrying = false;
 
@@ -99,6 +103,9 @@
 	function finish(status) {
 		if (result || submitting || data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) return;
 		result = status;
+		if (isTime) {
+			finishedElapsedMs = Math.max(0, Date.now() - data.run.startedOn);
+		}
 		submitting = true;
 		queueMicrotask(() => completeForm?.requestSubmit());
 	}
@@ -177,6 +184,12 @@
 
 		if (status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) {
 			result = status === CHALLENGE_RUN_STATUS.WON ? "won" : "lost";
+			const metrics = data.run.metrics;
+			if (metrics && typeof metrics === "object") {
+				const elapsed = /** @type {{ elapsedMs?: unknown }} */ (metrics).elapsedMs;
+				finishedElapsedMs =
+					typeof elapsed === "number" && Number.isFinite(elapsed) ? elapsed : null;
+			}
 			return;
 		}
 
@@ -246,7 +259,11 @@
 	<input
 		type="hidden"
 		name="score"
-		value={isRecovery ? (game?.moveCount ?? 0) : (game?.score ?? 0)}
+		value={isRecovery
+			? (game?.moveCount ?? 0)
+			: isTime
+				? (finishedElapsedMs ?? Math.max(0, Date.now() - data.run.startedOn))
+				: (game?.score ?? 0)}
 	/>
 	<input
 		type="hidden"
@@ -254,8 +271,10 @@
 		value={JSON.stringify({
 			moveCount: game?.moveCount ?? 0,
 			filledCells: game ? countFilledCells(game.board) : 0,
-			elapsedMs: isTime ? Date.now() - data.run.startedOn : undefined,
-			mergeScore: isRecovery ? (game?.score ?? 0) : undefined,
+			elapsedMs: isTime
+				? (finishedElapsedMs ?? Math.max(0, Date.now() - data.run.startedOn))
+				: undefined,
+			mergeScore: game?.score ?? 0,
 		})}
 	/>
 </form>
@@ -351,6 +370,9 @@
 			<p class="mb-4 text-sm text-muted-foreground">
 				{#if isRecovery}
 					Moves: {game?.moveCount ?? 0}
+				{:else if isTime}
+					Time: {formatChallengeElapsedMs(finishedElapsedMs)}
+					· Score: {game?.score.toLocaleString() ?? 0}
 				{:else}
 					Score: {game?.score.toLocaleString() ?? 0}
 				{/if}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Time-mode daily challenges (Point Rush, Score Sprint, etc.) used to rank by merge score. They now rank by **time to reach the target score** (faster clears rank higher), consistent with recovery’s fewest-moves ranking.

## Changes
- Persist elapsed ms as the run’s ranking `score` for time clears (merge points stay in `metrics.mergeScore`)
- Leaderboard prefers `metrics.elapsedMs` so existing clears re-rank correctly
- Update challenge copy, detail stats, leaderboard column/labels, and finish overlay to show time

## Test plan
- [ ] Play a time challenge, clear it, and confirm the finish overlay shows elapsed time
- [ ] Confirm the challenge leaderboard sorts fastest clears first and labels the column “Time”
- [ ] Confirm recovery challenges still rank by fewest moves
- [ ] Confirm personal best on the challenge detail page shows “Best time” for time modes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6bae-3d23-759b-b8c5-fc77f8d38008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6bae-3d23-759b-b8c5-fc77f8d38008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

