### PR TITLE
Include active games on classic leaderboard and history

### DIFF
--- a/src/lib/components/ClassicPeriodLeaderboard.svelte
+++ b/src/lib/components/ClassicPeriodLeaderboard.svelte
@@ -79,18 +79,19 @@
 </div>
 
 <p class="mb-4 text-center text-xs text-muted-foreground">
-	Best completed classic game score for this {periodNoun} (Central Time).
+	Best classic score (including active runs) last updated this {periodNoun} (Central Time).
 </p>
 
 {#if data.leaderboard.length === 0}
 	<p class="rounded-lg bg-muted px-4 py-8 text-center text-sm text-muted-foreground">
-		No completed scores for this {periodNoun} yet.
+		No scores for this {periodNoun} yet.
 	</p>
 {:else}
 	<Table.Root class="overflow-hidden rounded-lg border">
 		<Table.Header>
 			<Table.Row class="bg-secondary hover:bg-secondary">
-				<Table.Head class="px-4 py-3 text-sm font-semibold tracking-wide uppercase">Rank</Table.Head>
+				<Table.Head class="px-4 py-3 text-sm font-semibold tracking-wide uppercase">Rank</Table.Head
+				>
 				<Table.Head class="px-4 py-3 text-sm font-semibold tracking-wide uppercase">
 					Username
 				</Table.Head>

--- a/src/lib/server/db/schema/gameSchemas.ts
+++ b/src/lib/server/db/schema/gameSchemas.ts
@@ -9,10 +9,16 @@ export const game = sqliteTable("game", {
 		.notNull()
 		.references(() => user.id, { onDelete: "cascade" }),
 	createdOn: integer("created_on", { mode: "timestamp" }).notNull(),
+	/** Last activity (every autosave). Period leaderboards key off this. */
 	updatedOn: integer("updated_on", { mode: "timestamp" }).notNull(),
+	/**
+	 * When the run finished or first reached a win — not a copy of updatedOn.
+	 * Freezes on first win / finalize while updatedOn keeps moving (Keep Playing).
+	 */
 	completedOn: integer("completed_on", { mode: "timestamp" }),
 	score: integer("score"),
 	won: integer("won", { mode: "boolean" }).notNull(),
+	/** false = active run; true = finished (including abandoned prior runs) */
 	complete: integer("complete", { mode: "boolean" }).notNull(),
 	board: text("board", { mode: "json" }).$type<number[][]>().notNull(),
 	/** Recorded move directions (see DIRECTIONS) for Pro replay — null when not replayable */

--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -20,10 +20,11 @@ export const gameHasReplaySql = /** @type {import("drizzle-orm").SQL} */ (
 );
 
 /**
- * Recompute `user_profile.best_score` from completed classic games.
+ * Recompute `user_profile.best_score` from classic games (active or finished).
  *
  * Profile best is a cache for personal UI only — all-time leaderboard aggregates
  * from `game` rows. Only replayable games count (seed + matching move history).
+ * Incomplete runs count: score only increases within a game.
  * Never trust a client-submitted score here (that path used to allow inflated
  * highs without a matching game).
  *
@@ -45,12 +46,7 @@ export async function syncBestScoreFromGames(userId) {
 		})
 		.from(table.game)
 		.where(
-			and(
-				eq(table.game.playerId, userId),
-				eq(table.game.complete, true),
-				sql`${table.game.score} is not null`,
-				gameHasReplaySql
-			)
+			and(eq(table.game.playerId, userId), sql`${table.game.score} is not null`, gameHasReplaySql)
 		)
 		.get();
 
@@ -104,9 +100,9 @@ export function gameHasReplay(game) {
 /**
  * Mark every other in-progress game for this user as complete.
  *
- * A player should only have one current (incomplete) run. Older incomplete rows
- * (e.g. abandoned after Keep Playing → New Game) would otherwise never appear
- * in history, which requires complete === true.
+ * A player should only have one active (`complete !== true`) run. Older incomplete
+ * rows (e.g. abandoned after Keep Playing → New Game) are finalized so history
+ * shows them as finished rather than competing "active" sessions.
  *
  * Performance: one UPDATE by player_id; usually matches 0 rows.
  *
@@ -235,14 +231,22 @@ export function getCurrentGame(userId) {
 }
 
 /**
- * List completed games for history (Pro feature).
+ * Derived history status from the `complete` flag.
+ * No separate DB status column: `complete === false` means active; true means finished
+ * (including abandoned prior runs finalized by New Game / abandonOtherInProgressGames).
  *
- * Incomplete (current) games are out of scope: there is at most one active run
- * per user (`getCurrentGame`), resumed from `/game`. History is for finished
- * sessions (win or loss); listing mid-run rows would duplicate that surface and
- * offer awkward partial replays that end before game over. When a player starts
- * a new game, `abandonOtherInProgressGames` / New Game finalization marks the
- * prior run complete so it appears here.
+ * @param {boolean} complete
+ * @returns {import("$lib/types").GameHistoryStatus}
+ */
+export function gameHistoryStatus(complete) {
+	return complete ? "finished" : "active";
+}
+
+/**
+ * List games for history (Pro feature) — active and finished.
+ *
+ * Status is derived (`active` | `finished`) from `complete`; we do not store a
+ * separate status enum unless abandoned needs to differ from finished later.
  *
  * @param {string} userId
  * @param {{
@@ -253,23 +257,21 @@ export function getCurrentGame(userId) {
  * }} [options]
  * @returns {import("$lib/types").GameHistoryEntry[]}
  */
-export function getCompletedGames(userId, options = {}) {
+export function getGameHistory(userId, options = {}) {
 	const sort = options.sort ?? "date";
 	const filter = options.filter ?? "all";
 	const limit = options.limit ?? 50;
 	const offset = options.offset ?? 0;
 
-	/** @type {import("drizzle-orm").SQL | undefined} */
-	let filterClause;
-	if (filter === "won") {
-		filterClause = eq(table.game.won, true);
+	/** @type {import("drizzle-orm").SQL[]} */
+	const conditions = [eq(table.game.playerId, userId)];
+	if (filter === "active") {
+		conditions.push(not(eq(table.game.complete, true)));
+	} else if (filter === "won") {
+		conditions.push(eq(table.game.won, true));
 	} else if (filter === "lost") {
-		filterClause = and(eq(table.game.won, false), eq(table.game.complete, true));
+		conditions.push(eq(table.game.won, false), eq(table.game.complete, true));
 	}
-
-	const whereClause = filterClause
-		? and(eq(table.game.playerId, userId), eq(table.game.complete, true), filterClause)
-		: and(eq(table.game.playerId, userId), eq(table.game.complete, true));
 
 	/** @type {import("drizzle-orm").SQL[]} */
 	let orderBy;
@@ -278,11 +280,8 @@ export function getCompletedGames(userId, options = {}) {
 	} else if (sort === "moves") {
 		orderBy = [desc(table.game.moveCount), desc(table.game.updatedOn)];
 	} else {
-		// Prefer completedOn when present, fall back to updatedOn
-		orderBy = [
-			desc(sql`coalesce(${table.game.completedOn}, ${table.game.updatedOn})`),
-			desc(table.game.updatedOn),
-		];
+		// Last activity — works for active runs and finished ones alike
+		orderBy = [desc(table.game.updatedOn)];
 	}
 
 	const rows = db
@@ -299,7 +298,7 @@ export function getCompletedGames(userId, options = {}) {
 			moves: table.game.moves,
 		})
 		.from(table.game)
-		.where(whereClause)
+		.where(and(...conditions))
 		.orderBy(...orderBy)
 		.limit(limit)
 		.offset(offset)
@@ -310,6 +309,7 @@ export function getCompletedGames(userId, options = {}) {
 		score: row.score ?? 0,
 		won: row.won,
 		complete: row.complete,
+		status: gameHistoryStatus(row.complete),
 		moveCount: row.moveCount,
 		createdOn: row.createdOn,
 		updatedOn: row.updatedOn,
@@ -323,19 +323,35 @@ export function getCompletedGames(userId, options = {}) {
 }
 
 /**
- * Get a completed game owned by the user (for replay)
+ * @deprecated Use {@link getGameHistory}
+ * @param {string} userId
+ * @param {Parameters<typeof getGameHistory>[1]} [options]
+ */
+export function getCompletedGames(userId, options = {}) {
+	return getGameHistory(userId, options);
+}
+
+/**
+ * Get a game owned by the user (for replay of finished or in-progress runs)
  *
  * @param {string} gameId
  * @param {string} userId
  */
-export function getCompletedGameById(gameId, userId) {
+export function getOwnedGameById(gameId, userId) {
 	const game = db
 		.select()
 		.from(table.game)
-		.where(
-			and(eq(table.game.id, gameId), eq(table.game.playerId, userId), eq(table.game.complete, true))
-		)
+		.where(and(eq(table.game.id, gameId), eq(table.game.playerId, userId)))
 		.get();
 
 	return game ?? null;
+}
+
+/**
+ * @deprecated Use {@link getOwnedGameById}
+ * @param {string} gameId
+ * @param {string} userId
+ */
+export function getCompletedGameById(gameId, userId) {
+	return getOwnedGameById(gameId, userId);
 }

--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -235,7 +235,14 @@ export function getCurrentGame(userId) {
 }
 
 /**
- * List completed games for history (Pro feature)
+ * List completed games for history (Pro feature).
+ *
+ * Incomplete (current) games are out of scope: there is at most one active run
+ * per user (`getCurrentGame`), resumed from `/game`. History is for finished
+ * sessions (win or loss); listing mid-run rows would duplicate that surface and
+ * offer awkward partial replays that end before game over. When a player starts
+ * a new game, `abandonOtherInProgressGames` / New Game finalization marks the
+ * prior run complete so it appears here.
  *
  * @param {string} userId
  * @param {{

--- a/src/lib/server/leaderboard.js
+++ b/src/lib/server/leaderboard.js
@@ -18,6 +18,13 @@ const gameScoreAt = sql`coalesce(${table.game.completedOn}, ${table.game.updated
  * Source of truth: completed, replayable `game` rows (not denormalized profile
  * best_score). Games without seed+moves cannot be verified and do not rank.
  *
+ * In-progress rows (`complete !== true`) are intentionally excluded — including
+ * "won but Keep Playing" runs. Ranking live autosaves would:
+ * - let unfinished (and still climbing) scores occupy the board
+ * - thrash ranks on every ~1s save
+ * - break period attribution, which keys off a finished run (`completedOn`)
+ * Current games already have their own path via `getCurrentGame` / `/game`.
+ *
  * @param {Date} [start]
  * @param {Date} [end]
  * @returns {{ id: string; username: string; displayName: string | null; bestScore: number }[]}

--- a/src/lib/server/leaderboard.js
+++ b/src/lib/server/leaderboard.js
@@ -6,24 +6,20 @@ import * as table from "$lib/server/db/schema";
 import { gameHasReplaySql } from "$lib/server/game";
 
 /**
- * Score attribution instant for a finished classic game.
- * Prefer completedOn; fall back to updatedOn for older/abandoned rows.
- */
-const gameScoreAt = sql`coalesce(${table.game.completedOn}, ${table.game.updatedOn})`;
-
-/**
- * Best completed classic score per Pro user.
- * Optional half-open time window [start, end). Omit both for all-time.
+ * Best classic score per Pro user (finished or still-active runs).
+ * Optional half-open time window [start, end) on `updatedOn`. Omit both for all-time.
  *
- * Source of truth: completed, replayable `game` rows (not denormalized profile
- * best_score). Games without seed+moves cannot be verified and do not rank.
+ * Source of truth: replayable `game` rows (not denormalized profile best_score).
+ * Games without seed+moves cannot be verified and do not rank.
  *
- * In-progress rows (`complete !== true`) are intentionally excluded — including
- * "won but Keep Playing" runs. Ranking live autosaves would:
- * - let unfinished (and still climbing) scores occupy the board
- * - thrash ranks on every ~1s save
- * - break period attribution, which keys off a finished run (`completedOn`)
- * Current games already have their own path via `getCurrentGame` / `/game`.
+ * Incomplete runs are included: classic score only increases, so a live high is a
+ * lower bound on the eventual score for that row. Period boards use `updatedOn`
+ * (last activity) so an active game counts in the window where it was last played —
+ * not `completedOn`, which is unset until win/finalize and would hide live scores.
+ *
+ * `completedOn` is kept on the row for history ("when finished / first won") and is
+ * not a duplicate of `updatedOn`: after a win with Keep Playing, `completedOn` freezes
+ * while `updatedOn` keeps advancing on each save.
  *
  * @param {Date} [start]
  * @param {Date} [end]
@@ -33,13 +29,12 @@ function getClassicBestByUser(start, end) {
 	/** @type {import("drizzle-orm").SQL[]} */
 	const conditions = [
 		eq(table.user.level, USER_LEVELS.PRO),
-		eq(table.game.complete, true),
 		sql`${table.game.score} is not null`,
 		gameHasReplaySql,
 	];
 
 	if (start != null && end != null) {
-		conditions.push(gte(gameScoreAt, start.getTime()), lt(gameScoreAt, end.getTime()));
+		conditions.push(gte(table.game.updatedOn, start), lt(table.game.updatedOn, end));
 	}
 
 	const rows = db
@@ -76,7 +71,7 @@ function getClassicBestByUser(start, end) {
 }
 
 /**
- * All-time classic leaderboard from completed games (max score per Pro user).
+ * All-time classic leaderboard (max score per Pro user, including active runs).
  * @param {number} [limit]
  */
 export function getAllTimeLeaderboard(limit = 10) {
@@ -84,7 +79,7 @@ export function getAllTimeLeaderboard(limit = 10) {
 }
 
 /**
- * 1-based rank of a user on the all-time classic leaderboard, or null if no completed score.
+ * 1-based rank of a user on the all-time classic leaderboard, or null if no ranked score.
  * @param {string} userId
  * @returns {{ rank: number; bestScore: number } | null}
  */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,11 +91,16 @@ export interface GameSaveData {
   moves?: number[] | null;
 }
 
+/** Derived from `complete` — not a separate DB column */
+export type GameHistoryStatus = "active" | "finished";
+
 export interface GameHistoryEntry {
   id: string;
   score: number;
   won: boolean;
   complete: boolean;
+  /** `active` when incomplete; `finished` when complete (including abandoned) */
+  status: GameHistoryStatus;
   moveCount: number;
   createdOn: Date;
   updatedOn: Date;
@@ -104,7 +109,7 @@ export interface GameHistoryEntry {
 }
 
 export type GameHistorySort = "date" | "score" | "moves";
-export type GameHistoryFilter = "all" | "won" | "lost";
+export type GameHistoryFilter = "all" | "active" | "won" | "lost";
 
 
 /** Snapshot payload used when setting a checkpoint */

--- a/src/routes/game/+page.js
+++ b/src/routes/game/+page.js
@@ -20,7 +20,7 @@ export async function load({ data, fetch }) {
 		localGame = loadGame();
 
 		if (user) {
-			// Authoritative personal best comes from completed games on the server.
+			// Authoritative personal best comes from ranked games on the server.
 			// Resync (and overwrite inflated localStorage leftovers from old bugs).
 			const res = await fetch("/game?/saveScore", {
 				method: "POST",

--- a/src/routes/game/+page.server.js
+++ b/src/routes/game/+page.server.js
@@ -48,7 +48,7 @@ export const actions = {
 			return fail(401, { message: "Not logged in." });
 		}
 
-		// Recompute personal best from completed games (ignore any client-submitted score).
+		// Recompute personal best from ranked games (ignore any client-submitted score).
 		const bestScore = await syncBestScoreFromGames(locals.user.id);
 
 		return { success: true, bestScore: bestScore ?? 0 };

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -189,11 +189,10 @@
 	}
 
 	/**
-	 * Finalize the current run for history, then start a fresh game.
+	 * Finalize the current run, then start a fresh game.
 	 *
-	 * History only lists complete === true. Winning does not set complete (players
-	 * can keep playing), so New Game must mark the abandoned run complete or it
-	 * disappears from /replay.
+	 * Winning does not set complete (Keep Playing). New Game marks the abandoned
+	 * run finished so only one active game remains and history shows a clean end.
 	 */
 	async function handleNewGame() {
 		const previous = gameState.currentGame;

--- a/src/routes/replay/+page.server.js
+++ b/src/routes/replay/+page.server.js
@@ -1,5 +1,5 @@
 import { USER_LEVELS } from "$lib/constants";
-import { getCompletedGames } from "$lib/server/game";
+import { getGameHistory } from "$lib/server/game";
 import { getUserProfile } from "$lib/server/user";
 
 /** @type {import("./$types").PageServerLoad} */
@@ -19,9 +19,14 @@ export function load({ locals, url }) {
 	const sort =
 		sortParam === "score" || sortParam === "moves" || sortParam === "date" ? sortParam : "date";
 	const filter =
-		filterParam === "won" || filterParam === "lost" || filterParam === "all" ? filterParam : "all";
+		filterParam === "won" ||
+		filterParam === "lost" ||
+		filterParam === "active" ||
+		filterParam === "all"
+			? filterParam
+			: "all";
 
-	const games = isPro && user ? getCompletedGames(user.id, { sort, filter }) : [];
+	const games = isPro && user ? getGameHistory(user.id, { sort, filter }) : [];
 
 	return {
 		user,

--- a/src/routes/replay/+page.svelte
+++ b/src/routes/replay/+page.svelte
@@ -29,18 +29,36 @@
 		const filter = updates.filter ?? data.filter;
 		return `/replay?sort=${encodeURIComponent(sort)}&filter=${encodeURIComponent(filter)}`;
 	}
+
+	/**
+	 * @param {import("$lib/types").GameHistoryEntry} game
+	 */
+	function statusLabel(game) {
+		if (game.status === "active") return "ACTIVE";
+		return game.won ? "WIN" : "LOSS";
+	}
+
+	/**
+	 * @param {import("$lib/types").GameHistoryEntry} game
+	 */
+	function statusClass(game) {
+		if (game.status === "active") return "bg-sky-100 text-sky-800";
+		return game.won ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700";
+	}
 </script>
 
 <svelte:head>
 	<title>Game History - 4096</title>
-	<meta name="description" content="Browse and replay your completed 4096 games." />
+	<meta
+		name="description"
+		content="Browse and replay your 4096 games, including your active run."
+	/>
 </svelte:head>
 
 <main class="mx-auto w-full max-w-lg px-6 pt-10 pb-28 text-foreground">
 	<h1 class="text-3xl font-bold text-primary">Game History</h1>
 	<p class="mb-4 text-sm text-muted-foreground">
-		Finished games only — your current run lives on the Play page; history is
-		for completed wins and losses you can replay move by move.
+		Active and finished games — continue your current run or replay moves so far.
 	</p>
 
 	{#if !data.user}
@@ -64,7 +82,7 @@
 	{:else}
 		<div class="mb-4 flex flex-wrap gap-2">
 			<div class="flex flex-1 gap-1 rounded-md bg-muted p-1">
-				{#each [{ key: "all", label: "All" }, { key: "won", label: "Wins" }, { key: "lost", label: "Losses" }] as option (option.key)}
+				{#each [{ key: "all", label: "All" }, { key: "active", label: "Active" }, { key: "won", label: "Wins" }, { key: "lost", label: "Losses" }] as option (option.key)}
 					<a
 						href={historyHref({ filter: option.key })}
 						class="flex-1 rounded px-2 py-1.5 text-center text-sm font-semibold transition-colors {data.filter ===
@@ -94,9 +112,9 @@
 
 		{#if data.games.length === 0}
 			<div class="rounded-lg border border-dashed px-6 py-12 text-center">
-				<p class="mb-1 font-semibold text-foreground">No completed games yet</p>
+				<p class="mb-1 font-semibold text-foreground">No games yet</p>
 				<p class="mb-4 text-sm text-muted-foreground">
-					Finish a game (win or lose) and it will show up here for replay.
+					Play a game and it will show up here — including your active run.
 				</p>
 				<Button href="/game" class="justify-center">Play a game</Button>
 			</div>
@@ -107,11 +125,11 @@
 						class="flex items-center gap-3 rounded-lg border bg-card px-4 py-3 text-card-foreground"
 					>
 						<div
-							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xs font-bold {game.won
-								? 'bg-green-100 text-green-700'
-								: 'bg-red-100 text-red-700'}"
+							class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-[10px] font-bold {statusClass(
+								game
+							)}"
 						>
-							{game.won ? "WIN" : "LOSS"}
+							{statusLabel(game)}
 						</div>
 						<div class="min-w-0 flex-1">
 							<div class="flex items-baseline gap-2">
@@ -119,22 +137,29 @@
 								<span class="text-xs text-muted-foreground">{game.moveCount} moves</span>
 							</div>
 							<div class="truncate text-xs text-muted-foreground">
-								{formatDate(game.completedOn ?? game.updatedOn)}
+								{formatDate(game.updatedOn)}
 							</div>
 						</div>
-						{#if game.hasReplay}
-							<Button href="/replay/{game.id}" class="gap-1" aria-label="Replay game">
-								<PlayIcon size={16} />
-								Replay
-							</Button>
-						{:else}
-							<span
-								class="text-xs text-muted-foreground/70"
-								title="Move list unavailable for this game"
-							>
-								No replay
-							</span>
-						{/if}
+						<div class="flex shrink-0 flex-col items-end gap-1 sm:flex-row sm:items-center">
+							{#if game.status === "active"}
+								<Button href="/game" variant="secondary" class="gap-1" aria-label="Continue game">
+									Continue
+								</Button>
+							{/if}
+							{#if game.hasReplay}
+								<Button href="/replay/{game.id}" class="gap-1" aria-label="Replay game">
+									<PlayIcon size={16} />
+									Replay
+								</Button>
+							{:else if game.status !== "active"}
+								<span
+									class="text-xs text-muted-foreground/70"
+									title="Move list unavailable for this game"
+								>
+									No replay
+								</span>
+							{/if}
+						</div>
 					</li>
 				{/each}
 			</ul>

--- a/src/routes/replay/+page.svelte
+++ b/src/routes/replay/+page.svelte
@@ -39,7 +39,8 @@
 <main class="mx-auto w-full max-w-lg px-6 pt-10 pb-28 text-foreground">
 	<h1 class="text-3xl font-bold text-primary">Game History</h1>
 	<p class="mb-4 text-sm text-muted-foreground">
-		Completed games only — replay wins and losses move by move.
+		Finished games only — your current run lives on the Play page; history is
+		for completed wins and losses you can replay move by move.
 	</p>
 
 	{#if !data.user}

--- a/src/routes/replay/[id]/+page.server.js
+++ b/src/routes/replay/[id]/+page.server.js
@@ -1,6 +1,6 @@
 import { error, redirect } from "@sveltejs/kit";
 import { USER_LEVELS } from "$lib/constants";
-import { gameHasReplay, getCompletedGameById } from "$lib/server/game";
+import { gameHasReplay, gameHistoryStatus, getOwnedGameById } from "$lib/server/game";
 import { requireLoginProfile } from "$lib/server/user";
 
 /** @type {import("./$types").PageServerLoad} */
@@ -11,7 +11,7 @@ export function load({ params }) {
 		redirect(302, "/stripe");
 	}
 
-	const game = getCompletedGameById(params.id, user.id);
+	const game = getOwnedGameById(params.id, user.id);
 	if (!game) {
 		error(404, "Game not found");
 	}
@@ -33,6 +33,7 @@ export function load({ params }) {
 			score: game.score ?? 0,
 			won: game.won,
 			complete: game.complete,
+			status: gameHistoryStatus(game.complete),
 			moveCount: game.moveCount,
 			seed: game.seed,
 			moves: game.moves,

--- a/src/routes/replay/[id]/+page.svelte
+++ b/src/routes/replay/[id]/+page.svelte
@@ -113,23 +113,38 @@
 
 <svelte:head>
 	<title>Replay - 4096</title>
-	<meta name="description" content="Watch a move-by-move replay of a completed 4096 game." />
+	<meta name="description" content="Watch a move-by-move replay of a 4096 game." />
 </svelte:head>
 
 <main class="mx-auto w-full max-w-lg px-4 pt-6 pb-28 text-foreground">
-	<div class="mb-3 flex items-center gap-2">
+	<div class="mb-3 flex flex-wrap items-center gap-2">
 		<Button href="/replay" variant="ghost" size="sm" class="gap-1">
 			<ChevronLeftIcon size={16} />
 			History
 		</Button>
 		<span class="text-sm text-muted-foreground">·</span>
-		<Badge variant={data.replay.won ? "secondary" : "destructive"}>
-			{data.replay.won ? "Win" : "Loss"}
-		</Badge>
+		{#if data.replay.status === "active"}
+			<Badge variant="outline">Active</Badge>
+			{#if data.replay.won}
+				<Badge variant="secondary">Won</Badge>
+			{/if}
+		{:else}
+			<Badge variant={data.replay.won ? "secondary" : "destructive"}>
+				{data.replay.won ? "Win" : "Loss"}
+			</Badge>
+		{/if}
 		<span class="text-sm font-semibold text-foreground">
 			{data.replay.score.toLocaleString()} pts
 		</span>
+		{#if data.replay.status === "active"}
+			<Button href="/game" variant="secondary" size="sm" class="ms-auto">Continue</Button>
+		{/if}
 	</div>
+	{#if data.replay.status === "active"}
+		<p class="mb-3 text-xs text-muted-foreground">
+			In-progress replay — playback covers moves recorded so far.
+		</p>
+	{/if}
 
 	{#if replayGame}
 		<div class="mb-2 flex items-center justify-between text-sm text-muted-foreground">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Classic leaderboard and Game History now include **active** (incomplete) runs, not only finished ones. Period boards attribute scores by **last activity** (`updatedOn`).

## Why this is safe

Classic score only increases within a game, so a live high is a lower bound on that row’s eventual score. Abandon / New Game keeps the score on the finalized row.

## Behavior

- **All-time / daily / weekly / monthly classic boards:** drop the `complete === true` filter; still require Pro + replayable seed/moves.
- **Period window:** filter on `updatedOn` so an active run counts in the window where it was last played.
- **Personal `best_score` cache:** includes active replayable games (same ranking rules).
- **Game History:** lists active + finished; new **Active** filter; Continue → `/game`; Replay works for moves recorded so far.
- **Challenge leaderboards:** unchanged (still wins only).

## Status column?

No new DB enum. Status is derived:

- `complete === false` → `active`
- `complete === true` → `finished` (includes abandoned prior runs)

A dedicated `status` column is only worth it later if abandoned needs to differ from finished in queries/UI.

## Is `completedOn` duplicating `updatedOn`?

No. After a win with Keep Playing, `completedOn` freezes at first win / finalize while `updatedOn` keeps advancing on every autosave. Ranking uses `updatedOn`; `completedOn` remains useful as “when finished / first won” metadata.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7aca-eafe-7f4d-86cf-4fbe7a617262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7aca-eafe-7f4d-86cf-4fbe7a617262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

