### PR TITLE
Show game stats on the You Won dialog

### DIFF
--- a/src/lib/formatTime.js
+++ b/src/lib/formatTime.js
@@ -1,0 +1,18 @@
+/**
+ * Classic win duration from created → completed (wall clock).
+ * @param {number | null | undefined} ms
+ * @returns {string}
+ */
+export function formatWinDuration(ms) {
+	if (typeof ms !== "number" || !Number.isFinite(ms) || ms < 0) return "—";
+	const totalSec = Math.floor(ms / 1000);
+	if (totalSec < 60) return `${totalSec}s`;
+	const minutes = Math.floor(totalSec / 60);
+	const seconds = totalSec % 60;
+	if (minutes < 60) {
+		return `${minutes}:${String(seconds).padStart(2, "0")}`;
+	}
+	const hours = Math.floor(minutes / 60);
+	const remMin = minutes % 60;
+	return `${hours}h ${remMin}m`;
+}

--- a/src/lib/game.svelte.js
+++ b/src/lib/game.svelte.js
@@ -126,6 +126,21 @@ function resolveRecordedMoves(initialState) {
 }
 
 /**
+ * Resolve wall-clock start time for a Game.
+ * Fresh games stamp now; resumed games keep a persisted timestamp when present.
+ * @param {import("./types").GameState | null | undefined} initialState
+ * @returns {number | null}
+ */
+function resolveCreatedOn(initialState) {
+	if (!initialState) return Date.now();
+	const createdOn = initialState.createdOn;
+	if (typeof createdOn === "number" && Number.isFinite(createdOn) && createdOn > 0) {
+		return createdOn;
+	}
+	return null;
+}
+
+/**
  * Game Class
  *
  * Encapsulates the game state and logic
@@ -170,6 +185,13 @@ export class Game {
 		 * @type {number[] | null}
 		 */
 		this.moves = $state(resolveRecordedMoves(initialState));
+
+		/**
+		 * Wall-clock start (ms since epoch). New games stamp Date.now();
+		 * resumed games use persisted/server createdOn when available.
+		 * @type {number | null}
+		 */
+		this.createdOn = $state(resolveCreatedOn(initialState));
 
 		const resolvedSeed = seed ?? initialState?.seed ?? generateSeed();
 		/** @type {number} */
@@ -723,6 +745,7 @@ export class Game {
 			moveCount: this.moveCount,
 			undoCooldownRemaining: this.undoCooldownRemaining,
 			moves: this.moves,
+			createdOn: this.createdOn,
 		};
 	}
 }

--- a/src/lib/localStorage.svelte.js
+++ b/src/lib/localStorage.svelte.js
@@ -14,6 +14,7 @@ import { getTheme } from "./assets/themes";
  *   moveCount?: number;
  *   undoCooldownRemaining?: number;
  *   moves?: number[] | null;
+ *   createdOn?: number | null;
  * }} game
  */
 export function saveGame({
@@ -25,6 +26,7 @@ export function saveGame({
 	moveCount,
 	undoCooldownRemaining,
 	moves,
+	createdOn,
 }) {
 	if (!browser) return;
 	localStorage.setItem(
@@ -38,6 +40,7 @@ export function saveGame({
 			moveCount,
 			undoCooldownRemaining,
 			moves: moves ?? null,
+			createdOn: createdOn ?? null,
 			lastUpdated: Date.now(),
 		})
 	);

--- a/src/lib/server/checkpoint.js
+++ b/src/lib/server/checkpoint.js
@@ -156,7 +156,7 @@ export async function restoreCheckpoint(userId, gameId) {
 	requireProUser(userId);
 	assert(gameId, "gameId is required");
 
-	requireOwnedGame(gameId, userId);
+	const existingGame = requireOwnedGame(gameId, userId);
 
 	const checkpoint = db
 		.select()
@@ -211,5 +211,6 @@ export async function restoreCheckpoint(userId, gameId) {
 		won: checkpoint.won,
 		complete: false,
 		moves,
+		createdOn: existingGame.createdOn instanceof Date ? existingGame.createdOn.getTime() : null,
 	};
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,6 +76,8 @@ export interface GameState {
   undoCooldownRemaining?: number;
   /** Recorded slide directions and board transforms; null when recording was invalidated */
   moves?: number[] | null;
+  /** Wall-clock start time (ms since epoch). Used for win-dialog duration. */
+  createdOn?: number | null;
 }
 
 export interface GameSaveData {
@@ -91,6 +93,8 @@ export interface GameSaveData {
   undoCooldownRemaining?: number;
   /** Recorded slide directions and board transforms; null when recording was invalidated */
   moves?: number[] | null;
+  /** Client wall-clock start (ms); ignored by server insert (DB stamps its own) */
+  createdOn?: number | null;
 }
 
 /** Derived from `complete` — not a separate DB column */
@@ -152,4 +156,6 @@ export interface CheckpointRestoreState {
   complete: boolean;
   /** Restored move history when the checkpoint stored it; null for legacy checkpoints */
   moves?: number[] | null;
+  /** Original game start time (ms since epoch), preserved across checkpoint restore */
+  createdOn?: number | null;
 }

--- a/src/routes/game/+page.server.js
+++ b/src/routes/game/+page.server.js
@@ -24,6 +24,7 @@ export function load({ locals }) {
 				moveCount: dbGame.moveCount ?? 0,
 				undoCooldownRemaining: dbGame.undoCooldownRemaining ?? 0,
 				moves: dbGame.moves ?? null,
+				createdOn: dbGame.createdOn instanceof Date ? dbGame.createdOn.getTime() : null,
 				lastUpdated: dbGame.updatedOn.getTime(),
 			};
 

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -42,6 +42,20 @@
 	}
 
 	/**
+	 * Prefer an explicit createdOn; otherwise borrow from the other copy.
+	 * @param {import("$lib/types").GameState & { lastUpdated?: number } | null | undefined} primary
+	 * @param {import("$lib/types").GameState & { lastUpdated?: number } | null | undefined} fallback
+	 */
+	function withCreatedOnFallback(primary, fallback) {
+		if (!primary) return primary;
+		if (typeof primary.createdOn === "number") return primary;
+		if (typeof fallback?.createdOn === "number") {
+			return { ...primary, createdOn: fallback.createdOn };
+		}
+		return primary;
+	}
+
+	/**
 	 * Try to load game from local or server storage.
 	 *
 	 * When boards diverge, prefer the newer timestamp and only prompt
@@ -52,7 +66,9 @@
 
 		if (data.localGame && data.dbGame) {
 			if (isSameGame(data.localGame, data.dbGame)) {
-				gameState.currentGame = createGameFromState(data.dbGame);
+				gameState.currentGame = createGameFromState(
+					withCreatedOnFallback(data.dbGame, data.localGame)
+				);
 				return;
 			}
 
@@ -62,10 +78,15 @@
 			if (typeof localUpdated === "number" && typeof dbUpdated === "number") {
 				if (localUpdated >= dbUpdated) {
 					// Local is ahead (common after a missed flush) — keep it and push.
-					gameState.currentGame = createGameFromState(data.localGame, data.dbGame.id);
+					gameState.currentGame = createGameFromState(
+						withCreatedOnFallback(data.localGame, data.dbGame),
+						data.dbGame.id
+					);
 					queueMicrotask(() => flushSaveToServer());
 				} else {
-					gameState.currentGame = createGameFromState(data.dbGame);
+					gameState.currentGame = createGameFromState(
+						withCreatedOnFallback(data.dbGame, data.localGame)
+					);
 				}
 				return;
 			}
@@ -87,10 +108,15 @@
 	 */
 	function resolveConflict(source) {
 		if (source === "local") {
-			gameState.currentGame = createGameFromState(data.localGame, data.dbGame?.id);
+			gameState.currentGame = createGameFromState(
+				withCreatedOnFallback(data.localGame, data.dbGame),
+				data.dbGame?.id
+			);
 			queueMicrotask(() => flushSaveToServer());
 		} else if (source === "server") {
-			gameState.currentGame = createGameFromState(data.dbGame);
+			gameState.currentGame = createGameFromState(
+				withCreatedOnFallback(data.dbGame, data.localGame)
+			);
 		}
 		conflict = false;
 	}

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { page } from "$app/state";
 	import { USER_LEVELS } from "$lib/constants.js";
+	import { formatWinDuration } from "$lib/formatTime.js";
 	import { Game } from "$lib/game.svelte.js";
 	import { Button } from "$lib/components/ui/button/index.js";
 	import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
@@ -70,6 +71,8 @@
 
 	let showGameOver = $state(false);
 	let showWin = $state(false);
+	/** Frozen wall-clock duration when the win overlay opens */
+	let winElapsedMs = $state(/** @type {number | null} */ (null));
 	let openMenu = $state(false);
 	/** True while waiting for move animations to finish before applying undo */
 	let undoQueued = $state(false);
@@ -95,9 +98,12 @@
 
 		if (!game.won || game.canContinue) {
 			showWin = false;
+			winElapsedMs = null;
 		} else if (animationIdle) {
 			const timeout = setTimeout(() => {
 				showWin = true;
+				winElapsedMs =
+					typeof game.createdOn === "number" ? Math.max(0, Date.now() - game.createdOn) : null;
 			}, GAME_WIN_DELAY);
 			return () => clearTimeout(timeout);
 		}
@@ -136,6 +142,7 @@
 	function newGame() {
 		showGameOver = false;
 		showWin = false;
+		winElapsedMs = null;
 		undoQueued = false;
 		restoreQueued = false;
 		if (onNewGame) {
@@ -150,6 +157,7 @@
 		if (!game) return;
 		game.canContinue = true;
 		showWin = false;
+		winElapsedMs = null;
 	}
 
 	function rotateBoard() {
@@ -201,6 +209,7 @@
 			await onRestoreCheckpoint?.();
 			showGameOver = false;
 			showWin = false;
+			winElapsedMs = null;
 		} finally {
 			checkpointBusy = false;
 		}
@@ -465,6 +474,14 @@
 					style:background-color={page.data.theme?.boardBackground}
 					style:color={page.data.theme?.textDark}
 				>
+					<span class="win-stat-label">Time</span>
+					<span class="win-stat-value">{formatWinDuration(winElapsedMs)}</span>
+				</div>
+				<div
+					class="win-stat"
+					style:background-color={page.data.theme?.boardBackground}
+					style:color={page.data.theme?.textDark}
+				>
 					<span class="win-stat-label">Highest</span>
 					<span class="win-stat-value">{winHighestTile.toLocaleString()}</span>
 				</div>
@@ -527,7 +544,7 @@
 
 	.win-stats {
 		display: grid;
-		grid-template-columns: repeat(3, minmax(0, 1fr));
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 		gap: 0.5rem;
 		margin: 0 0 1.5rem;
 	}

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -232,6 +232,18 @@
 	);
 
 	let canRestoreCheckpoint = $derived(isPro && gameState.hasCheckpoint && !checkpointBusy);
+
+	/** Highest tile on the board for the win overlay stats */
+	let winHighestTile = $derived.by(() => {
+		if (!game) return 0;
+		let max = 0;
+		for (const row of game.board) {
+			for (const cell of row) {
+				if (cell > max) max = cell;
+			}
+		}
+		return max;
+	});
 </script>
 
 <!-- Header -->
@@ -430,7 +442,33 @@
 	<div class="overlay win">
 		<div class="overlay-content">
 			<h2>You Won!</h2>
-			<p>Score: {game.score.toLocaleString()}</p>
+			<p class="win-message">You reached {game.winTile.toLocaleString()}!</p>
+			<div class="win-stats" role="group" aria-label="Game stats">
+				<div
+					class="win-stat"
+					style:background-color={page.data.theme?.boardBackground}
+					style:color={page.data.theme?.textDark}
+				>
+					<span class="win-stat-label">Score</span>
+					<span class="win-stat-value">{game.score.toLocaleString()}</span>
+				</div>
+				<div
+					class="win-stat"
+					style:background-color={page.data.theme?.boardBackground}
+					style:color={page.data.theme?.textDark}
+				>
+					<span class="win-stat-label">Moves</span>
+					<span class="win-stat-value">{game.moveCount.toLocaleString()}</span>
+				</div>
+				<div
+					class="win-stat"
+					style:background-color={page.data.theme?.boardBackground}
+					style:color={page.data.theme?.textDark}
+				>
+					<span class="win-stat-label">Highest</span>
+					<span class="win-stat-value">{winHighestTile.toLocaleString()}</span>
+				</div>
+			</div>
 			<Button class="m-1" onclick={continueGame}>Keep Playing</Button>
 			<Button class="m-1" variant="secondary" onclick={newGame}>New Game</Button>
 		</div>
@@ -467,11 +505,12 @@
 		padding: 40px;
 		border-radius: 12px;
 		text-align: center;
-		max-width: 400px;
+		max-width: 420px;
+		width: calc(100% - 2rem);
 	}
 
 	.overlay-content h2 {
-		margin: 0 0 20px 0;
+		margin: 0 0 12px 0;
 		font-size: 2rem;
 	}
 
@@ -479,5 +518,43 @@
 		margin: 0 0 30px 0;
 		color: var(--muted-foreground);
 		font-size: 1.2rem;
+	}
+
+	.win-message {
+		margin-bottom: 20px;
+		font-size: 1.05rem;
+	}
+
+	.win-stats {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: 0.5rem;
+		margin: 0 0 1.5rem;
+	}
+
+	.win-stat {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.15rem;
+		padding: 0.65rem 0.5rem;
+		border-radius: 0.5rem;
+		min-width: 0;
+	}
+
+	.win-stat-label {
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		opacity: 0.8;
+	}
+
+	.win-stat-value {
+		font-size: 1.15rem;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		line-height: 1.2;
 	}
 </style>

--- a/src/routes/stats/+page.svelte
+++ b/src/routes/stats/+page.svelte
@@ -6,6 +6,7 @@
 	import { formatChallengeElapsedMs } from "$lib/challenges.js";
 	import { DEFAULT_BOARD_SIZE, USER_LEVELS } from "$lib/constants";
 	import { Button } from "$lib/components/ui/button/index.js";
+	import { formatWinDuration } from "$lib/formatTime.js";
 	import { getTileBackground, getTileColor } from "$lib/game.svelte.js";
 
 	let { data } = $props();
@@ -69,24 +70,6 @@
 		if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
 		const formatted = value.toLocaleString();
 		return options.suffix ? `${formatted}${options.suffix}` : formatted;
-	}
-
-	/**
-	 * Classic win duration from created → completed (wall clock).
-	 * @param {number | null | undefined} ms
-	 */
-	function formatWinDuration(ms) {
-		if (typeof ms !== "number" || !Number.isFinite(ms) || ms < 0) return "—";
-		const totalSec = Math.floor(ms / 1000);
-		if (totalSec < 60) return `${totalSec}s`;
-		const minutes = Math.floor(totalSec / 60);
-		const seconds = totalSec % 60;
-		if (minutes < 60) {
-			return `${minutes}:${String(seconds).padStart(2, "0")}`;
-		}
-		const hours = Math.floor(minutes / 60);
-		const remMin = minutes % 60;
-		return `${hours}h ${remMin}m`;
 	}
 
 	/**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refactors the classic **You Won!** overlay into a run summary with **Score**, **Moves**, **Time**, and **Highest**.
- Tracks wall-clock `createdOn` on the client (local storage + server load + checkpoint restore) and freezes elapsed time when the overlay opens.
- Extracts shared `formatWinDuration` used by both the win dialog and the stats page (“Wall-clock start → finish”).

[You Won dialog with Score, Moves, Time, and Highest](https://cursor.com/agents/bc-019fa479-b21d-77e7-9feb-924f91204901/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwin-dialog-with-time.png)

## Test plan
- [x] Triggered a win overlay with a seeded `createdOn` and confirmed Time shows as `m:ss` wall-clock duration.
- [x] Confirmed Score / Moves / Highest still update correctly.
- [x] Spot-checked on a narrow viewport (~420px) with the 2×2 stats grid.
- [x] `pnpm lint` passes.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa479-b21d-77e7-9feb-924f91204901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa479-b21d-77e7-9feb-924f91204901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

