### PR TITLE
Explain missing replays with a help dialog on history

### DIFF
--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -116,6 +116,33 @@ export function gameHasReplay(game) {
 }
 
 /**
+ * Human-readable explanation when {@link gameHasReplay} is false.
+ * @param {{ seed: number | null, moves: number[] | null, moveCount: number }} game
+ * @returns {string | null}
+ */
+export function replayUnavailableReason(game) {
+	if (gameHasReplay(game)) return null;
+
+	if (game.seed == null) {
+		return "This game has no seed, so it can't be reconstructed move-by-move.";
+	}
+
+	if (game.moves == null) {
+		return "Move history wasn't saved for this run. That usually means a legacy mid-game save, an older checkpoint restore, or a board rotate/mirror before those actions were recorded for replay.";
+	}
+
+	if (!Array.isArray(game.moves) || game.moves.length === 0) {
+		return "No moves were saved for this game, so there's nothing to replay.";
+	}
+
+	if (game.moves.length !== game.moveCount) {
+		return "The saved move list doesn't match the move count, so replay wouldn't be reliable.";
+	}
+
+	return "Move history isn't available for this game.";
+}
+
+/**
  * Mark every other in-progress game for this user as complete.
  *
  * A player should only have one active (`complete !== true`) run. Older incomplete
@@ -322,22 +349,26 @@ export function getGameHistory(userId, options = {}) {
 		.offset(offset)
 		.all();
 
-	return rows.map((row) => ({
-		id: row.id,
-		score: row.score ?? 0,
-		won: row.won,
-		complete: row.complete,
-		status: gameHistoryStatus(row.complete),
-		moveCount: row.moveCount,
-		createdOn: row.createdOn,
-		updatedOn: row.updatedOn,
-		completedOn: row.completedOn,
-		hasReplay: gameHasReplay({
+	return rows.map((row) => {
+		const replayFields = {
 			seed: row.seed,
 			moves: row.moves,
 			moveCount: row.moveCount,
-		}),
-	}));
+		};
+		return {
+			id: row.id,
+			score: row.score ?? 0,
+			won: row.won,
+			complete: row.complete,
+			status: gameHistoryStatus(row.complete),
+			moveCount: row.moveCount,
+			createdOn: row.createdOn,
+			updatedOn: row.updatedOn,
+			completedOn: row.completedOn,
+			hasReplay: gameHasReplay(replayFields),
+			replayUnavailableReason: replayUnavailableReason(replayFields),
+		};
+	});
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -108,6 +108,8 @@ export interface GameHistoryEntry {
   updatedOn: Date;
   completedOn: Date | null;
   hasReplay: boolean;
+  /** Set when hasReplay is false; explains why move-by-move replay isn't available */
+  replayUnavailableReason: string | null;
 }
 
 export type GameHistorySort = "date" | "score" | "moves";

--- a/src/routes/replay/+page.svelte
+++ b/src/routes/replay/+page.svelte
@@ -1,7 +1,8 @@
 <script>
 	import { USER_LEVELS } from "$lib/constants";
 	import { Button } from "$lib/components/ui/button/index.js";
-	import { PlayIcon } from "@lucide/svelte";
+	import * as Dialog from "$lib/components/ui/dialog/index.js";
+	import { CircleHelpIcon, PlayIcon } from "@lucide/svelte";
 
 	let { data } = $props();
 
@@ -152,12 +153,24 @@
 									Replay
 								</Button>
 							{:else if game.status !== "active"}
-								<span
-									class="text-xs text-muted-foreground/70"
-									title="Move list unavailable for this game"
-								>
-									No replay
-								</span>
+								<Dialog.Root>
+									<Dialog.Trigger
+										class="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+										aria-label="Why can't this game be replayed?"
+										title="Why no replay?"
+									>
+										<CircleHelpIcon size={18} />
+									</Dialog.Trigger>
+									<Dialog.Content class="sm:max-w-sm">
+										<Dialog.Header>
+											<Dialog.Title>No replay available</Dialog.Title>
+											<Dialog.Description>
+												{game.replayUnavailableReason ??
+													"Move history isn't available for this game."}
+											</Dialog.Description>
+										</Dialog.Header>
+									</Dialog.Content>
+								</Dialog.Root>
 							{/if}
 						</div>
 					</li>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Finished games without a verifiable move history now show a question-mark control where the Replay button would be.

Tapping it opens a short dialog with the specific reason (missing seed, null/empty moves, or move-count mismatch), covering the usual legacy-save / old checkpoint / pre-recording rotate-mirror cases.

**Changes**
- Add `replayUnavailableReason()` and include it on history entries
- Replace the static “No replay” label with a `CircleHelp` dialog trigger
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f82b7-087a-7a7c-bae0-12db0491e282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f82b7-087a-7a7c-bae0-12db0491e282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

