### PR TITLE
Confirm checkpoint restore with moves-back count and undo icon

### DIFF
--- a/src/routes/game/components/BookmarkUndoIcon.svelte
+++ b/src/routes/game/components/BookmarkUndoIcon.svelte
@@ -1,0 +1,21 @@
+<script>
+	import { Icon } from "@lucide/svelte";
+
+	/** @type {import("@lucide/svelte").IconProps} */
+	let props = $props();
+
+	// Bookmark outline (same as Lucide bookmark-plus) with a compact undo-2 arrow
+	// in place of the plus — tip left, stem curving down-right like Undo2.
+	const iconNode = [
+		["path", { d: "M13 13.5 9.5 10l3.5-3.5" }],
+		["path", { d: "M9.5 10h4.5a2.5 2.5 0 0 1 2.5 2.5" }],
+		[
+			"path",
+			{
+				d: "M17 3a2 2 0 0 1 2 2v15a1 1 0 0 1-1.496.868l-4.512-2.578a2 2 0 0 0-1.984 0l-4.512 2.578A1 1 0 0 1 5 20V5a2 2 0 0 1 2-2z",
+			},
+		],
+	];
+</script>
+
+<Icon name="bookmark-undo" {...props} {iconNode} />

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -9,7 +9,6 @@
 	import { Button } from "$lib/components/ui/button/index.js";
 	import { gameState } from "../state.svelte.js";
 	import {
-		BookmarkIcon,
 		BookmarkPlusIcon,
 		CrownIcon,
 		LoaderCircleIcon,
@@ -20,6 +19,7 @@
 		RotateCwIcon,
 		Undo2Icon,
 	} from "@lucide/svelte";
+	import BookmarkUndoIcon from "./BookmarkUndoIcon.svelte";
 
 	let game = $derived(gameState.currentGame);
 	let isPro = $derived(page.data.user?.level === USER_LEVELS.PRO);
@@ -54,6 +54,8 @@
 	let winNewBest = $state({ score: false, moves: false, time: false });
 	/** Confirmation dialog before ending a run in progress for a new game */
 	let confirmNewGame = $state(false);
+	/** Confirmation dialog before restoring the active checkpoint */
+	let confirmRestoreCheckpoint = $state(false);
 	/** True while waiting for move animations to finish before applying undo */
 	let undoQueued = $state(false);
 	/** True while waiting for animations before restoring a checkpoint */
@@ -158,6 +160,7 @@
 		winElapsedMs = null;
 		undoQueued = false;
 		restoreQueued = false;
+		confirmRestoreCheckpoint = false;
 		if (onNewGame) {
 			void onNewGame();
 			return;
@@ -245,6 +248,17 @@
 		}
 	}
 
+	/** Ask before discarding progress since the checkpoint */
+	function requestRestoreCheckpoint() {
+		if (!isPro || !gameState.hasCheckpoint || checkpointBusy || restoreQueued) return;
+		confirmRestoreCheckpoint = true;
+	}
+
+	function confirmRestoreCheckpointAction() {
+		confirmRestoreCheckpoint = false;
+		handleRestoreCheckpoint();
+	}
+
 	function handleRestoreCheckpoint() {
 		if (!isPro || !gameState.hasCheckpoint || checkpointBusy || restoreQueued) return;
 
@@ -281,6 +295,12 @@
 		return Math.min(CHECKPOINT_COOLDOWN_MOVES, Math.max(0, CHECKPOINT_COOLDOWN_MOVES - movesSince));
 	});
 
+	/** How many board moves restoring the checkpoint will rewind */
+	let checkpointMovesBack = $derived.by(() => {
+		if (!game || gameState.checkpointMoveCount == null) return 0;
+		return Math.max(0, game.moveCount - gameState.checkpointMoveCount);
+	});
+
 	let setCheckpointBusy = $derived(checkpointBusy && checkpointAction === "set");
 	let restoreCheckpointBusy = $derived(
 		restoreQueued || (checkpointBusy && checkpointAction === "restore")
@@ -299,7 +319,9 @@
 		restoreCheckpointBusy
 			? "Restoring checkpoint…"
 			: gameState.hasCheckpoint
-				? "Restore your last checkpoint"
+				? checkpointMovesBack === 0
+					? "Restore your last checkpoint"
+					: `Restore checkpoint (${checkpointMovesBack} move${checkpointMovesBack === 1 ? "" : "s"} back)`
 				: "No checkpoint set"
 	);
 </script>
@@ -368,16 +390,17 @@
 		</button>
 		<button
 			class="controls-btn relative bg-primary text-primary-foreground hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-40"
-			onclick={handleRestoreCheckpoint}
+			onclick={requestRestoreCheckpoint}
 			disabled={!canRestoreCheckpoint && !restoreQueued}
 			title={restoreCheckpointTitle}
 			aria-label={restoreCheckpointTitle}
 			aria-busy={restoreCheckpointBusy}
+			aria-haspopup="dialog"
 		>
 			{#if restoreCheckpointBusy}
 				<LoaderCircleIcon class="animate-spin" size={18} />
 			{:else}
-				<BookmarkIcon size={18} />
+				<BookmarkUndoIcon size={18} />
 			{/if}
 		</button>
 	{:else}
@@ -449,8 +472,9 @@
 				<Button
 					class="m-1"
 					variant={game.canUndo ? "secondary" : "default"}
-					onclick={handleRestoreCheckpoint}
+					onclick={requestRestoreCheckpoint}
 					disabled={checkpointBusy || restoreQueued}
+					aria-haspopup="dialog"
 				>
 					{#if restoreCheckpointBusy}
 						Restoring…
@@ -533,6 +557,27 @@
 		<AlertDialog.Footer>
 			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
 			<AlertDialog.Action onclick={confirmStartNewGame}>New Game</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
+<AlertDialog.Root bind:open={confirmRestoreCheckpoint}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Restore checkpoint?</AlertDialog.Title>
+			<AlertDialog.Description>
+				{#if checkpointMovesBack === 0}
+					This restores your board to the saved checkpoint.
+				{:else}
+					This goes back {checkpointMovesBack.toLocaleString()} move{checkpointMovesBack === 1
+						? ""
+						: "s"} and restores your board to the saved checkpoint.
+				{/if}
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Action onclick={confirmRestoreCheckpointAction}>Restore</AlertDialog.Action>
 		</AlertDialog.Footer>
 	</AlertDialog.Content>
 </AlertDialog.Root>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Restore-from-checkpoint now opens a confirm dialog that states how many moves will be rewound (same AlertDialog pattern as “new game”).
- Toolbar restore control uses a new `BookmarkUndoIcon` (bookmark + undo glyph) so it mirrors `BookmarkPlus` on set checkpoint; tooltip also includes the moves-back count.
- Game Over “Restore Checkpoint” uses the same confirm flow.

## Test plan
- [x] As a Pro user, set a checkpoint, make several moves, click restore → dialog shows the correct moves-back count; Cancel leaves the board unchanged
- [x] Confirm restore → board/score return to the checkpoint
- [x] Compare set/restore toolbar icons: plus vs undo inside the bookmark

### Verification
Toolbar icons (set = bookmark+plus, restore = bookmark+undo):

[Checkpoint control icons](https://cursor.com/agents/bc-019fb4a3-93c5-74dd-a5a6-fc0f95995569/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F10-controls-icons.png)

Confirm dialog with moves-back count:

[Restore checkpoint confirm dialog](https://cursor.com/agents/bc-019fb4a3-93c5-74dd-a5a6-fc0f95995569/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F11-dialog-closeup.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb4a3-93c5-74dd-a5a6-fc0f95995569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb4a3-93c5-74dd-a5a6-fc0f95995569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

