### PR TITLE
Fix active games missing from classic leaderboard

### DIFF
--- a/drizzle/0015_checkpoint_moves.sql
+++ b/drizzle/0015_checkpoint_moves.sql
@@ -1,0 +1,3 @@
+-- Persist move history on checkpoints so restore keeps the run replayable
+-- (and eligible for permanent classic ranking after the game finishes).
+ALTER TABLE `game_checkpoint` ADD `moves` text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1784080000000,
       "tag": "0014_remove_unreplayable_games",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1784501000000,
+      "tag": "0015_checkpoint_moves",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -35,9 +35,27 @@ export const EVENT_TYPES = {
 	SNAPSHOT: 30,
 };
 
+/** Slide directions recorded in `game.moves` for replay */
 export const DIRECTIONS = {
 	LEFT: 10,
 	RIGHT: 20,
 	UP: 30,
 	DOWN: 40,
 };
+
+/**
+ * Board transforms recorded in `game.moves` alongside slide directions.
+ * Values stay outside the DIRECTIONS range so older replay clients can detect unknowns.
+ */
+export const BOARD_TRANSFORMS = {
+	ROTATE_CW: 50,
+	ROTATE_CCW: 60,
+	MIRROR_H: 70,
+	MIRROR_V: 80,
+};
+
+/** @type {ReadonlySet<number>} */
+export const SLIDE_DIRECTION_VALUES = new Set(Object.values(DIRECTIONS));
+
+/** @type {ReadonlySet<number>} */
+export const BOARD_TRANSFORM_VALUES = new Set(Object.values(BOARD_TRANSFORMS));

--- a/src/lib/game.svelte.js
+++ b/src/lib/game.svelte.js
@@ -5,6 +5,9 @@ import {
 	DEFAULT_STARTING_TILES,
 	DEFAULT_WIN_TILE,
 	DIRECTIONS,
+	BOARD_TRANSFORMS,
+	BOARD_TRANSFORM_VALUES,
+	SLIDE_DIRECTION_VALUES,
 	EVENT_TYPES,
 	TWO_TO_FOUR_RATIO,
 	UNDO_COOLDOWN_MOVES,
@@ -208,7 +211,7 @@ export class Game {
 	}
 
 	/**
-	 * Undo the last successful move, if allowed.
+	 * Undo the last successful move or board transform, if allowed.
 	 * After undoing, undo stays disabled until UNDO_COOLDOWN_MOVES new moves.
 	 * @returns {boolean} Whether an undo was applied
 	 */
@@ -234,11 +237,109 @@ export class Game {
 	}
 
 	/**
-	 * Stop recording moves so this game cannot be replayed from seed+directions
-	 * (used after board transforms that bypass moveTiles).
+	 * Capture undo state before a successful slide or board transform.
+	 * @returns {import("./types").GameUndoSnapshot}
 	 */
-	invalidateMoveRecording() {
-		this.moves = null;
+	#captureUndoSnapshot() {
+		return {
+			board: this.board.map((row) => [...row]),
+			score: this.score,
+			gameOver: this.gameOver,
+			won: this.won,
+			canContinue: this.canContinue,
+			rngState: this.rng.state,
+			moveCount: this.moveCount,
+		};
+	}
+
+	/**
+	 * Commit a recorded action (slide direction or board transform) into history.
+	 * @param {number} action
+	 * @param {import("./types").GameUndoSnapshot} undoSnapshot
+	 */
+	#commitRecordedAction(action, undoSnapshot) {
+		this.#previousState = undoSnapshot;
+		this.hasUndoSnapshot = true;
+		this.moveCount += 1;
+		if (this.moves) {
+			this.moves = [...this.moves, action];
+		}
+		if (this.undoCooldownRemaining > 0) {
+			this.undoCooldownRemaining -= 1;
+		}
+	}
+
+	/**
+	 * Apply a recorded slide or board-transform action (used by replay).
+	 * @param {number} action
+	 * @returns {import("./types").GameEvent[]}
+	 */
+	applyRecordedAction(action) {
+		if (SLIDE_DIRECTION_VALUES.has(action)) {
+			return this.moveTiles(action);
+		}
+		if (BOARD_TRANSFORM_VALUES.has(action)) {
+			return this.applyBoardTransform(action);
+		}
+		return [];
+	}
+
+	/**
+	 * Apply a board transform without spawning tiles, recording it for replay/undo.
+	 * @param {number} transform One of {@link BOARD_TRANSFORMS}
+	 * @returns {import("./types").GameEvent[]}
+	 */
+	applyBoardTransform(transform) {
+		if (this.gameOver) return [];
+		if (!BOARD_TRANSFORM_VALUES.has(transform)) return [];
+
+		const undoSnapshot = this.#captureUndoSnapshot();
+		this.#mutateBoardTransform(transform);
+		this.#commitRecordedAction(transform, undoSnapshot);
+
+		return [{ resync: true, snapshot: this.board.map((row) => [...row]) }];
+	}
+
+	/**
+	 * Mutate `this.board` for a single transform action (no recording / undo).
+	 * @param {number} transform
+	 */
+	#mutateBoardTransform(transform) {
+		const n = this.boardSize;
+		const src = this.board;
+		const next = Array(n)
+			.fill(null)
+			.map(() => Array(n).fill(0));
+
+		if (transform === BOARD_TRANSFORMS.ROTATE_CW) {
+			for (let i = 0; i < n; i++) {
+				for (let j = 0; j < n; j++) {
+					next[j][n - 1 - i] = src[i][j];
+				}
+			}
+		} else if (transform === BOARD_TRANSFORMS.ROTATE_CCW) {
+			for (let i = 0; i < n; i++) {
+				for (let j = 0; j < n; j++) {
+					next[n - 1 - j][i] = src[i][j];
+				}
+			}
+		} else if (transform === BOARD_TRANSFORMS.MIRROR_H) {
+			for (let i = 0; i < n; i++) {
+				for (let j = 0; j < n; j++) {
+					next[i][n - 1 - j] = src[i][j];
+				}
+			}
+		} else if (transform === BOARD_TRANSFORMS.MIRROR_V) {
+			for (let i = 0; i < n; i++) {
+				for (let j = 0; j < n; j++) {
+					next[n - 1 - i][j] = src[i][j];
+				}
+			}
+		} else {
+			return;
+		}
+
+		this.board = next;
 	}
 
 	/**
@@ -548,62 +649,38 @@ export class Game {
 	}
 
 	/**
-	 * Rotate the board by a given factor
+	 * Rotate the board clockwise by 90° × factor (records one CW or CCW action when factor is 1 or 3).
 	 * @param {number} factor Factor to rotate the board clockwise by (0-3)
+	 * @returns {import("./types").GameEvent[]}
 	 */
 	rotateBoard(factor) {
-		if (factor <= 0) return;
+		const turns = ((factor % 4) + 4) % 4;
+		if (turns === 0) return [];
+		if (turns === 1) return this.applyBoardTransform(BOARD_TRANSFORMS.ROTATE_CW);
+		if (turns === 3) return this.applyBoardTransform(BOARD_TRANSFORMS.ROTATE_CCW);
 
-		this.invalidateMoveRecording();
-
-		const newBoard = Array(this.boardSize)
-			.fill(null)
-			.map(() => Array(this.boardSize).fill(0));
-
-		for (let i = 0; i < this.boardSize; i++) {
-			for (let j = 0; j < this.boardSize; j++) {
-				newBoard[j][this.boardSize - 1 - i] = this.board[i][j];
-			}
+		// 180° — record as two CW turns so replay stays a sequence of atomic actions
+		const events = [];
+		for (let i = 0; i < turns; i++) {
+			events.push(...this.applyBoardTransform(BOARD_TRANSFORMS.ROTATE_CW));
 		}
-		this.board = newBoard;
-
-		this.rotateBoard(factor - 1);
+		return events;
 	}
 
 	/**
-	 * Mirror the board horizontally
+	 * Mirror the board horizontally (left ↔ right).
+	 * @returns {import("./types").GameEvent[]}
 	 */
 	mirrorBoardHorizontally() {
-		this.invalidateMoveRecording();
-
-		const newBoard = Array(this.boardSize)
-			.fill(null)
-			.map(() => Array(this.boardSize).fill(0));
-
-		for (let i = 0; i < this.boardSize; i++) {
-			for (let j = 0; j < this.boardSize; j++) {
-				newBoard[i][j] = this.board[i][this.boardSize - 1 - j];
-			}
-		}
-		this.board = newBoard;
+		return this.applyBoardTransform(BOARD_TRANSFORMS.MIRROR_H);
 	}
 
 	/**
-	 * Mirror the board vertically
+	 * Mirror the board vertically (top ↔ bottom).
+	 * @returns {import("./types").GameEvent[]}
 	 */
 	mirrorBoardVertically() {
-		this.invalidateMoveRecording();
-
-		const newBoard = Array(this.boardSize)
-			.fill(null)
-			.map(() => Array(this.boardSize).fill(0));
-
-		for (let i = 0; i < this.boardSize; i++) {
-			for (let j = 0; j < this.boardSize; j++) {
-				newBoard[i][j] = this.board[this.boardSize - 1 - i][j];
-			}
-		}
-		this.board = newBoard;
+		return this.applyBoardTransform(BOARD_TRANSFORMS.MIRROR_V);
 	}
 
 	/**

--- a/src/lib/server/checkpoint.js
+++ b/src/lib/server/checkpoint.js
@@ -91,7 +91,7 @@ export async function setCheckpoint(userId, snapshot) {
 	assert(Array.isArray(snapshot.board), "board is required");
 	assert(typeof snapshot.score === "number", "score is required");
 
-	requireOwnedGame(snapshot.gameId, userId);
+	const existingGame = requireOwnedGame(snapshot.gameId, userId);
 
 	await db
 		.update(table.gameCheckpoint)
@@ -103,6 +103,23 @@ export async function setCheckpoint(userId, snapshot) {
 				eq(table.gameCheckpoint.isActive, true)
 			)
 		);
+
+	/** @type {number[] | null} */
+	let moves = null;
+	if (snapshot.moves === null) {
+		moves = null;
+	} else if (Array.isArray(snapshot.moves)) {
+		moves = snapshot.moves;
+	} else {
+		// Older clients omit moves — fall back to the game row when lengths match.
+		const existingMoves = existingGame.moves;
+		if (
+			Array.isArray(existingMoves) &&
+			existingMoves.length === (snapshot.moveCount ?? existingGame.moveCount)
+		) {
+			moves = existingMoves;
+		}
+	}
 
 	const createdOn = new Date();
 	const inserted = db
@@ -120,6 +137,7 @@ export async function setCheckpoint(userId, snapshot) {
 			moveCount: snapshot.moveCount ?? 0,
 			undoCooldownRemaining: snapshot.undoCooldownRemaining ?? 0,
 			won: snapshot.won ?? false,
+			moves,
 		})
 		.returning()
 		.get();
@@ -163,7 +181,9 @@ export async function restoreCheckpoint(userId, gameId) {
 	}
 
 	// Restore into the same game (not a new slot). Always reopen as incomplete so play can continue.
-	// Invalidate recorded moves — checkpoints do not capture the direction history needed for replay.
+	// Prefer stored moves so the run stays replayable; legacy checkpoints may still be null.
+	const moves = Array.isArray(checkpoint.moves) ? checkpoint.moves : null;
+
 	await db
 		.update(table.game)
 		.set({
@@ -175,7 +195,7 @@ export async function restoreCheckpoint(userId, gameId) {
 			rngState: checkpoint.rngState,
 			moveCount: checkpoint.moveCount,
 			undoCooldownRemaining: checkpoint.undoCooldownRemaining,
-			moves: null,
+			moves,
 			updatedOn: new Date(),
 		})
 		.where(eq(table.game.id, gameId));
@@ -190,6 +210,6 @@ export async function restoreCheckpoint(userId, gameId) {
 		undoCooldownRemaining: checkpoint.undoCooldownRemaining,
 		won: checkpoint.won,
 		complete: false,
-		moves: null,
+		moves,
 	};
 }

--- a/src/lib/server/db/schema/gameSchemas.ts
+++ b/src/lib/server/db/schema/gameSchemas.ts
@@ -21,7 +21,7 @@ export const game = sqliteTable("game", {
 	/** false = active run; true = finished (including abandoned prior runs) */
 	complete: integer("complete", { mode: "boolean" }).notNull(),
 	board: text("board", { mode: "json" }).$type<number[][]>().notNull(),
-	/** Recorded move directions (see DIRECTIONS) for Pro replay — null when not replayable */
+	/** Recorded move directions + board transforms (see DIRECTIONS / BOARD_TRANSFORMS) for Pro replay — null when not replayable */
 	moves: text("moves", { mode: "json" }).$type<number[] | null>(),
 	seed: integer("seed"),
 	rngState: integer("rng_state"),

--- a/src/lib/server/db/schema/gameSchemas.ts
+++ b/src/lib/server/db/schema/gameSchemas.ts
@@ -52,4 +52,6 @@ export const gameCheckpoint = sqliteTable("game_checkpoint", {
 	moveCount: integer("move_count").notNull().default(0),
 	undoCooldownRemaining: integer("undo_cooldown_remaining").notNull().default(0),
 	won: integer("won", { mode: "boolean" }).notNull().default(false),
+	/** Move directions at checkpoint time — restored so the run stays replayable */
+	moves: text("moves", { mode: "json" }).$type<number[] | null>(),
 });

--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -23,9 +23,10 @@ export const gameHasReplaySql = /** @type {import("drizzle-orm").SQL} */ (
  * Classic ranking eligibility for leaderboard / personal-best cache.
  *
  * Active (`complete !== true`) runs always qualify: score only increases within
- * a run, and live autosaves may lack moves after checkpoint restore, board
- * transforms, or legacy mid-game saves. Finished runs still need
- * {@link gameHasReplaySql} so permanent ranks stay verifiable.
+ * a run, and live autosaves may lack moves after legacy mid-game saves or older
+ * checkpoint restores. Finished runs still need {@link gameHasReplaySql} so
+ * permanent ranks stay verifiable. Rotate/mirror are recorded as moves so those
+ * runs stay replayable.
  *
  * @type {import("drizzle-orm").SQL}
  */

--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -1,12 +1,12 @@
 import * as table from "$lib/server/db/schema";
 import { db } from "$lib/server/db";
-import { and, desc, eq, ne, not, sql } from "drizzle-orm";
+import { and, desc, eq, ne, not, or, sql } from "drizzle-orm";
 import assert from "node:assert";
 
 /**
  * SQL predicate matching {@link gameHasReplay}: seed + non-empty moves whose
- * length equals move_count. Use for leaderboard / best-score queries so
- * unverifiable (cheat / checkpoint / legacy) scores cannot rank.
+ * length equals move_count. Finished classic scores must pass this to keep a
+ * permanent leaderboard rank.
  *
  * @type {import("drizzle-orm").SQL}
  */
@@ -20,13 +20,26 @@ export const gameHasReplaySql = /** @type {import("drizzle-orm").SQL} */ (
 );
 
 /**
+ * Classic ranking eligibility for leaderboard / personal-best cache.
+ *
+ * Active (`complete !== true`) runs always qualify: score only increases within
+ * a run, and live autosaves may lack moves after checkpoint restore, board
+ * transforms, or legacy mid-game saves. Finished runs still need
+ * {@link gameHasReplaySql} so permanent ranks stay verifiable.
+ *
+ * @type {import("drizzle-orm").SQL}
+ */
+export const gameRanksOnClassicSql = /** @type {import("drizzle-orm").SQL} */ (
+	or(not(eq(table.game.complete, true)), gameHasReplaySql)
+);
+
+/**
  * Recompute `user_profile.best_score` from classic games (active or finished).
  *
  * Profile best is a cache for personal UI only — all-time leaderboard aggregates
- * from `game` rows. Only replayable games count (seed + matching move history).
- * Incomplete runs count: score only increases within a game.
- * Never trust a client-submitted score here (that path used to allow inflated
- * highs without a matching game).
+ * from `game` rows. Active runs count even without replay data; finished runs
+ * must be replayable. Never trust a client-submitted score here (that path used
+ * to allow inflated highs without a matching game).
  *
  * @param {string} userId
  * @returns {Promise<number | null>} The recomputed best score, or null if none
@@ -46,7 +59,11 @@ export async function syncBestScoreFromGames(userId) {
 		})
 		.from(table.game)
 		.where(
-			and(eq(table.game.playerId, userId), sql`${table.game.score} is not null`, gameHasReplaySql)
+			and(
+				eq(table.game.playerId, userId),
+				sql`${table.game.score} is not null`,
+				gameRanksOnClassicSql
+			)
 		)
 		.get();
 

--- a/src/lib/server/leaderboard.js
+++ b/src/lib/server/leaderboard.js
@@ -3,19 +3,21 @@ import { CHALLENGE_RUN_STATUS, CHALLENGE_TYPES } from "$lib/challenges.js";
 import { USER_LEVELS } from "$lib/constants";
 import { db } from "$lib/server/db";
 import * as table from "$lib/server/db/schema";
-import { gameHasReplaySql } from "$lib/server/game";
+import { gameRanksOnClassicSql } from "$lib/server/game";
 
 /**
  * Best classic score per Pro user (finished or still-active runs).
  * Optional half-open time window [start, end) on `updatedOn`. Omit both for all-time.
  *
- * Source of truth: replayable `game` rows (not denormalized profile best_score).
- * Games without seed+moves cannot be verified and do not rank.
+ * Source of truth: `game` rows (not denormalized profile best_score).
  *
- * Incomplete runs are included: classic score only increases, so a live high is a
- * lower bound on the eventual score for that row. Period boards use `updatedOn`
- * (last activity) so an active game counts in the window where it was last played —
- * not `completedOn`, which is unset until win/finalize and would hide live scores.
+ * Active runs always count (score only increases; moves may be null after
+ * checkpoint restore / transforms / legacy saves). Finished runs must still be
+ * replayable so permanent ranks stay verifiable.
+ *
+ * Period boards use `updatedOn` (last activity) so an active game counts in the
+ * window where it was last played — not `completedOn`, which is unset until
+ * win/finalize and would hide live scores.
  *
  * `completedOn` is kept on the row for history ("when finished / first won") and is
  * not a duplicate of `updatedOn`: after a win with Keep Playing, `completedOn` freezes
@@ -30,7 +32,7 @@ function getClassicBestByUser(start, end) {
 	const conditions = [
 		eq(table.user.level, USER_LEVELS.PRO),
 		sql`${table.game.score} is not null`,
-		gameHasReplaySql,
+		gameRanksOnClassicSql,
 	];
 
 	if (start != null && end != null) {

--- a/src/lib/server/leaderboard.js
+++ b/src/lib/server/leaderboard.js
@@ -11,9 +11,9 @@ import { gameRanksOnClassicSql } from "$lib/server/game";
  *
  * Source of truth: `game` rows (not denormalized profile best_score).
  *
- * Active runs always count (score only increases; moves may be null after
- * checkpoint restore / transforms / legacy saves). Finished runs must still be
- * replayable so permanent ranks stay verifiable.
+ * Active runs always count (score only increases; moves may be null for legacy
+ * saves / older checkpoint restores). Rotate/mirror are recorded as moves.
+ * Finished runs must still be replayable so permanent ranks stay verifiable.
  *
  * Period boards use `updatedOn` (last activity) so an active game counts in the
  * window where it was last played — not `completedOn`, which is unset until

--- a/src/lib/tileAnimator.js
+++ b/src/lib/tileAnimator.js
@@ -110,7 +110,10 @@ export class TileAnimator {
 	 * @param {import("./types").GameEvent} event
 	 */
 	processEvent(event) {
-		if (event.start && event.end) {
+		if (event.resync && event.snapshot) {
+			// Instant board replace for recorded transforms (rotate / mirror).
+			this.syncFromBoard(event.snapshot);
+		} else if (event.start && event.end) {
 			this.#processMove(event);
 			this.#ensureAnimationRunning();
 		} else if (event.end && event.newTileValue !== undefined) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,6 +25,8 @@ export interface GameEvent {
   gameLost?: boolean;
   gameWon?: boolean;
   snapshot?: number[][];
+  /** When true with snapshot, animator rebuilds tiles immediately (board transforms). */
+  resync?: boolean;
 }
 
 export interface VisualTile {
@@ -72,7 +74,7 @@ export interface GameState {
   rngState?: number;
   moveCount?: number;
   undoCooldownRemaining?: number;
-  /** Recorded move directions; null when replay was invalidated (e.g. cheat) */
+  /** Recorded slide directions and board transforms; null when recording was invalidated */
   moves?: number[] | null;
 }
 
@@ -87,7 +89,7 @@ export interface GameSaveData {
   rngState?: number;
   moveCount?: number;
   undoCooldownRemaining?: number;
-  /** Recorded move directions; null when replay was invalidated (e.g. cheat) */
+  /** Recorded slide directions and board transforms; null when recording was invalidated */
   moves?: number[] | null;
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -122,6 +122,8 @@ export interface CheckpointSaveData {
   moveCount?: number;
   undoCooldownRemaining?: number;
   won?: boolean;
+  /** Move directions at checkpoint time (null when recording was invalidated) */
+  moves?: number[] | null;
 }
 
 /** Active checkpoint metadata returned to the client */
@@ -144,6 +146,6 @@ export interface CheckpointRestoreState {
   undoCooldownRemaining: number;
   won: boolean;
   complete: boolean;
-  /** Always null after restore — direction history is not captured in checkpoints */
+  /** Restored move history when the checkpoint stored it; null for legacy checkpoints */
   moves?: number[] | null;
 }

--- a/src/routes/api/game/checkpoint/+server.js
+++ b/src/routes/api/game/checkpoint/+server.js
@@ -55,6 +55,7 @@ export async function POST({ request, locals }) {
 			moveCount: body.moveCount,
 			undoCooldownRemaining: body.undoCooldownRemaining,
 			won: body.won,
+			moves: body.moves,
 		});
 		return json({ success: true, checkpoint });
 	} catch (error) {

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -309,6 +309,7 @@
 					moveCount: snapshot.moveCount,
 					undoCooldownRemaining: snapshot.undoCooldownRemaining,
 					won: snapshot.won,
+					moves: snapshot.moves,
 				}),
 			});
 			const result = await response.json();

--- a/src/routes/game/components/AnimatedBoard.svelte
+++ b/src/routes/game/components/AnimatedBoard.svelte
@@ -140,7 +140,7 @@
 		}
 	});
 
-	// Sync after cheat transforms (rotate/mirror) when idle
+	// Sync after board transforms (rotate/mirror) when idle
 	$effect(() => {
 		if (!game || animating || pendingEvents.length > 0) return;
 

--- a/src/routes/replay/[id]/+page.svelte
+++ b/src/routes/replay/[id]/+page.svelte
@@ -54,16 +54,16 @@
 	}
 
 	/**
-	 * Apply the next recorded direction and queue animation events
+	 * Apply the next recorded action (slide or board transform) and queue animation events
 	 * @returns {boolean} Whether a move was applied
 	 */
 	function stepForward() {
 		if (!replayGame || atEnd || pendingEvents.length > 0 || !animationIdle) return false;
 
-		const direction = data.replay.moves[moveIndex];
-		const events = replayGame.moveTiles(direction);
+		const action = data.replay.moves[moveIndex];
+		const events = replayGame.applyRecordedAction(action);
 		if (events.length === 0) {
-			// Corrupted / desynced move — stop playback
+			// Corrupted / desynced / unknown action — stop playback
 			playing = false;
 			return false;
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

#42 included incomplete classic games on the leaderboard, but ranking still required `seed` + matching `moves` (`gameHasReplaySql`).

That left many live runs invisible after deploy, including:
- Games restored from a **checkpoint** (restore previously set `moves: null`)
- Games after **rotate/mirror** (previously invalidated move recording)
- **Legacy** mid-game saves that never recorded moves

Production currently shows Joel at **1,000** (a finished replayable score) while a higher in-progress score can still be excluded by that gate.

## Fix

1. **Rank active runs without the replay gate** — incomplete games count by score (score only increases within a run). Finished games still need replayable move history for a permanent rank.
2. **Persist `moves` on checkpoints** and restore them, so future checkpoint restores stay replayable.
3. **Record rotate/mirror as board-transform move codes** (`BOARD_TRANSFORMS`) so those actions stay in history, remain undoable, and replay via `applyRecordedAction` + an animator resync event — no more wiping the move list.

## Test plan

- [x] Local SQL check: active game with `moves: null` ranks; finished unreplayable does not; finished replayable does
- [x] Migration `0015_checkpoint_moves` applies
- [x] Transform math invertibility (CW↔CCW, mirrors)
- [x] `pnpm lint`
- [ ] After deploy: mid-run score appears on leaderboard even without Replay
- [ ] Rotate/mirror mid-game → History still offers Replay and playback includes the transforms
- [ ] Undo after a transform restores the prior board
- [ ] Set checkpoint → restore → moves survive
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7c7f-0d8b-75d8-bcd0-c9b8bf954c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7c7f-0d8b-75d8-bcd0-c9b8bf954c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

