### PR TITLE
Add play stats page from existing game data

### DIFF
--- a/src/lib/server/stats.js
+++ b/src/lib/server/stats.js
@@ -1,0 +1,373 @@
+import { CHALLENGE_RUN_STATUS, CHALLENGE_TYPES } from "$lib/challenges.js";
+import { db } from "$lib/server/db";
+import * as table from "$lib/server/db/schema";
+import { and, asc, eq, inArray } from "drizzle-orm";
+
+/**
+ * Highest tile value on a board (empty / invalid boards → 0).
+ * @param {unknown} board
+ * @returns {number}
+ */
+export function highestTileFromBoard(board) {
+	if (!Array.isArray(board)) return 0;
+	let max = 0;
+	for (const row of board) {
+		if (!Array.isArray(row)) continue;
+		for (const cell of row) {
+			if (typeof cell === "number" && Number.isFinite(cell) && cell > max) {
+				max = cell;
+			}
+		}
+	}
+	return max;
+}
+
+/**
+ * Elapsed ms between two timestamps, or null if either is missing/invalid.
+ * @param {Date | null | undefined} start
+ * @param {Date | null | undefined} end
+ * @returns {number | null}
+ */
+function durationMs(start, end) {
+	if (!(start instanceof Date) || !(end instanceof Date)) return null;
+	const ms = end.getTime() - start.getTime();
+	return Number.isFinite(ms) && ms >= 0 ? ms : null;
+}
+
+/**
+ * Ranking value for a winning challenge run (lower is better).
+ * @param {{ score: number | null; metrics: unknown }} win
+ * @param {string} challengeType
+ * @returns {number | null}
+ */
+function rankingValueFromWin(win, challengeType) {
+	if (challengeType === CHALLENGE_TYPES.TIME) {
+		if (win.metrics && typeof win.metrics === "object") {
+			const elapsed = /** @type {{ elapsedMs?: unknown }} */ (win.metrics).elapsedMs;
+			if (typeof elapsed === "number" && Number.isFinite(elapsed) && elapsed >= 0) {
+				return elapsed;
+			}
+		}
+		if (typeof win.score === "number" && Number.isFinite(win.score) && win.score >= 0) {
+			return win.score;
+		}
+		return null;
+	}
+
+	if (typeof win.score !== "number" || !Number.isFinite(win.score)) return null;
+	return win.score;
+}
+
+/**
+ * Average 1-based daily-challenge leaderboard rank across challenges the user has won.
+ * Uses each challenge's best win per player (same rules as the challenge leaderboard).
+ *
+ * @param {string} userId
+ * @returns {{ averageRank: number | null; rankedClears: number }}
+ */
+function getAverageDailyChallengeRank(userId) {
+	const userWins = db
+		.select({
+			challengeId: table.challengeRun.challengeId,
+			score: table.challengeRun.score,
+			metrics: table.challengeRun.metrics,
+		})
+		.from(table.challengeRun)
+		.where(
+			and(
+				eq(table.challengeRun.userId, userId),
+				eq(table.challengeRun.status, CHALLENGE_RUN_STATUS.WON)
+			)
+		)
+		.all();
+
+	if (userWins.length === 0) {
+		return { averageRank: null, rankedClears: 0 };
+	}
+
+	const challengeIds = [...new Set(userWins.map((w) => w.challengeId))];
+
+	const challengeRows = db
+		.select({
+			id: table.dailyChallenge.id,
+			type: table.dailyChallenge.type,
+		})
+		.from(table.dailyChallenge)
+		.where(inArray(table.dailyChallenge.id, challengeIds))
+		.all();
+
+	/** @type {Map<string, string>} */
+	const typeById = new Map(challengeRows.map((row) => [row.id, row.type]));
+
+	const allWins = db
+		.select({
+			challengeId: table.challengeRun.challengeId,
+			userId: table.challengeRun.userId,
+			score: table.challengeRun.score,
+			metrics: table.challengeRun.metrics,
+		})
+		.from(table.challengeRun)
+		.where(
+			and(
+				inArray(table.challengeRun.challengeId, challengeIds),
+				eq(table.challengeRun.status, CHALLENGE_RUN_STATUS.WON)
+			)
+		)
+		.all();
+
+	/** @type {Map<string, Map<string, number>>} */
+	const bestByChallenge = new Map();
+	for (const win of allWins) {
+		const challengeType = typeById.get(win.challengeId);
+		if (!challengeType) continue;
+		const value = rankingValueFromWin(win, challengeType);
+		if (value == null) continue;
+
+		let byUser = bestByChallenge.get(win.challengeId);
+		if (!byUser) {
+			byUser = new Map();
+			bestByChallenge.set(win.challengeId, byUser);
+		}
+		const existing = byUser.get(win.userId);
+		if (existing == null || value < existing) {
+			byUser.set(win.userId, value);
+		}
+	}
+
+	/** @type {number[]} */
+	const ranks = [];
+	for (const challengeId of challengeIds) {
+		const byUser = bestByChallenge.get(challengeId);
+		if (!byUser || !byUser.has(userId)) continue;
+
+		const ranked = [...byUser.entries()].sort((a, b) => a[1] - b[1]);
+		const index = ranked.findIndex(([id]) => id === userId);
+		if (index >= 0) ranks.push(index + 1);
+	}
+
+	if (ranks.length === 0) {
+		return { averageRank: null, rankedClears: 0 };
+	}
+
+	const sum = ranks.reduce((acc, rank) => acc + rank, 0);
+	return {
+		averageRank: Math.round((sum / ranks.length) * 10) / 10,
+		rankedClears: ranks.length,
+	};
+}
+
+/**
+ * Longest and current win streaks over finished classic games (chronological).
+ * @param {{ won: boolean; complete: boolean; completedOn: Date | null; updatedOn: Date }[]} games
+ * @returns {{ longestWinStreak: number; currentWinStreak: number }}
+ */
+function winStreaksFromGames(games) {
+	const finished = games
+		.filter((g) => g.complete)
+		.slice()
+		.sort((a, b) => {
+			const aTime = (a.completedOn ?? a.updatedOn)?.getTime?.() ?? 0;
+			const bTime = (b.completedOn ?? b.updatedOn)?.getTime?.() ?? 0;
+			return aTime - bTime;
+		});
+
+	let longest = 0;
+	let current = 0;
+	for (const game of finished) {
+		if (game.won) {
+			current += 1;
+			if (current > longest) longest = current;
+		} else {
+			current = 0;
+		}
+	}
+
+	return { longestWinStreak: longest, currentWinStreak: current };
+}
+
+/**
+ * Aggregate personal play stats from classic games + daily challenge runs.
+ *
+ * @param {string} userId
+ * @returns {{
+ *   totalGames: number;
+ *   completedGames: number;
+ *   activeGames: number;
+ *   wins: number;
+ *   losses: number;
+ *   winRate: number | null;
+ *   bestScore: number | null;
+ *   averageScore: number | null;
+ *   highestTile: number;
+ *   leastMovesToWin: number | null;
+ *   fastestWinMs: number | null;
+ *   totalMoves: number;
+ *   averageMovesPerWin: number | null;
+ *   longestWinStreak: number;
+ *   currentWinStreak: number;
+ *   challengeAttempts: number;
+ *   challengeWins: number;
+ *   challengeLosses: number;
+ *   challengeWinRate: number | null;
+ *   averageDailyChallengeRank: number | null;
+ *   rankedChallengeClears: number;
+ *   bestChallengeElapsedMs: number | null;
+ *   bestChallengeMoveCount: number | null;
+ * }}
+ */
+export function getUserPlayStats(userId) {
+	const games = db
+		.select({
+			score: table.game.score,
+			won: table.game.won,
+			complete: table.game.complete,
+			board: table.game.board,
+			moveCount: table.game.moveCount,
+			createdOn: table.game.createdOn,
+			updatedOn: table.game.updatedOn,
+			completedOn: table.game.completedOn,
+		})
+		.from(table.game)
+		.where(eq(table.game.playerId, userId))
+		.orderBy(asc(table.game.createdOn))
+		.all();
+
+	let wins = 0;
+	let losses = 0;
+	let activeGames = 0;
+	let highestTile = 0;
+	/** @type {number | null} */
+	let bestScore = null;
+	/** @type {number | null} */
+	let leastMovesToWin = null;
+	/** @type {number | null} */
+	let fastestWinMs = null;
+	let totalMoves = 0;
+	let scoreSum = 0;
+	let scoredCompleted = 0;
+	let winMoveSum = 0;
+
+	for (const game of games) {
+		totalMoves += game.moveCount ?? 0;
+		const tile = highestTileFromBoard(game.board);
+		if (tile > highestTile) highestTile = tile;
+
+		if (typeof game.score === "number" && Number.isFinite(game.score)) {
+			if (bestScore == null || game.score > bestScore) bestScore = game.score;
+		}
+
+		if (!game.complete) {
+			activeGames += 1;
+			continue;
+		}
+
+		if (typeof game.score === "number" && Number.isFinite(game.score)) {
+			scoreSum += game.score;
+			scoredCompleted += 1;
+		}
+
+		if (game.won) {
+			wins += 1;
+			winMoveSum += game.moveCount ?? 0;
+			if (
+				typeof game.moveCount === "number" &&
+				(leastMovesToWin == null || game.moveCount < leastMovesToWin)
+			) {
+				leastMovesToWin = game.moveCount;
+			}
+			const elapsed = durationMs(game.createdOn, game.completedOn ?? game.updatedOn);
+			if (elapsed != null && (fastestWinMs == null || elapsed < fastestWinMs)) {
+				fastestWinMs = elapsed;
+			}
+		} else {
+			losses += 1;
+		}
+	}
+
+	const completedGames = wins + losses;
+	const decided = wins + losses;
+	const { longestWinStreak, currentWinStreak } = winStreaksFromGames(games);
+
+	const challengeRuns = db
+		.select({
+			status: table.challengeRun.status,
+			score: table.challengeRun.score,
+			metrics: table.challengeRun.metrics,
+			challengeId: table.challengeRun.challengeId,
+		})
+		.from(table.challengeRun)
+		.where(eq(table.challengeRun.userId, userId))
+		.all();
+
+	let challengeAttempts = 0;
+	let challengeWins = 0;
+	let challengeLosses = 0;
+	/** @type {number | null} */
+	let bestChallengeElapsedMs = null;
+	/** @type {number | null} */
+	let bestChallengeMoveCount = null;
+
+	for (const run of challengeRuns) {
+		if (run.status === CHALLENGE_RUN_STATUS.ABANDONED) continue;
+		if (
+			run.status === CHALLENGE_RUN_STATUS.IN_PROGRESS ||
+			run.status === CHALLENGE_RUN_STATUS.WON ||
+			run.status === CHALLENGE_RUN_STATUS.LOST
+		) {
+			challengeAttempts += 1;
+		}
+		if (run.status === CHALLENGE_RUN_STATUS.WON) {
+			challengeWins += 1;
+			if (run.metrics && typeof run.metrics === "object") {
+				const metrics = /** @type {{ elapsedMs?: unknown; moveCount?: unknown }} */ (run.metrics);
+				if (
+					typeof metrics.elapsedMs === "number" &&
+					Number.isFinite(metrics.elapsedMs) &&
+					metrics.elapsedMs >= 0 &&
+					(bestChallengeElapsedMs == null || metrics.elapsedMs < bestChallengeElapsedMs)
+				) {
+					bestChallengeElapsedMs = metrics.elapsedMs;
+				}
+				if (
+					typeof metrics.moveCount === "number" &&
+					Number.isFinite(metrics.moveCount) &&
+					(bestChallengeMoveCount == null || metrics.moveCount < bestChallengeMoveCount)
+				) {
+					bestChallengeMoveCount = metrics.moveCount;
+				}
+			}
+		} else if (run.status === CHALLENGE_RUN_STATUS.LOST) {
+			challengeLosses += 1;
+		}
+	}
+
+	const { averageRank, rankedClears } = getAverageDailyChallengeRank(userId);
+	const challengeDecided = challengeWins + challengeLosses;
+
+	return {
+		totalGames: games.length,
+		completedGames,
+		activeGames,
+		wins,
+		losses,
+		winRate: decided > 0 ? Math.round((wins / decided) * 1000) / 10 : null,
+		bestScore,
+		averageScore: scoredCompleted > 0 ? Math.round(scoreSum / scoredCompleted) : null,
+		highestTile,
+		leastMovesToWin,
+		fastestWinMs,
+		totalMoves,
+		averageMovesPerWin: wins > 0 ? Math.round(winMoveSum / wins) : null,
+		longestWinStreak,
+		currentWinStreak,
+		challengeAttempts,
+		challengeWins,
+		challengeLosses,
+		challengeWinRate:
+			challengeDecided > 0 ? Math.round((challengeWins / challengeDecided) * 1000) / 10 : null,
+		averageDailyChallengeRank: averageRank,
+		rankedChallengeClears: rankedClears,
+		bestChallengeElapsedMs,
+		bestChallengeMoveCount,
+	};
+}

--- a/src/routes/FooterNav.svelte
+++ b/src/routes/FooterNav.svelte
@@ -7,6 +7,7 @@
 		HistoryIcon,
 		UserIcon,
 		TargetIcon,
+		ChartColumnIcon,
 	} from "@lucide/svelte";
 
 	const navItems = [
@@ -27,6 +28,10 @@
 			href: "/leaderboard",
 		},
 		{
+			icon: ChartColumnIcon,
+			href: "/stats",
+		},
+		{
 			icon: HistoryIcon,
 			href: "/replay",
 		},
@@ -44,18 +49,18 @@
 </script>
 
 <nav
-	class="fixed bottom-1 left-1/2 z-50 flex -translate-x-1/2 justify-between gap-2 rounded-full bg-secondary p-1 text-secondary-foreground shadow-lg ring-1 ring-border/50 sm:bottom-10"
+	class="fixed bottom-1 left-1/2 z-50 flex max-w-[calc(100vw-1rem)] -translate-x-1/2 justify-between gap-1 rounded-full bg-secondary p-1 text-secondary-foreground shadow-lg ring-1 ring-border/50 sm:bottom-10 sm:gap-2"
 >
 	{#each navItems as navItem, index (index)}
 		{@const IconComponent = navItem.icon}
 		<a
 			href={navItem.href}
-			class="rounded-full p-2 transition-colors {activeNavItem === navItem
+			class="rounded-full p-1.5 transition-colors sm:p-2 {activeNavItem === navItem
 				? 'bg-primary text-primary-foreground'
 				: 'bg-background text-foreground hover:bg-muted'}"
 			aria-current={activeNavItem === navItem ? "page" : undefined}
 		>
-			<IconComponent />
+			<IconComponent class="size-5 sm:size-6" />
 		</a>
 	{/each}
 </nav>

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -12,6 +12,7 @@
 		MailIcon,
 		LockIcon,
 		PaletteIcon,
+		ChartColumnIcon,
 	} from "@lucide/svelte";
 	import { USER_LEVELS } from "$lib/constants";
 	import { gameState } from "../game/state.svelte";
@@ -118,6 +119,12 @@
 				<PaletteIcon size={18} />
 			</div>
 			<div class="flex-5/6 text-start">Themes</div>
+		</Button>
+		<Button class="flex w-60 gap-2" href="/stats">
+			<div class="flex flex-1/6 items-center justify-end">
+				<ChartColumnIcon size={18} />
+			</div>
+			<div class="flex-5/6 text-start">Play Stats</div>
 		</Button>
 		{#if data.userProfile.level !== USER_LEVELS.PRO}
 			<Button class="flex w-60 gap-2" href="/stripe" variant="secondary">

--- a/src/routes/stats/+page.server.js
+++ b/src/routes/stats/+page.server.js
@@ -1,0 +1,16 @@
+import { USER_LEVELS } from "$lib/constants";
+import { getUserPlayStats } from "$lib/server/stats";
+import { getUserProfile } from "$lib/server/user";
+
+/** @type {import("./$types").PageServerLoad} */
+export function load({ locals }) {
+	const user = locals.user ? getUserProfile(locals.user.id) : null;
+	const isPro = user?.level === USER_LEVELS.PRO;
+	const stats = isPro && user ? getUserPlayStats(user.id) : null;
+
+	return {
+		user,
+		isPro,
+		stats,
+	};
+}

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -1,9 +1,10 @@
 <script>
+	import { browser } from "$app/environment";
 	import { page } from "$app/state";
 	import { defaultTheme } from "$lib/assets/themes.js";
-	import { TILE_BORDER_RADIUS } from "$lib/boardConstants.js";
+	import { BOARD_GAP, BOARD_PADDING, TILE_BORDER_RADIUS } from "$lib/boardConstants.js";
 	import { formatChallengeElapsedMs } from "$lib/challenges.js";
-	import { USER_LEVELS } from "$lib/constants";
+	import { DEFAULT_BOARD_SIZE, USER_LEVELS } from "$lib/constants";
 	import { Button } from "$lib/components/ui/button/index.js";
 	import { getTileBackground, getTileColor } from "$lib/game.svelte.js";
 
@@ -11,14 +12,52 @@
 
 	let theme = $derived(page.data.theme || defaultTheme);
 
+	/** Game page `.game-container` chrome used to derive live board cell size. */
+	const GAME_CONTAINER_MAX_WIDTH = 500;
+	const GAME_CONTAINER_PADDING_X = 40;
+
 	/**
-	 * Font size for a standalone stats tile preview.
+	 * Board cell size for the current viewport — same geometry as AnimatedBoard
+	 * inside `.game-container` (max-width 500px, 20px horizontal padding).
+	 * @param {number} viewportWidth
+	 */
+	function boardCellSize(viewportWidth) {
+		const boardWidth = Math.min(GAME_CONTAINER_MAX_WIDTH, viewportWidth) - GAME_CONTAINER_PADDING_X;
+		return (
+			(boardWidth - BOARD_PADDING * 2 - BOARD_GAP * (DEFAULT_BOARD_SIZE - 1)) / DEFAULT_BOARD_SIZE
+		);
+	}
+
+	/** Mirrors AnimatedBoard's `window.innerWidth <= 600` breakpoint. */
+	let isMobileViewport = $state(browser ? window.innerWidth <= 600 : true);
+	/** Keep the stats tile pixel-identical to a live board cell. */
+	let statsTileSize = $state(browser ? boardCellSize(window.innerWidth) : 75);
+
+	$effect(() => {
+		if (!browser) return;
+		const mq = window.matchMedia("(max-width: 600px)");
+		const sync = () => {
+			isMobileViewport = mq.matches;
+			statsTileSize = boardCellSize(window.innerWidth);
+		};
+		sync();
+		mq.addEventListener("change", sync);
+		window.addEventListener("resize", sync);
+		return () => {
+			mq.removeEventListener("change", sync);
+			window.removeEventListener("resize", sync);
+		};
+	});
+
+	/**
+	 * Exact font-size formula from AnimatedBoard / BasicBoard.
 	 * @param {number} value
 	 */
-	function highestTileFontSize(value) {
-		const digits = String(value).length;
-		const rem = Math.max(1.35 - (digits - 1) * 0.18, 0.7);
-		return `${rem}rem`;
+	function getTileFontSize(value) {
+		const baseSize = isMobileViewport ? 2.5 : (theme.textScale ?? 3);
+		const digits = value.toString().length;
+		const fontSize = Math.max(baseSize - (digits - 1) * 0.3, 1);
+		return `${fontSize}rem`;
 	}
 
 	/**
@@ -120,14 +159,16 @@
 					</p>
 					{#if stats.highestTile > 0}
 						<div
-							class="mt-2 flex size-16 items-center justify-center font-bold tabular-nums shadow-sm sm:size-[4.5rem]"
+							class="stats-tile mt-2"
+							style:width={`${statsTileSize}px`}
+							style:height={`${statsTileSize}px`}
 							style:background={getTileBackground(stats.highestTile, theme)}
 							style:color={getTileColor(stats.highestTile, theme)}
 							style:border-radius={`${TILE_BORDER_RADIUS}px`}
-							style:font-size={highestTileFontSize(stats.highestTile)}
-							aria-label={`Highest tile ${stats.highestTile.toLocaleString()}`}
+							style:font-size={getTileFontSize(stats.highestTile)}
+							aria-label={`Highest tile ${stats.highestTile}`}
 						>
-							{stats.highestTile.toLocaleString()}
+							{stats.highestTile}
 						</div>
 					{:else}
 						<p class="mt-1 text-2xl font-bold tabular-nums">—</p>
@@ -281,3 +322,19 @@
 		</section>
 	{/if}
 </main>
+
+<style>
+	/* Match AnimatedBoard / BasicBoard `.tile` text rendering */
+	.stats-tile {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-weight: 800;
+		text-align: center;
+		padding: 0.2em;
+		line-height: 1;
+		flex: 0 0 auto;
+		overflow: hidden;
+		box-sizing: border-box;
+	}
+</style>

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -1,9 +1,25 @@
 <script>
+	import { page } from "$app/state";
+	import { defaultTheme } from "$lib/assets/themes.js";
+	import { TILE_BORDER_RADIUS } from "$lib/boardConstants.js";
 	import { formatChallengeElapsedMs } from "$lib/challenges.js";
 	import { USER_LEVELS } from "$lib/constants";
 	import { Button } from "$lib/components/ui/button/index.js";
+	import { getTileBackground, getTileColor } from "$lib/game.svelte.js";
 
 	let { data } = $props();
+
+	let theme = $derived(page.data.theme || defaultTheme);
+
+	/**
+	 * Font size for a standalone stats tile preview.
+	 * @param {number} value
+	 */
+	function highestTileFontSize(value) {
+		const digits = String(value).length;
+		const rem = Math.max(1.35 - (digits - 1) * 0.18, 0.7);
+		return `${rem}rem`;
+	}
 
 	/**
 	 * @param {number | null | undefined} value
@@ -102,9 +118,20 @@
 					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
 						Highest tile
 					</p>
-					<p class="mt-1 text-2xl font-bold tabular-nums">
-						{formatNumber(stats.highestTile || null, { fallback: "—" })}
-					</p>
+					{#if stats.highestTile > 0}
+						<div
+							class="mt-2 flex size-16 items-center justify-center font-bold tabular-nums shadow-sm sm:size-[4.5rem]"
+							style:background={getTileBackground(stats.highestTile, theme)}
+							style:color={getTileColor(stats.highestTile, theme)}
+							style:border-radius={`${TILE_BORDER_RADIUS}px`}
+							style:font-size={highestTileFontSize(stats.highestTile)}
+							aria-label={`Highest tile ${stats.highestTile.toLocaleString()}`}
+						>
+							{stats.highestTile.toLocaleString()}
+						</div>
+					{:else}
+						<p class="mt-1 text-2xl font-bold tabular-nums">—</p>
+					{/if}
 				</div>
 				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
 					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
@@ -151,7 +178,7 @@
 					</p>
 					<p class="mt-0.5 text-[11px] text-muted-foreground">
 						{stats.completedGames} finished{#if stats.activeGames > 0}
-							{" · "}{stats.activeGames} active{/if}
+							<span aria-hidden="true"> · </span>{stats.activeGames} active{/if}
 					</p>
 				</div>
 				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -1,0 +1,256 @@
+<script>
+	import { formatChallengeElapsedMs } from "$lib/challenges.js";
+	import { USER_LEVELS } from "$lib/constants";
+	import { Button } from "$lib/components/ui/button/index.js";
+
+	let { data } = $props();
+
+	/**
+	 * @param {number | null | undefined} value
+	 * @param {{ suffix?: string; fallback?: string }} [options]
+	 */
+	function formatNumber(value, options = {}) {
+		const fallback = options.fallback ?? "—";
+		if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+		const formatted = value.toLocaleString();
+		return options.suffix ? `${formatted}${options.suffix}` : formatted;
+	}
+
+	/**
+	 * Classic win duration from created → completed (wall clock).
+	 * @param {number | null | undefined} ms
+	 */
+	function formatWinDuration(ms) {
+		if (typeof ms !== "number" || !Number.isFinite(ms) || ms < 0) return "—";
+		const totalSec = Math.floor(ms / 1000);
+		if (totalSec < 60) return `${totalSec}s`;
+		const minutes = Math.floor(totalSec / 60);
+		const seconds = totalSec % 60;
+		if (minutes < 60) {
+			return `${minutes}:${String(seconds).padStart(2, "0")}`;
+		}
+		const hours = Math.floor(minutes / 60);
+		const remMin = minutes % 60;
+		return `${hours}h ${remMin}m`;
+	}
+
+	/**
+	 * @param {number | null | undefined} wins
+	 * @param {number | null | undefined} losses
+	 */
+	function formatRecord(wins, losses) {
+		const w = typeof wins === "number" ? wins : 0;
+		const l = typeof losses === "number" ? losses : 0;
+		return `${w}–${l}`;
+	}
+</script>
+
+<svelte:head>
+	<title>Play Stats - 4096</title>
+	<meta
+		name="description"
+		content="Your 4096 play stats — highest tile, fastest wins, challenge ranks, and more."
+	/>
+</svelte:head>
+
+<main class="mx-auto w-full max-w-lg px-6 pt-10 pb-28 text-foreground">
+	<h1 class="text-3xl font-bold text-primary">Play Stats</h1>
+	<p class="mb-6 text-sm text-muted-foreground">
+		Personal records from your classic games and daily challenges.
+	</p>
+
+	{#if !data.user}
+		<div class="rounded-lg border border-dashed px-6 py-12 text-center">
+			<p class="mb-1 font-semibold text-foreground">Sign in to view your stats</p>
+			<p class="mb-4 text-sm text-muted-foreground">
+				Play stats are available for Pro players with a game history.
+			</p>
+			<Button href="/login?redirectTo=/stats" class="justify-center">Log in</Button>
+		</div>
+	{:else if data.user.level !== USER_LEVELS.PRO}
+		<div
+			class="rounded-lg border border-dashed border-primary/30 bg-primary/10 px-6 py-12 text-center"
+		>
+			<p class="mb-1 font-semibold text-foreground">Pro feature</p>
+			<p class="mb-4 text-sm text-muted-foreground">
+				Upgrade to Pro to unlock play stats, game history, and daily challenge archives.
+			</p>
+			<Button href="/stripe" class="justify-center">Upgrade to Pro</Button>
+		</div>
+	{:else if data.stats}
+		{@const stats = data.stats}
+
+		{#if stats.totalGames === 0 && stats.challengeAttempts === 0}
+			<div class="mb-6 rounded-lg border border-dashed px-6 py-12 text-center">
+				<p class="mb-1 font-semibold text-foreground">No games yet</p>
+				<p class="mb-4 text-sm text-muted-foreground">
+					Play a classic game or today's challenge — your records will show up here.
+				</p>
+				<div class="flex flex-wrap justify-center gap-2">
+					<Button href="/game" class="justify-center">Play classic</Button>
+					<Button href="/challenges" variant="secondary" class="justify-center">
+						Daily challenges
+					</Button>
+				</div>
+			</div>
+		{/if}
+
+		<section class="mb-8">
+			<h2 class="mb-3 text-sm font-bold tracking-wide text-muted-foreground uppercase">Classic</h2>
+			<div class="grid grid-cols-2 gap-3">
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Highest tile
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatNumber(stats.highestTile || null, { fallback: "—" })}
+					</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Best score
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatNumber(stats.bestScore)}
+					</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Least moves to win
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatNumber(stats.leastMovesToWin)}
+					</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Fastest win
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatWinDuration(stats.fastestWinMs)}
+					</p>
+					<p class="mt-0.5 text-[11px] text-muted-foreground">Wall-clock start → finish</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Win / loss
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatRecord(stats.wins, stats.losses)}
+					</p>
+					<p class="mt-0.5 text-[11px] text-muted-foreground">
+						{stats.winRate != null ? `${stats.winRate}% win rate` : "No finished games"}
+					</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Games played
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatNumber(stats.totalGames, { fallback: "0" })}
+					</p>
+					<p class="mt-0.5 text-[11px] text-muted-foreground">
+						{stats.completedGames} finished{#if stats.activeGames > 0}
+							{" · "}{stats.activeGames} active{/if}
+					</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Avg score
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatNumber(stats.averageScore)}
+					</p>
+					<p class="mt-0.5 text-[11px] text-muted-foreground">Finished games</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Total moves
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatNumber(stats.totalMoves, { fallback: "0" })}
+					</p>
+					<p class="mt-0.5 text-[11px] text-muted-foreground">
+						{stats.averageMovesPerWin != null
+							? `Avg ${stats.averageMovesPerWin.toLocaleString()} / win`
+							: "Across all runs"}
+					</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Win streak
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatNumber(stats.currentWinStreak, { fallback: "0" })}
+					</p>
+					<p class="mt-0.5 text-[11px] text-muted-foreground">
+						Best {formatNumber(stats.longestWinStreak, { fallback: "0" })}
+					</p>
+				</div>
+			</div>
+		</section>
+
+		<section>
+			<h2 class="mb-3 text-sm font-bold tracking-wide text-muted-foreground uppercase">
+				Daily challenges
+			</h2>
+			<div class="grid grid-cols-2 gap-3">
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Avg daily rank
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{stats.averageDailyChallengeRank != null ? `#${stats.averageDailyChallengeRank}` : "—"}
+					</p>
+					<p class="mt-0.5 text-[11px] text-muted-foreground">
+						{stats.rankedChallengeClears > 0
+							? `Across ${stats.rankedChallengeClears} clear${stats.rankedChallengeClears === 1 ? "" : "s"}`
+							: "Win a challenge to rank"}
+					</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Challenge record
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatRecord(stats.challengeWins, stats.challengeLosses)}
+					</p>
+					<p class="mt-0.5 text-[11px] text-muted-foreground">
+						{stats.challengeWinRate != null
+							? `${stats.challengeWinRate}% clear rate`
+							: "No finishes yet"}
+					</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Best time clear
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatChallengeElapsedMs(stats.bestChallengeElapsedMs)}
+					</p>
+				</div>
+				<div class="rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Best recovery
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{stats.bestChallengeMoveCount != null
+							? `${stats.bestChallengeMoveCount.toLocaleString()} moves`
+							: "—"}
+					</p>
+				</div>
+				<div class="col-span-2 rounded-xl bg-muted/60 p-4 ring-1 ring-border/40">
+					<p class="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+						Challenge attempts
+					</p>
+					<p class="mt-1 text-2xl font-bold tabular-nums">
+						{formatNumber(stats.challengeAttempts, { fallback: "0" })}
+					</p>
+					<p class="mt-0.5 text-[11px] text-muted-foreground">
+						Includes in-progress runs; abandoned retries are excluded
+					</p>
+				</div>
+			</div>
+		</section>
+	{/if}
+</main>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a Pro **Play Stats** page at `/stats` that aggregates personal records from classic `game` rows and daily `challenge_run` history — no new schema.

### Classic
- Highest tile achieved, rendered as a themed game tile (same size, font formula, and CSS as the in-game board)
- Best / average score
- Least moves to win
- Fastest win (wall-clock `createdOn` → `completedOn`)
- Win/loss record + win rate
- Total games played (finished + active)
- Total moves, average moves per win
- Current / best win streak

### Daily challenges
- Average leaderboard rank across clears
- Challenge win/loss + clear rate
- Best time clear / best recovery move count
- Challenge attempts (excluding abandoned retries)

### Navigation
- New footer nav item (chart icon)
- Account → Play Stats link
- Same Pro / login gating pattern as game history

## Test plan
- [ ] Log in as Pro → open `/stats` and confirm stats match game history / challenge results
- [ ] Confirm highest tile matches an in-game tile (colors, font size/weight, padding) on mobile and desktop
- [ ] Confirm unauthenticated and Free users see login / upgrade gates
- [ ] Footer stats icon highlights on `/stats` and remains usable on a narrow phone
- [ ] Play a classic win and a daily clear → reload `/stats` and see updated records

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f82b4-c20d-7dea-839b-a3d9db19698f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f82b4-c20d-7dea-839b-a3d9db19698f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

