### PR TITLE
Win modal "New Best!" badges, controls refactor, checkpoint cooldown

### DIFF
--- a/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = undefined,
 		variant = "default",
 		size = "default",
 		...restProps

--- a/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -5,7 +5,7 @@
 
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = undefined,
 		variant = "outline",
 		size = "default",
 		...restProps

--- a/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -5,9 +5,9 @@
 	import { cn } from "$lib/utils.js";
 	let {
 		ref = $bindable(null),
-		class: className,
+		class: className = undefined,
 		size = "default",
-		portalProps,
+		portalProps = undefined,
 		...restProps
 	} = $props();
 </script>

--- a/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
@@ -2,7 +2,7 @@
 	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
 	import { cn } from "$lib/utils.js";
 
-	let { ref = $bindable(null), class: className, ...restProps } = $props();
+	let { ref = $bindable(null), class: className = undefined, ...restProps } = $props();
 </script>
 
 <AlertDialogPrimitive.Description

--- a/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { cn } from "$lib/utils.js";
-	let { ref = $bindable(null), class: className, children, ...restProps } = $props();
+	let { ref = $bindable(null), class: className = undefined, children, ...restProps } = $props();
 </script>
 
 <div

--- a/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { cn } from "$lib/utils.js";
 
-	let { ref = $bindable(null), class: className, children, ...restProps } = $props();
+	let { ref = $bindable(null), class: className = undefined, children, ...restProps } = $props();
 </script>
 
 <div

--- a/src/lib/components/ui/alert-dialog/alert-dialog-media.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-media.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { cn } from "$lib/utils.js";
 
-	let { ref = $bindable(null), class: className, children, ...restProps } = $props();
+	let { ref = $bindable(null), class: className = undefined, children, ...restProps } = $props();
 </script>
 
 <div

--- a/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -2,7 +2,7 @@
 	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
 	import { cn } from "$lib/utils.js";
 
-	let { ref = $bindable(null), class: className, ...restProps } = $props();
+	let { ref = $bindable(null), class: className = undefined, ...restProps } = $props();
 </script>
 
 <AlertDialogPrimitive.Overlay

--- a/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
+++ b/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
@@ -2,7 +2,7 @@
 	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
 	import { cn } from "$lib/utils.js";
 
-	let { ref = $bindable(null), class: className, ...restProps } = $props();
+	let { ref = $bindable(null), class: className = undefined, ...restProps } = $props();
 </script>
 
 <AlertDialogPrimitive.Title

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -13,6 +13,8 @@ export const TILE_MERGE_DURATION = 100;
 export const TILE_MOVE_DURATION_MS = 12;
 export const LOCAL_STORAGE_CURRENT_GAME = "play-4096.currentGame";
 export const LOCAL_STORAGE_BEST_SCORE = "play-4096.bestScore";
+/** Best win stats (fewest moves / fastest time) recorded on this device */
+export const LOCAL_STORAGE_BEST_WIN = "play-4096.bestWin";
 export const LOCAL_STORAGE_THEME = "play-4096.theme";
 export const THEME_COOKIE_NAME = "play-4096.theme";
 export const DEFAULT_WIN_TILE = 4096;

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -6,6 +6,8 @@ export const DEFAULT_BOARD_SIZE = 4;
 export const DEFAULT_STARTING_TILES = 2;
 /** Moves required after an undo before undo can be used again */
 export const UNDO_COOLDOWN_MOVES = 10;
+/** Board progress (moves) required past the active checkpoint before a new one can be set */
+export const CHECKPOINT_COOLDOWN_MOVES = 100;
 export const SPAWN_START_SCALE = 0.5;
 export const DEFAULT_LUMINANCE_THRESHOLD = 0.7;
 export const TILE_SPAWN_DURATION = 100;

--- a/src/lib/localStorage.svelte.js
+++ b/src/lib/localStorage.svelte.js
@@ -1,6 +1,7 @@
 import { browser } from "$app/environment";
 import {
 	LOCAL_STORAGE_BEST_SCORE,
+	LOCAL_STORAGE_BEST_WIN,
 	LOCAL_STORAGE_CURRENT_GAME,
 	LOCAL_STORAGE_THEME,
 } from "./constants";
@@ -87,6 +88,61 @@ export function loadBestScore() {
 export function clearBestScore() {
 	if (!browser) return;
 	localStorage.removeItem(LOCAL_STORAGE_BEST_SCORE);
+}
+
+/**
+ * Lowest of the given values, ignoring nulls (lower is better for win stats).
+ * @param {...(number | null | undefined)} values
+ * @returns {number | null}
+ */
+export function lowestOf(...values) {
+	/** @type {number | null} */
+	let lowest = null;
+	for (const value of values) {
+		if (typeof value !== "number" || !Number.isFinite(value) || value < 0) continue;
+		if (lowest == null || value < lowest) lowest = value;
+	}
+	return lowest;
+}
+
+/**
+ * Best win stats achieved on this device (exact at-win values).
+ * @returns {{ moves: number | null, timeMs: number | null }}
+ */
+export function loadBestWinStats() {
+	if (!browser) return { moves: null, timeMs: null };
+	try {
+		const raw = localStorage.getItem(LOCAL_STORAGE_BEST_WIN);
+		if (!raw) return { moves: null, timeMs: null };
+		const parsed = JSON.parse(raw);
+		return {
+			moves: lowestOf(parsed?.moves),
+			timeMs: lowestOf(parsed?.timeMs),
+		};
+	} catch {
+		return { moves: null, timeMs: null };
+	}
+}
+
+/**
+ * Record a win's stats, keeping the best (lowest) of stored and provided values.
+ * @param {{ moves?: number | null, timeMs?: number | null }} stats
+ */
+export function saveBestWinStats({ moves = null, timeMs = null } = {}) {
+	if (!browser) return;
+	const current = loadBestWinStats();
+	localStorage.setItem(
+		LOCAL_STORAGE_BEST_WIN,
+		JSON.stringify({
+			moves: lowestOf(current.moves, moves),
+			timeMs: lowestOf(current.timeMs, timeMs),
+		})
+	);
+}
+
+export function clearBestWinStats() {
+	if (!browser) return;
+	localStorage.removeItem(LOCAL_STORAGE_BEST_WIN);
 }
 
 /**

--- a/src/lib/server/checkpoint.js
+++ b/src/lib/server/checkpoint.js
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { and, desc, eq } from "drizzle-orm";
 
-import { USER_LEVELS } from "$lib/constants";
+import { CHECKPOINT_COOLDOWN_MOVES, USER_LEVELS } from "$lib/constants";
 import { db } from "$lib/server/db";
 import * as table from "$lib/server/db/schema";
 import { getUser } from "$lib/server/user";
@@ -92,6 +92,26 @@ export async function setCheckpoint(userId, snapshot) {
 	assert(typeof snapshot.score === "number", "score is required");
 
 	const existingGame = requireOwnedGame(snapshot.gameId, userId);
+
+	// Checkpoints recharge with board progress: the next one unlocks
+	// CHECKPOINT_COOLDOWN_MOVES moves past the active checkpoint. Anchoring to
+	// the checkpoint's move count means undo/restore can't shortcut the wait.
+	const activeCheckpoint = getActiveCheckpoint(userId, snapshot.gameId);
+	if (activeCheckpoint) {
+		const movesSince =
+			(snapshot.moveCount ?? existingGame.moveCount ?? 0) - activeCheckpoint.moveCount;
+		if (movesSince < CHECKPOINT_COOLDOWN_MOVES) {
+			const remaining = Math.min(CHECKPOINT_COOLDOWN_MOVES, CHECKPOINT_COOLDOWN_MOVES - movesSince);
+			const error = new Error(
+				`Checkpoint available in ${remaining} move${remaining === 1 ? "" : "s"}`
+			);
+			// @ts-ignore attach status for API handlers
+			error.status = 429;
+			// @ts-ignore
+			error.code = "CHECKPOINT_COOLDOWN";
+			throw error;
+		}
+	}
 
 	await db
 		.update(table.gameCheckpoint)

--- a/src/lib/server/game.js
+++ b/src/lib/server/game.js
@@ -92,6 +92,56 @@ export async function saveScore(_score, userId) {
 }
 
 /**
+ * Coerce a SQLite aggregate result to a finite number, or null.
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function aggregateNumber(value) {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value !== "" && Number.isFinite(Number(value))) {
+		return Number(value);
+	}
+	return null;
+}
+
+/**
+ * Personal bests across won classic games, used by the win overlay's
+ * "New Best!" badges.
+ *
+ * - Fastest win is exact: `completedOn` freezes on the first win while
+ *   `updatedOn` keeps moving (Keep Playing).
+ * - Least moves uses the run's stored `moveCount`, which keeps growing after a
+ *   Keep Playing win — an upper bound on moves-at-win. Exact at-win values from
+ *   this device live in localStorage; the client compares against the lower of
+ *   the two.
+ *
+ * @param {string} userId
+ * @returns {{ leastMovesToWin: number | null, fastestWinMs: number | null }}
+ */
+export function getBestWinStats(userId) {
+	// Timestamps are stored as unix seconds (drizzle `mode: "timestamp"`).
+	const winSeconds = sql`coalesce(${table.game.completedOn}, ${table.game.updatedOn}) - ${table.game.createdOn}`;
+
+	const row = db
+		.select({
+			leastMovesToWin: sql`min(${table.game.moveCount})`,
+			// Per-game negative durations (clock skew / bad data) are ignored, matching stats
+			fastestWinSeconds: sql`min(case when ${winSeconds} >= 0 then ${winSeconds} end)`,
+		})
+		.from(table.game)
+		.where(and(eq(table.game.playerId, userId), eq(table.game.won, true)))
+		.get();
+
+	const leastMovesToWin = aggregateNumber(row?.leastMovesToWin);
+	const fastestWinSeconds = aggregateNumber(row?.fastestWinSeconds);
+
+	return {
+		leastMovesToWin,
+		fastestWinMs: fastestWinSeconds == null ? null : fastestWinSeconds * 1000,
+	};
+}
+
+/**
  * Normalize moves for persistence
  * @param {number[] | null | undefined} moves
  * @returns {number[] | null}

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -3,7 +3,7 @@
 	import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
 	import { Badge } from "$lib/components/ui/badge/index.js";
 	import { Button } from "$lib/components/ui/button/index.js";
-	import { clearBestScore, clearGame } from "$lib/localStorage.svelte";
+	import { clearBestScore, clearBestWinStats, clearGame } from "$lib/localStorage.svelte";
 	import {
 		LogOutIcon,
 		PencilIcon,
@@ -27,8 +27,11 @@
 	function clearUserData() {
 		clearGame();
 		clearBestScore();
+		clearBestWinStats();
 
 		gameState.bestScore = 0;
+		gameState.bestWinMoves = null;
+		gameState.bestWinTimeMs = null;
 		gameState.currentGame = null;
 	}
 

--- a/src/routes/game/+page.js
+++ b/src/routes/game/+page.js
@@ -11,7 +11,7 @@ import { general, gameState } from "./state.svelte.js";
 
 /** @type {import("./$types").PageLoad} */
 export async function load({ data, fetch }) {
-	let { user, dbGame, winBests } = data;
+	let { user, dbGame, checkpoint, winBests } = data;
 	let bestScore = user?.bestScore ?? 0;
 	let localGame = null;
 
@@ -70,5 +70,6 @@ export async function load({ data, fetch }) {
 		dbGame,
 		localGame,
 		bestScore,
+		checkpoint,
 	};
 }

--- a/src/routes/game/+page.js
+++ b/src/routes/game/+page.js
@@ -1,11 +1,17 @@
 import { browser } from "$app/environment";
 import { deserialize } from "$app/forms";
-import { loadBestScore, loadGame, saveBestScore } from "$lib/localStorage.svelte";
+import {
+	loadBestScore,
+	loadBestWinStats,
+	loadGame,
+	lowestOf,
+	saveBestScore,
+} from "$lib/localStorage.svelte";
 import { general, gameState } from "./state.svelte.js";
 
 /** @type {import("./$types").PageLoad} */
 export async function load({ data, fetch }) {
-	let { user, dbGame } = data;
+	let { user, dbGame, winBests } = data;
 	let bestScore = user?.bestScore ?? 0;
 	let localGame = null;
 
@@ -18,6 +24,20 @@ export async function load({ data, fetch }) {
 	if (browser) {
 		// Load game from local storage
 		localGame = loadGame();
+
+		// Previous best win stats: lowest of session, this device (exact at-win
+		// values) and the account's won games (server) for the "New Best!" badges.
+		const localWinStats = loadBestWinStats();
+		gameState.bestWinMoves = lowestOf(
+			gameState.bestWinMoves,
+			localWinStats.moves,
+			winBests?.leastMovesToWin
+		);
+		gameState.bestWinTimeMs = lowestOf(
+			gameState.bestWinTimeMs,
+			localWinStats.timeMs,
+			winBests?.fastestWinMs
+		);
 
 		if (user) {
 			// Authoritative personal best comes from ranked games on the server.

--- a/src/routes/game/+page.server.js
+++ b/src/routes/game/+page.server.js
@@ -8,7 +8,8 @@ import { fail } from "@sveltejs/kit";
 export function load({ locals }) {
 	let user = null;
 	let dbGame = null;
-	let hasCheckpoint = false;
+	/** @type {import("$lib/types").CheckpointInfo | null} */
+	let checkpoint = null;
 	/** @type {{ leastMovesToWin: number | null, fastestWinMs: number | null } | null} */
 	let winBests = null;
 
@@ -32,7 +33,7 @@ export function load({ locals }) {
 			};
 
 			if (user?.level === USER_LEVELS.PRO) {
-				hasCheckpoint = !!getActiveCheckpoint(locals.user.id, gameId);
+				checkpoint = getActiveCheckpoint(locals.user.id, gameId);
 			}
 		}
 	}
@@ -41,7 +42,7 @@ export function load({ locals }) {
 		user,
 		/** @type {import("$lib/types").GameState & { lastUpdated: number } | null} */
 		dbGame,
-		hasCheckpoint,
+		checkpoint,
 		winBests,
 	};
 }

--- a/src/routes/game/+page.server.js
+++ b/src/routes/game/+page.server.js
@@ -1,6 +1,6 @@
 import { USER_LEVELS } from "$lib/constants.js";
 import { getActiveCheckpoint } from "$lib/server/checkpoint";
-import { getCurrentGame, syncBestScoreFromGames } from "$lib/server/game";
+import { getBestWinStats, getCurrentGame, syncBestScoreFromGames } from "$lib/server/game";
 import { getUserProfile } from "$lib/server/user.js";
 import { fail } from "@sveltejs/kit";
 
@@ -9,9 +9,12 @@ export function load({ locals }) {
 	let user = null;
 	let dbGame = null;
 	let hasCheckpoint = false;
+	/** @type {{ leastMovesToWin: number | null, fastestWinMs: number | null } | null} */
+	let winBests = null;
 
 	if (locals.user) {
 		user = getUserProfile(locals.user.id);
+		winBests = getBestWinStats(locals.user.id);
 		dbGame = getCurrentGame(locals.user.id);
 		if (dbGame) {
 			const gameId = dbGame.id;
@@ -39,6 +42,7 @@ export function load({ locals }) {
 		/** @type {import("$lib/types").GameState & { lastUpdated: number } | null} */
 		dbGame,
 		hasCheckpoint,
+		winBests,
 	};
 }
 

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount } from "svelte";
 	import { page } from "$app/state";
+	import { toast } from "svelte-sonner";
 
 	import { Game, isSameGame } from "$lib/game.svelte.js";
 	import { DIRECTIONS } from "$lib/constants.js";
@@ -119,6 +120,17 @@
 			);
 		}
 		conflict = false;
+		syncCheckpointFromData();
+	}
+
+	/**
+	 * Apply the server's active checkpoint when it belongs to the loaded game
+	 */
+	function syncCheckpointFromData() {
+		const checkpoint = data.checkpoint;
+		const applies = !!checkpoint && gameState.currentGame?.id === checkpoint.gameId;
+		gameState.hasCheckpoint = applies;
+		gameState.checkpointMoveCount = applies && checkpoint ? checkpoint.moveCount : null;
 	}
 
 	/**
@@ -236,6 +248,7 @@
 
 		pendingEvents.splice(0, pendingEvents.length);
 		gameState.hasCheckpoint = false;
+		gameState.checkpointMoveCount = null;
 		gameState.currentGame = new Game();
 	}
 
@@ -318,6 +331,9 @@
 		const gameId = await ensurePersistedGameId();
 		if (!gameId) {
 			console.error("Unable to set checkpoint: game is not saved");
+			toast.error("Couldn't set checkpoint", {
+				description: "The game hasn't synced to the server yet. Try again in a moment.",
+			});
 			return;
 		}
 
@@ -343,8 +359,15 @@
 				throw new Error(result.error || "Failed to set checkpoint");
 			}
 			gameState.hasCheckpoint = true;
+			gameState.checkpointMoveCount = result.checkpoint?.moveCount ?? snapshot.moveCount;
+			toast.success("Checkpoint saved", {
+				description: `Score ${snapshot.score.toLocaleString()} · move ${snapshot.moveCount.toLocaleString()}`,
+			});
 		} catch (error) {
 			console.error("Failed to set checkpoint:", error);
+			toast.error("Couldn't set checkpoint", {
+				description: error instanceof Error ? error.message : "Please try again.",
+			});
 		}
 	}
 
@@ -371,10 +394,14 @@
 				initialState: result.game,
 			});
 			gameState.hasCheckpoint = true;
+			gameState.checkpointMoveCount = result.game.moveCount ?? null;
 			localSaveGame(gameState.currentGame.json());
 			queueMicrotask(() => flushSaveToServer());
 		} catch (error) {
 			console.error("Failed to restore checkpoint:", error);
+			toast.error("Couldn't restore checkpoint", {
+				description: error instanceof Error ? error.message : "Please try again.",
+			});
 		}
 	}
 
@@ -439,8 +466,8 @@
 
 	// Setup listeners on mount
 	onMount(() => {
-		gameState.hasCheckpoint = !!data.hasCheckpoint;
 		tryLoadGame();
+		syncCheckpointFromData();
 
 		window.addEventListener("keydown", handleKeydown);
 		document.addEventListener("visibilitychange", handleVisibilityChange);

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -1,8 +1,10 @@
 <script>
+	import { untrack } from "svelte";
 	import { page } from "$app/state";
 	import { USER_LEVELS } from "$lib/constants.js";
 	import { formatWinDuration } from "$lib/formatTime.js";
 	import { Game } from "$lib/game.svelte.js";
+	import { saveBestWinStats } from "$lib/localStorage.svelte.js";
 	import { Button } from "$lib/components/ui/button/index.js";
 	import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
 	import { gameState } from "../state.svelte.js";
@@ -73,6 +75,8 @@
 	let showWin = $state(false);
 	/** Frozen wall-clock duration when the win overlay opens */
 	let winElapsedMs = $state(/** @type {number | null} */ (null));
+	/** Which of this win's stats are personal bests, frozen when the overlay opens */
+	let winNewBest = $state({ score: false, moves: false, time: false });
 	let openMenu = $state(false);
 	/** True while waiting for move animations to finish before applying undo */
 	let undoQueued = $state(false);
@@ -93,17 +97,48 @@
 		}
 	});
 
+	/**
+	 * Freeze this win's stats, flag the ones beating the previous bests, then
+	 * fold the run into session + device bests for future comparisons.
+	 */
+	function captureWinStats() {
+		if (!game) return;
+
+		const score = game.score;
+		const moves = game.moveCount;
+		const elapsedMs =
+			typeof game.createdOn === "number" ? Math.max(0, Date.now() - game.createdOn) : null;
+
+		winElapsedMs = elapsedMs;
+		winNewBest = {
+			// bestScore is raised live while playing, so a new best shows up as a tie
+			score: score >= gameState.bestScore,
+			moves: gameState.bestWinMoves == null || moves < gameState.bestWinMoves,
+			time:
+				elapsedMs != null &&
+				(gameState.bestWinTimeMs == null || elapsedMs < gameState.bestWinTimeMs),
+		};
+
+		if (score > gameState.bestScore) gameState.bestScore = score;
+		if (winNewBest.moves) gameState.bestWinMoves = moves;
+		if (winNewBest.time) gameState.bestWinTimeMs = elapsedMs;
+		saveBestWinStats({ moves, timeMs: elapsedMs });
+	}
+
 	$effect(() => {
 		if (!game) return;
 
 		if (!game.won || game.canContinue) {
 			showWin = false;
 			winElapsedMs = null;
+			winNewBest = { score: false, moves: false, time: false };
 		} else if (animationIdle) {
+			// Already open — moves made behind the overlay must not reset frozen stats
+			if (untrack(() => showWin)) return;
+
 			const timeout = setTimeout(() => {
 				showWin = true;
-				winElapsedMs =
-					typeof game.createdOn === "number" ? Math.max(0, Date.now() - game.createdOn) : null;
+				captureWinStats();
 			}, GAME_WIN_DELAY);
 			return () => clearTimeout(timeout);
 		}
@@ -241,18 +276,6 @@
 	);
 
 	let canRestoreCheckpoint = $derived(isPro && gameState.hasCheckpoint && !checkpointBusy);
-
-	/** Highest tile on the board for the win overlay stats */
-	let winHighestTile = $derived.by(() => {
-		if (!game) return 0;
-		let max = 0;
-		for (const row of game.board) {
-			for (const cell of row) {
-				if (cell > max) max = cell;
-			}
-		}
-		return max;
-	});
 </script>
 
 <!-- Header -->
@@ -451,13 +474,15 @@
 	<div class="overlay win">
 		<div class="overlay-content">
 			<h2>You Won!</h2>
-			<p class="win-message">You reached {game.winTile.toLocaleString()}!</p>
 			<div class="win-stats" role="group" aria-label="Game stats">
 				<div
 					class="win-stat"
 					style:background-color={page.data.theme?.boardBackground}
 					style:color={page.data.theme?.textDark}
 				>
+					{#if winNewBest.score}
+						<span class="win-stat-badge">New Best!</span>
+					{/if}
 					<span class="win-stat-label">Score</span>
 					<span class="win-stat-value">{game.score.toLocaleString()}</span>
 				</div>
@@ -466,6 +491,9 @@
 					style:background-color={page.data.theme?.boardBackground}
 					style:color={page.data.theme?.textDark}
 				>
+					{#if winNewBest.moves}
+						<span class="win-stat-badge">New Best!</span>
+					{/if}
 					<span class="win-stat-label">Moves</span>
 					<span class="win-stat-value">{game.moveCount.toLocaleString()}</span>
 				</div>
@@ -474,16 +502,11 @@
 					style:background-color={page.data.theme?.boardBackground}
 					style:color={page.data.theme?.textDark}
 				>
+					{#if winNewBest.time}
+						<span class="win-stat-badge">New Best!</span>
+					{/if}
 					<span class="win-stat-label">Time</span>
 					<span class="win-stat-value">{formatWinDuration(winElapsedMs)}</span>
-				</div>
-				<div
-					class="win-stat"
-					style:background-color={page.data.theme?.boardBackground}
-					style:color={page.data.theme?.textDark}
-				>
-					<span class="win-stat-label">Highest</span>
-					<span class="win-stat-value">{winHighestTile.toLocaleString()}</span>
 				</div>
 			</div>
 			<Button class="m-1" onclick={continueGame}>Keep Playing</Button>
@@ -537,19 +560,15 @@
 		font-size: 1.2rem;
 	}
 
-	.win-message {
-		margin-bottom: 20px;
-		font-size: 1.05rem;
-	}
-
 	.win-stats {
 		display: grid;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
+		grid-template-columns: repeat(3, minmax(0, 1fr));
 		gap: 0.5rem;
-		margin: 0 0 1.5rem;
+		margin: 1.25rem 0 1.5rem;
 	}
 
 	.win-stat {
+		position: relative;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -558,6 +577,41 @@
 		padding: 0.65rem 0.5rem;
 		border-radius: 0.5rem;
 		min-width: 0;
+	}
+
+	.win-stat-badge {
+		position: absolute;
+		top: -0.55rem;
+		left: 50%;
+		transform: translateX(-50%);
+		padding: 0.16rem 0.45rem;
+		border-radius: 999px;
+		background: linear-gradient(135deg, #fbbf24, #f59e0b);
+		color: #451a03;
+		font-size: 0.58rem;
+		font-weight: 800;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		white-space: nowrap;
+		box-shadow: 0 2px 6px rgb(0 0 0 / 0.25);
+		animation: win-badge-pop 300ms cubic-bezier(0.34, 1.56, 0.64, 1) 250ms both;
+	}
+
+	@keyframes win-badge-pop {
+		from {
+			opacity: 0;
+			transform: translateX(-50%) scale(0.5);
+		}
+		to {
+			opacity: 1;
+			transform: translateX(-50%) scale(1);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.win-stat-badge {
+			animation: none;
+		}
 	}
 
 	.win-stat-label {

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -5,46 +5,21 @@
 	import { formatWinDuration } from "$lib/formatTime.js";
 	import { Game } from "$lib/game.svelte.js";
 	import { saveBestWinStats } from "$lib/localStorage.svelte.js";
+	import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
 	import { Button } from "$lib/components/ui/button/index.js";
-	import * as DropdownMenu from "$lib/components/ui/dropdown-menu/index.js";
 	import { gameState } from "../state.svelte.js";
 	import {
 		BookmarkIcon,
 		BookmarkPlusIcon,
 		CrownIcon,
 		LoaderCircleIcon,
-		MenuIcon,
 		MoveHorizontalIcon,
 		MoveVerticalIcon,
 		PlusIcon,
 		RotateCcwIcon,
 		RotateCwIcon,
 		Undo2Icon,
-		XIcon,
 	} from "@lucide/svelte";
-	import { cubicOut } from "svelte/easing";
-
-	/**
-	 * Custom transition that combines scale and rotation
-	 * @param {HTMLElement} node
-	 * @param {{ duration?: number; start?: number; delay?: number; rotateDegrees?: number }} params
-	 */
-	function scaleRotate(node, params = {}) {
-		const { duration = 200, start = 0.8, delay = 0, rotateDegrees = 45 } = params;
-		return {
-			delay,
-			duration,
-			easing: cubicOut,
-			/**
-			 * @param {number} t
-			 */
-			css: (t) => {
-				const scaleValue = start + (1 - start) * t;
-				const rotate = rotateDegrees * (1 - t);
-				return `transform: scale(${scaleValue}) rotate(${rotate}deg); opacity: ${t};`;
-			},
-		};
-	}
 
 	let game = $derived(gameState.currentGame);
 	let isPro = $derived(page.data.user?.level === USER_LEVELS.PRO);
@@ -77,12 +52,15 @@
 	let winElapsedMs = $state(/** @type {number | null} */ (null));
 	/** Which of this win's stats are personal bests, frozen when the overlay opens */
 	let winNewBest = $state({ score: false, moves: false, time: false });
-	let openMenu = $state(false);
+	/** Confirmation dialog before ending a run in progress for a new game */
+	let confirmNewGame = $state(false);
 	/** True while waiting for move animations to finish before applying undo */
 	let undoQueued = $state(false);
 	/** True while waiting for animations before restoring a checkpoint */
 	let restoreQueued = $state(false);
 	let checkpointBusy = $state(false);
+	/** Which checkpoint op is in flight, so only that button shows a spinner @type {"set" | "restore" | null} */
+	let checkpointAction = $state(null);
 
 	$effect(() => {
 		if (!game) return;
@@ -188,6 +166,20 @@
 		gameState.currentGame = new Game();
 	}
 
+	/** Confirm before ending a run in progress; start right away when nothing is lost */
+	function requestNewGame() {
+		if (!game || game.moveCount === 0 || game.gameOver) {
+			newGame();
+			return;
+		}
+		confirmNewGame = true;
+	}
+
+	function confirmStartNewGame() {
+		confirmNewGame = false;
+		newGame();
+	}
+
 	function continueGame() {
 		if (!game) return;
 		game.canContinue = true;
@@ -227,19 +219,20 @@
 
 	async function runSetCheckpoint() {
 		if (!isPro || !game || checkpointBusy) return;
-		openMenu = false;
 		checkpointBusy = true;
+		checkpointAction = "set";
 		try {
 			await onSetCheckpoint?.();
 		} finally {
 			checkpointBusy = false;
+			checkpointAction = null;
 		}
 	}
 
 	async function runRestoreCheckpoint() {
 		if (!isPro || !game || !gameState.hasCheckpoint || checkpointBusy) return;
-		openMenu = false;
 		checkpointBusy = true;
+		checkpointAction = "restore";
 		try {
 			await onRestoreCheckpoint?.();
 			showGameOver = false;
@@ -247,6 +240,7 @@
 			winElapsedMs = null;
 		} finally {
 			checkpointBusy = false;
+			checkpointAction = null;
 		}
 	}
 
@@ -276,6 +270,26 @@
 	);
 
 	let canRestoreCheckpoint = $derived(isPro && gameState.hasCheckpoint && !checkpointBusy);
+
+	let setCheckpointBusy = $derived(checkpointBusy && checkpointAction === "set");
+	let restoreCheckpointBusy = $derived(
+		restoreQueued || (checkpointBusy && checkpointAction === "restore")
+	);
+
+	let setCheckpointTitle = $derived(
+		setCheckpointBusy
+			? "Saving checkpoint…"
+			: game?.gameOver
+				? "Checkpoints can only be set during an active game"
+				: "Set a checkpoint for this run"
+	);
+	let restoreCheckpointTitle = $derived(
+		restoreCheckpointBusy
+			? "Restoring checkpoint…"
+			: gameState.hasCheckpoint
+				? "Restore your last checkpoint"
+				: "No checkpoint set"
+	);
 </script>
 
 <!-- Header -->
@@ -312,79 +326,56 @@
 </div>
 
 <div class="mb-2 flex items-center gap-1">
-	<DropdownMenu.Root bind:open={openMenu}>
-		<DropdownMenu.Trigger
-			class="controls-btn relative bg-primary text-primary-foreground hover:bg-primary/80"
-			aria-label="Game menu"
-		>
-			<div class="relative h-[18px] w-[18px]">
-				{#if openMenu}
-					<div
-						class="absolute inset-0"
-						in:scaleRotate={{ duration: 200, start: 0.8, delay: 100, rotateDegrees: -45 }}
-						out:scaleRotate={{ duration: 150, start: 0.8, rotateDegrees: -45 }}
-					>
-						<XIcon size={18} />
-					</div>
-				{:else}
-					<div
-						class="absolute inset-0"
-						in:scaleRotate={{ duration: 200, start: 0.8, delay: 100 }}
-						out:scaleRotate={{ duration: 150, start: 0.8 }}
-					>
-						<MenuIcon size={18} />
-					</div>
-				{/if}
-			</div>
-		</DropdownMenu.Trigger>
-		<DropdownMenu.Content class="w-56">
-			<DropdownMenu.Item onSelect={newGame}>
-				<PlusIcon size={18} />
-				New Game
-			</DropdownMenu.Item>
-			{#if isPro}
-				<DropdownMenu.Item
-					onSelect={() => void runSetCheckpoint()}
-					disabled={!game || game.gameOver || checkpointBusy}
-					title={game?.gameOver
-						? "Checkpoints can only be set during an active game"
-						: "Save a restore point for this run"}
-				>
-					{#if checkpointBusy}
-						<LoaderCircleIcon class="animate-spin" size={18} />
-					{:else}
-						<BookmarkPlusIcon size={18} />
-					{/if}
-					Set Checkpoint
-				</DropdownMenu.Item>
-				<DropdownMenu.Item
-					onSelect={handleRestoreCheckpoint}
-					disabled={!canRestoreCheckpoint && !restoreQueued}
-					title={gameState.hasCheckpoint ? "Restore to your last checkpoint" : "No checkpoint set"}
-				>
-					{#if restoreQueued || checkpointBusy}
-						<LoaderCircleIcon class="animate-spin" size={18} />
-					{:else}
-						<BookmarkIcon size={18} />
-					{/if}
-					Restore Checkpoint
-				</DropdownMenu.Item>
-			{:else}
-				<Button
-					href={isLoggedIn ? "/stripe" : "/login"}
-					variant="ghost"
-					class="w-full justify-start gap-2 px-2"
-					onclick={() => {
-						openMenu = false;
-					}}
-				>
-					<CrownIcon size={18} />
-					Checkpoints (Pro)
-				</Button>
-			{/if}
-		</DropdownMenu.Content>
-	</DropdownMenu.Root>
+	<button
+		class="controls-btn bg-primary text-primary-foreground hover:bg-primary/80"
+		onclick={requestNewGame}
+		title="New game"
+		aria-label="New game"
+		aria-haspopup="dialog"
+	>
+		<PlusIcon size={18} />
+	</button>
 	<div class="flex-1"></div>
+	{#if isPro}
+		<button
+			class="controls-btn relative bg-primary text-primary-foreground hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-40"
+			onclick={() => void runSetCheckpoint()}
+			disabled={!game || game.gameOver || checkpointBusy}
+			title={setCheckpointTitle}
+			aria-label={setCheckpointTitle}
+			aria-busy={setCheckpointBusy}
+		>
+			{#if setCheckpointBusy}
+				<LoaderCircleIcon class="animate-spin" size={18} />
+			{:else}
+				<BookmarkPlusIcon size={18} />
+			{/if}
+		</button>
+		<button
+			class="controls-btn relative bg-primary text-primary-foreground hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-40"
+			onclick={handleRestoreCheckpoint}
+			disabled={!canRestoreCheckpoint && !restoreQueued}
+			title={restoreCheckpointTitle}
+			aria-label={restoreCheckpointTitle}
+			aria-busy={restoreCheckpointBusy}
+		>
+			{#if restoreCheckpointBusy}
+				<LoaderCircleIcon class="animate-spin" size={18} />
+			{:else}
+				<BookmarkIcon size={18} />
+			{/if}
+		</button>
+	{:else}
+		<a
+			href={isLoggedIn ? "/stripe" : "/login"}
+			class="controls-btn relative flex items-center justify-center bg-primary text-primary-foreground hover:bg-primary/80"
+			title="Checkpoints (Pro)"
+			aria-label="Checkpoints (Pro)"
+		>
+			<BookmarkPlusIcon size={18} />
+			<span class="pro-badge"><CrownIcon size={10} /></span>
+		</a>
+	{/if}
 	<button
 		class="controls-btn relative bg-primary text-primary-foreground hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-40"
 		onclick={handleUndo}
@@ -446,7 +437,7 @@
 					onclick={handleRestoreCheckpoint}
 					disabled={checkpointBusy || restoreQueued}
 				>
-					{#if restoreQueued || checkpointBusy}
+					{#if restoreCheckpointBusy}
 						Restoring…
 					{:else}
 						Restore Checkpoint
@@ -515,6 +506,22 @@
 	</div>
 {/if}
 
+<AlertDialog.Root bind:open={confirmNewGame}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Start a new game?</AlertDialog.Title>
+			<AlertDialog.Description>
+				This ends your current run{game ? ` at ${game.score.toLocaleString()} points` : ""} and starts
+				a fresh board.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Action onclick={confirmStartNewGame}>New Game</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
 <style lang="postcss">
 	@reference "../../../app.css";
 
@@ -524,6 +531,10 @@
 
 	.cooldown-badge {
 		@apply absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-black/70 px-1 text-[10px] leading-none font-bold text-white;
+	}
+
+	.pro-badge {
+		@apply absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-amber-400 text-amber-950;
 	}
 
 	.overlay {

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { untrack } from "svelte";
 	import { page } from "$app/state";
-	import { USER_LEVELS } from "$lib/constants.js";
+	import { CHECKPOINT_COOLDOWN_MOVES, USER_LEVELS } from "$lib/constants.js";
 	import { formatWinDuration } from "$lib/formatTime.js";
 	import { Game } from "$lib/game.svelte.js";
 	import { saveBestWinStats } from "$lib/localStorage.svelte.js";
@@ -163,6 +163,7 @@
 			return;
 		}
 		gameState.hasCheckpoint = false;
+		gameState.checkpointMoveCount = null;
 		gameState.currentGame = new Game();
 	}
 
@@ -218,7 +219,7 @@
 	}
 
 	async function runSetCheckpoint() {
-		if (!isPro || !game || checkpointBusy) return;
+		if (!isPro || !game || checkpointBusy || checkpointCooldownRemaining > 0) return;
 		checkpointBusy = true;
 		checkpointAction = "set";
 		try {
@@ -271,6 +272,15 @@
 
 	let canRestoreCheckpoint = $derived(isPro && gameState.hasCheckpoint && !checkpointBusy);
 
+	// Checkpoints recharge with board progress: the next one unlocks
+	// CHECKPOINT_COOLDOWN_MOVES moves past the active checkpoint. Anchoring to the
+	// checkpoint's move count means undo/restore can't shortcut the wait.
+	let checkpointCooldownRemaining = $derived.by(() => {
+		if (!game || !gameState.hasCheckpoint || gameState.checkpointMoveCount == null) return 0;
+		const movesSince = game.moveCount - gameState.checkpointMoveCount;
+		return Math.min(CHECKPOINT_COOLDOWN_MOVES, Math.max(0, CHECKPOINT_COOLDOWN_MOVES - movesSince));
+	});
+
 	let setCheckpointBusy = $derived(checkpointBusy && checkpointAction === "set");
 	let restoreCheckpointBusy = $derived(
 		restoreQueued || (checkpointBusy && checkpointAction === "restore")
@@ -281,7 +291,9 @@
 			? "Saving checkpoint…"
 			: game?.gameOver
 				? "Checkpoints can only be set during an active game"
-				: "Set a checkpoint for this run"
+				: checkpointCooldownRemaining > 0
+					? `Checkpoint available in ${checkpointCooldownRemaining} move${checkpointCooldownRemaining === 1 ? "" : "s"}`
+					: "Set a checkpoint for this run"
 	);
 	let restoreCheckpointTitle = $derived(
 		restoreCheckpointBusy
@@ -340,7 +352,7 @@
 		<button
 			class="controls-btn relative bg-primary text-primary-foreground hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-40"
 			onclick={() => void runSetCheckpoint()}
-			disabled={!game || game.gameOver || checkpointBusy}
+			disabled={!game || game.gameOver || checkpointBusy || checkpointCooldownRemaining > 0}
 			title={setCheckpointTitle}
 			aria-label={setCheckpointTitle}
 			aria-busy={setCheckpointBusy}
@@ -349,6 +361,9 @@
 				<LoaderCircleIcon class="animate-spin" size={18} />
 			{:else}
 				<BookmarkPlusIcon size={18} />
+			{/if}
+			{#if checkpointCooldownRemaining > 0 && !setCheckpointBusy}
+				<span class="cooldown-badge">{checkpointCooldownRemaining}</span>
 			{/if}
 		</button>
 		<button

--- a/src/routes/game/state.svelte.js
+++ b/src/routes/game/state.svelte.js
@@ -13,6 +13,9 @@ export const gameState = $state({
 
 	/** Whether the current game has an active restorable checkpoint */
 	hasCheckpoint: false,
+
+	/** Move count when the active checkpoint was set — drives the set-checkpoint cooldown @type {number | null} */
+	checkpointMoveCount: null,
 });
 
 export const general = $state({

--- a/src/routes/game/state.svelte.js
+++ b/src/routes/game/state.svelte.js
@@ -2,6 +2,12 @@ export const gameState = $state({
 	/** @type {number} */
 	bestScore: 0,
 
+	/** Fewest moves in any previous win — null until a win is known @type {number | null} */
+	bestWinMoves: null,
+
+	/** Fastest previous win in ms — null until a win is known @type {number | null} */
+	bestWinTimeMs: null,
+
 	/** @type {import("$lib/game.svelte.js").Game | null} */
 	currentGame: null,
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Win overlay

- Removes the redundant tile number: both the "You reached 4,096!" line and the "Highest" stat always equal the win tile when the overlay opens, so they carried no information. The stats are now a single Score / Moves / Time row.
- Adds a gold "New Best!" badge to each stat when this win beats the player's previous personal best.

| First win (all bests) | Mixed | No new bests | Logged in (server bests) |
| --- | --- | --- | --- |
| [First win, all three badges](/opt/cursor/artifacts/screenshots/win-modal-first-win.png) | [Score and time badges only](/opt/cursor/artifacts/screenshots/win-modal-mixed-badges.png) | [No badges](/opt/cursor/artifacts/screenshots/win-modal-no-badges.png) | [Time badge only, from server-side bests](/opt/cursor/artifacts/screenshots/win-modal-logged-in.png) |

### Controls row

- **Set/Restore Checkpoint** move out of the hamburger dropdown into the controls row as icon buttons directly next to undo (Pro). Guests and free users see a single crown-badged bookmark button in their place linking to the existing upgrade path (`/stripe`, or `/login` for guests). Busy spinners are scoped to whichever checkpoint operation is in flight.
- **The menu button becomes a plus button.** With an active run in progress it opens a confirmation dialog (showing the at-stake score) before starting a new game; fresh boards and finished games skip straight to a new game. The dropdown menu is gone entirely.

| Controls row (Pro) | New-game confirmation |
| --- | --- |
| [Plus, checkpoint, undo and transform buttons in one row](/opt/cursor/artifacts/screenshots/controls-row-pro.png) | [Start a new game confirmation dialog](/opt/cursor/artifacts/screenshots/new-game-confirm.png) |

### Checkpoint cooldown + toasts (Pro)

- **Setting a checkpoint starts a 100-turn cooldown.** The next checkpoint unlocks `CHECKPOINT_COOLDOWN_MOVES` (100) moves of board progress past the active checkpoint (`game.moveCount − checkpoint.moveCount`). Anchoring to the checkpoint's already-persisted move count needs no schema change, survives reloads, and can't be shortcut with undo or restore — restoring rewinds board progress, so the cooldown re-arms to the full 100.
- While cooling down, the set button disables with a countdown badge (matching undo's) and an explanatory tooltip ("Checkpoint available in N moves").
- **Server-enforced too:** `setCheckpoint()` rejects requests inside the cooldown with `429` / `CHECKPOINT_COOLDOWN` and the remaining-move message, so the rule can't be bypassed by calling the API directly.
- **A toast confirms a successful set** ("Checkpoint saved — Score X · move N") via the already-mounted svelte-sonner Toaster; set/restore failures now also toast instead of failing silently.
- Fixes a bug this feature surfaced: the game page's universal load dropped the server's checkpoint flag, so after any reload the restore button was dead even with an active checkpoint. The active checkpoint's info now flows through the full load chain (applied only when it belongs to the loaded game), so restore and the cooldown both survive reloads.

| Just set (badge 100) | Toast + countdown at 97 | Recharged after 100+ moves |
| --- | --- | --- |
| [Set button disabled with 100-move badge](/opt/cursor/artifacts/screenshots/cooldown-a2-toast.png) | [Checkpoint saved toast while badge counts down](/opt/cursor/artifacts/screenshots/cooldown-a4-counting.png) | [Set button enabled again once recharged](/opt/cursor/artifacts/screenshots/cooldown-b1-recharged.png) |

## How previous bests are determined

- **Score** — compares against the existing best-score tracking (`gameState.bestScore`, live-raised while playing and server-synced for logged-in users). Because it is raised live, a new best shows up as a tie at win time, hence the `>=` comparison.
- **Moves / Time** — new tracking:
  - `getBestWinStats()` aggregates fewest moves and fastest win (`completedOn - createdOn`, unix seconds → ms) over the account's won games, returned from the game page's server load.
  - Exact at-win values are recorded per device in localStorage (`play-4096.bestWin`) the moment the overlay opens.
  - At page load the session compares against the lowest of session / device / server values. Device values are exact at-win numbers; the server's `moveCount` keeps growing after a Keep Playing win, so it acts as an upper bound (same semantics as the stats page's `leastMovesToWin`).
- Every win is folded into session + device bests, so consecutive wins in one session compare correctly; local win bests are cleared with other local data on logout / account deletion.

Also hardens the win-overlay effect: once open, moves made behind it (arrow keys still register) no longer re-trigger the effect, which previously reset the frozen `winElapsedMs`.

## Type-checking fix

The vendored alert-dialog components destructured `class` / `portalProps` without defaults, so svelte-check inferred them as required and flagged every call site omitting them (part of the large pre-existing error baseline). Adding `= undefined` defaults restores the intended optional typing: **svelte-check drops from 158 errors on `main` to 144 on this branch**, with strictly no new error locations (the remainder is the pre-existing `Button` typing pattern; the AGENTS.md note claiming 4 errors is stale).

## Testing

Playwright end-to-end against the dev server (Chromium): 40/40 checks (win overlay + controls) and 21/21 checks (checkpoint cooldown):

- **Win overlay** — guest first win (all badges + exact at-win values written to localStorage), all-bests-better (no badges), mixed (score+time only), and logged-in with seeded DB history (70,000 pts / 50 moves / 2h previous win correctly suppresses score+moves badges and allows the ~10min time badge, proving the server aggregate and seconds→ms conversion).
- **Controls** — plus button starts immediately on a fresh board (no dialog); with progress it opens the confirmation (title + score shown), Cancel preserves the game, confirm resets to a 2-tile board; guests get the `Checkpoints (Pro)` upsell link; Pro users get set/restore buttons directly before undo, restore disabled until a checkpoint exists, and a full set → move → restore round-trip returns the exact board and score.
- **Checkpoint cooldown** — set shows the success toast and arms the badge at 100; three moves tick it to 97; a direct API `POST` inside the cooldown is rejected with `429 CHECKPOINT_COOLDOWN`; after a reload the badge still reads 97 and restore is enabled (the reload regression fix); restoring re-arms the badge to 100 and rewinds the board; a new game clears checkpoint + cooldown; a seeded game 140 moves past its checkpoint has the set button enabled again, and re-setting re-arms the cooldown.
- `pnpm lint` and `pnpm build` pass; svelte-check unchanged at 144 (no new errors in touched files).

Pre-existing, unrelated notes: `pnpm db:seed` fails under plain Node (`schema/index.js` imports `./gameSchemas.js` but the file is `.ts`); `pnpm build` requires `BUILD_VERSION` in `.env` (as in `.env.example`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb415-a80b-71b6-a655-8da93f490158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb415-a80b-71b6-a655-8da93f490158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

