### PR TITLE
Remove completed games without replay data

### DIFF
--- a/drizzle/0014_remove_unreplayable_games.sql
+++ b/drizzle/0014_remove_unreplayable_games.sql
@@ -1,0 +1,30 @@
+-- Delete completed classic games that cannot be deterministically replayed
+-- (missing seed, null/empty moves, or moves length ≠ move_count). These include
+-- legacy saves, cheat/transform-invalidated runs, checkpoint restores, and
+-- potentially fabricated scores that never recorded a move history.
+--
+-- In-progress games are left alone (e.g. an active post-checkpoint run still
+-- has moves=null until it finishes). Checkpoints cascade-delete with their game.
+DELETE FROM `game`
+WHERE `complete` = 1
+	AND (
+		`seed` IS NULL
+		OR `moves` IS NULL
+		OR json_array_length(`moves`) IS NULL
+		OR json_array_length(`moves`) = 0
+		OR json_array_length(`moves`) != `move_count`
+	);
+--> statement-breakpoint
+-- Recompute personal best cache from remaining replayable completed games.
+UPDATE `user_profile`
+SET `best_score` = (
+	SELECT MAX(`g`.`score`)
+	FROM `game` AS `g`
+	WHERE `g`.`player_id` = `user_profile`.`user_id`
+		AND `g`.`complete` = 1
+		AND `g`.`score` IS NOT NULL
+		AND `g`.`seed` IS NOT NULL
+		AND `g`.`moves` IS NOT NULL
+		AND json_array_length(`g`.`moves`) > 0
+		AND json_array_length(`g`.`moves`) = `g`.`move_count`
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1784079000000,
       "tag": "0013_wipe_profile_best_scores",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1784080000000,
+      "tag": "0014_remove_unreplayable_games",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -4,11 +4,28 @@ import { and, desc, eq, ne, not, sql } from "drizzle-orm";
 import assert from "node:assert";
 
 /**
+ * SQL predicate matching {@link gameHasReplay}: seed + non-empty moves whose
+ * length equals move_count. Use for leaderboard / best-score queries so
+ * unverifiable (cheat / checkpoint / legacy) scores cannot rank.
+ *
+ * @type {import("drizzle-orm").SQL}
+ */
+export const gameHasReplaySql = /** @type {import("drizzle-orm").SQL} */ (
+	and(
+		sql`${table.game.seed} is not null`,
+		sql`${table.game.moves} is not null`,
+		sql`json_array_length(${table.game.moves}) > 0`,
+		sql`json_array_length(${table.game.moves}) = ${table.game.moveCount}`
+	)
+);
+
+/**
  * Recompute `user_profile.best_score` from completed classic games.
  *
  * Profile best is a cache for personal UI only — all-time leaderboard aggregates
- * from `game` rows. Never trust a client-submitted score here (that path used to
- * allow inflated highs without a matching game).
+ * from `game` rows. Only replayable games count (seed + matching move history).
+ * Never trust a client-submitted score here (that path used to allow inflated
+ * highs without a matching game).
  *
  * @param {string} userId
  * @returns {Promise<number | null>} The recomputed best score, or null if none
@@ -31,7 +48,8 @@ export async function syncBestScoreFromGames(userId) {
 			and(
 				eq(table.game.playerId, userId),
 				eq(table.game.complete, true),
-				sql`${table.game.score} is not null`
+				sql`${table.game.score} is not null`,
+				gameHasReplaySql
 			)
 		)
 		.get();

--- a/src/lib/server/leaderboard.js
+++ b/src/lib/server/leaderboard.js
@@ -3,6 +3,7 @@ import { CHALLENGE_RUN_STATUS, CHALLENGE_TYPES } from "$lib/challenges.js";
 import { USER_LEVELS } from "$lib/constants";
 import { db } from "$lib/server/db";
 import * as table from "$lib/server/db/schema";
+import { gameHasReplaySql } from "$lib/server/game";
 
 /**
  * Score attribution instant for a finished classic game.
@@ -14,7 +15,8 @@ const gameScoreAt = sql`coalesce(${table.game.completedOn}, ${table.game.updated
  * Best completed classic score per Pro user.
  * Optional half-open time window [start, end). Omit both for all-time.
  *
- * Source of truth: completed `game` rows (not denormalized profile best_score).
+ * Source of truth: completed, replayable `game` rows (not denormalized profile
+ * best_score). Games without seed+moves cannot be verified and do not rank.
  *
  * @param {Date} [start]
  * @param {Date} [end]
@@ -26,6 +28,7 @@ function getClassicBestByUser(start, end) {
 		eq(table.user.level, USER_LEVELS.PRO),
 		eq(table.game.complete, true),
 		sql`${table.game.score} is not null`,
+		gameHasReplaySql,
 	];
 
 	if (start != null && end != null) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Completed classic games without a verifiable replay (`seed` + matching `moves` history) cannot be trusted for rankings — that includes legacy saves, cheat/transform-invalidated runs, checkpoint restores, and potentially fabricated scores.

This change:

1. **Migration `0014_remove_unreplayable_games`** — deletes completed `game` rows that fail the same checks as `gameHasReplay()`, then recomputes `user_profile.best_score` from remaining replayable games. In-progress games (e.g. an active post-checkpoint run) are left alone; checkpoints cascade-delete with their parent game.

2. **Leaderboard + best-score sync** — classic leaderboards and `syncBestScoreFromGames` only count games that pass `gameHasReplaySql`, so unverifiable scores cannot reappear after deploy.

## How to apply
On deploy (or locally): `pnpm db:migrate`

## Note
Personal game history can still show future completed games marked “No replay” (e.g. finish after a checkpoint). Those no longer affect profile best or classic leaderboards.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f6bbb-7399-74e5-ae17-382e66479d92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f6bbb-7399-74e5-ae17-382e66479d92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

