### PR TITLE
Show stats on all end game dialogs and confirm every new-game button

### DIFF
--- a/src/lib/components/GameStats.svelte
+++ b/src/lib/components/GameStats.svelte
@@ -1,0 +1,103 @@
+<script>
+	import { page } from "$app/state";
+
+	/**
+	 * Themed stat cards shared by the end-game dialogs (win, game over,
+	 * challenge results). Extracted from the You Won dialog.
+	 *
+	 * @typedef {Object} GameStat
+	 * @property {string} label
+	 * @property {string} value
+	 * @property {boolean} [newBest] Show a "New Best!" badge on this stat
+	 */
+
+	/** @type {{ stats: GameStat[], label?: string }} */
+	let { stats, label = "Game stats" } = $props();
+</script>
+
+<div class="game-stats" role="group" aria-label={label} style:--stat-columns={stats.length}>
+	{#each stats as stat (stat.label)}
+		<div
+			class="game-stat"
+			style:background-color={page.data.theme?.boardBackground}
+			style:color={page.data.theme?.textDark}
+		>
+			{#if stat.newBest}
+				<span class="game-stat-badge">New Best!</span>
+			{/if}
+			<span class="game-stat-label">{stat.label}</span>
+			<span class="game-stat-value">{stat.value}</span>
+		</div>
+	{/each}
+</div>
+
+<style>
+	.game-stats {
+		display: grid;
+		grid-template-columns: repeat(var(--stat-columns, 3), minmax(0, 1fr));
+		gap: 0.5rem;
+		margin: 1.25rem 0 1.5rem;
+	}
+
+	.game-stat {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 0.15rem;
+		padding: 0.65rem 0.5rem;
+		border-radius: 0.5rem;
+		min-width: 0;
+	}
+
+	.game-stat-badge {
+		position: absolute;
+		top: -0.55rem;
+		left: 50%;
+		transform: translateX(-50%);
+		padding: 0.16rem 0.45rem;
+		border-radius: 999px;
+		background: linear-gradient(135deg, #fbbf24, #f59e0b);
+		color: #451a03;
+		font-size: 0.58rem;
+		font-weight: 800;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		white-space: nowrap;
+		box-shadow: 0 2px 6px rgb(0 0 0 / 0.25);
+		animation: game-stat-badge-pop 300ms cubic-bezier(0.34, 1.56, 0.64, 1) 250ms both;
+	}
+
+	@keyframes game-stat-badge-pop {
+		from {
+			opacity: 0;
+			transform: translateX(-50%) scale(0.5);
+		}
+		to {
+			opacity: 1;
+			transform: translateX(-50%) scale(1);
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.game-stat-badge {
+			animation: none;
+		}
+	}
+
+	.game-stat-label {
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		opacity: 0.8;
+	}
+
+	.game-stat-value {
+		font-size: 1.15rem;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		line-height: 1.2;
+	}
+</style>

--- a/src/routes/animated/+page.svelte
+++ b/src/routes/animated/+page.svelte
@@ -4,6 +4,7 @@
 
 	import { DIRECTIONS } from "$lib/constants.js";
 	import { Game } from "$lib/game.svelte.js";
+	import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
 	import CanvasGameBoard from "./CanvasGameBoard.svelte";
 
 	const TOUCH_THRESHOLD = 5;
@@ -124,11 +125,28 @@
 		}
 	}
 
+	/** Confirmation dialog before ending a run in progress for a new game */
+	let confirmNewGame = $state(false);
+
 	/**
 	 * Create a new game
 	 */
 	function newGame() {
 		game = new Game();
+	}
+
+	/** Confirm before ending a run in progress; start right away when nothing is lost */
+	function requestNewGame() {
+		if (!game || game.moveCount === 0 || game.gameOver) {
+			newGame();
+			return;
+		}
+		confirmNewGame = true;
+	}
+
+	function confirmStartNewGame() {
+		confirmNewGame = false;
+		newGame();
 	}
 
 	/**
@@ -176,7 +194,7 @@
 
 	<!-- Game Controls -->
 	<div class="mb-4 text-center">
-		<button class="new-game-btn" onclick={newGame}>New Game</button>
+		<button class="new-game-btn" onclick={requestNewGame} aria-haspopup="dialog">New Game</button>
 	</div>
 
 	<!-- Game Board -->
@@ -190,6 +208,22 @@
 		</p>
 	</div>
 </div>
+
+<AlertDialog.Root bind:open={confirmNewGame}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Start a new game?</AlertDialog.Title>
+			<AlertDialog.Description>
+				This ends your current run{game ? ` at ${game.score.toLocaleString()} points` : ""} and starts
+				a fresh board.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Action onclick={confirmStartNewGame}>New Game</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
 
 <style lang="postcss">
 	.game-container {

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -14,6 +14,7 @@
 		formatChallengeElapsedMs,
 	} from "$lib/challenges.js";
 	import { Button } from "$lib/components/ui/button/index.js";
+	import GameStats from "$lib/components/GameStats.svelte";
 	import AnimatedBoard from "../../../game/components/AnimatedBoard.svelte";
 
 	let { data } = $props();
@@ -22,7 +23,7 @@
 	let game = $state(null);
 	let result = $state(/** @type {'won' | 'lost' | null} */ (null));
 	let remainingMs = $state(0);
-	/** Elapsed ms captured when the run finishes (time challenges). */
+	/** Elapsed ms captured when the run finishes. */
 	let finishedElapsedMs = $state(/** @type {number | null} */ (null));
 	let submitting = $state(false);
 	let retrying = $state(false);
@@ -103,9 +104,7 @@
 	function finish(status) {
 		if (result || submitting || data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) return;
 		result = status;
-		if (isTime) {
-			finishedElapsedMs = Math.max(0, Date.now() - data.run.startedOn);
-		}
+		finishedElapsedMs = Math.max(0, Date.now() - data.run.startedOn);
 		submitting = true;
 		queueMicrotask(() => completeForm?.requestSubmit());
 	}
@@ -232,6 +231,35 @@
 			await applyAction(actionResult);
 		};
 	};
+
+	/**
+	 * @param {unknown} value
+	 * @returns {number | null}
+	 */
+	function asFiniteNumber(value) {
+		return typeof value === "number" && Number.isFinite(value) ? value : null;
+	}
+
+	/** Stored metrics fallback for finished runs viewed after a reload (no live game). */
+	const runMetrics = $derived(
+		/** @type {{ moveCount?: unknown, mergeScore?: unknown, elapsedMs?: unknown }} */ (
+			data.run.metrics ?? {}
+		)
+	);
+
+	/** Stat cards for the result dialog, ranked metric first. */
+	let resultStats = $derived.by(() => {
+		const statMoves = game?.moveCount ?? asFiniteNumber(runMetrics.moveCount);
+		const statScore = game?.score ?? asFiniteNumber(runMetrics.mergeScore);
+
+		const moves = { label: "Moves", value: statMoves?.toLocaleString() ?? "—" };
+		const score = { label: "Score", value: statScore?.toLocaleString() ?? "—" };
+		const time = { label: "Time", value: formatChallengeElapsedMs(finishedElapsedMs) };
+
+		if (isRecovery) return [moves, score, time];
+		if (isTime) return [time, score, moves];
+		return [score, moves, time];
+	});
 </script>
 
 <svelte:head>
@@ -271,9 +299,7 @@
 		value={JSON.stringify({
 			moveCount: game?.moveCount ?? 0,
 			filledCells: game ? countFilledCells(game.board) : 0,
-			elapsedMs: isTime
-				? (finishedElapsedMs ?? Math.max(0, Date.now() - data.run.startedOn))
-				: undefined,
+			elapsedMs: finishedElapsedMs ?? Math.max(0, Date.now() - data.run.startedOn),
 			mergeScore: game?.score ?? 0,
 		})}
 	/>
@@ -361,22 +387,13 @@
 			<p>
 				{#if result === "won"}
 					Nice work — {data.objective.toLowerCase()}.
-				{:else if isTime && game && "targetScore" in challenge.params && game.score < challenge.params.targetScore}
-					Time's up (or game over) with {game.score.toLocaleString()} points.
+				{:else if isTime}
+					Time's up (or game over) before reaching the target score.
 				{:else}
 					Game over before the objective was met.
 				{/if}
 			</p>
-			<p class="mb-4 text-sm text-muted-foreground">
-				{#if isRecovery}
-					Moves: {game?.moveCount ?? 0}
-				{:else if isTime}
-					Time: {formatChallengeElapsedMs(finishedElapsedMs)}
-					· Score: {game?.score.toLocaleString() ?? 0}
-				{:else}
-					Score: {game?.score.toLocaleString() ?? 0}
-				{/if}
-			</p>
+			<GameStats stats={resultStats} label="Challenge stats" />
 			<div class="flex flex-wrap justify-center gap-2">
 				<form method="POST" action="?/start" use:enhance={onRetry}>
 					<Button type="submit" class="justify-center" disabled={retrying || submitting}>

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -7,6 +7,7 @@
 	import { saveBestWinStats } from "$lib/localStorage.svelte.js";
 	import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
 	import { Button } from "$lib/components/ui/button/index.js";
+	import GameStats from "$lib/components/GameStats.svelte";
 	import { gameState } from "../state.svelte.js";
 	import {
 		BookmarkPlusIcon,
@@ -52,6 +53,10 @@
 	let winElapsedMs = $state(/** @type {number | null} */ (null));
 	/** Which of this win's stats are personal bests, frozen when the overlay opens */
 	let winNewBest = $state({ score: false, moves: false, time: false });
+	/** Frozen wall-clock duration when the game over overlay opens */
+	let gameOverElapsedMs = $state(/** @type {number | null} */ (null));
+	/** Whether the finished run's score is a personal best, frozen when the overlay opens */
+	let gameOverNewBestScore = $state(false);
 	/** Confirmation dialog before ending a run in progress for a new game */
 	let confirmNewGame = $state(false);
 	/** Confirmation dialog before restoring the active checkpoint */
@@ -69,13 +74,34 @@
 
 		if (!game.gameOver) {
 			showGameOver = false;
+			gameOverElapsedMs = null;
+			gameOverNewBestScore = false;
 		} else if (animationIdle) {
+			// Already open — don't reschedule or reset the frozen stats
+			if (untrack(() => showGameOver)) return;
+
 			const timeout = setTimeout(() => {
 				showGameOver = true;
+				captureGameOverStats();
 			}, GAME_OVER_DELAY);
 			return () => clearTimeout(timeout);
 		}
 	});
+
+	/**
+	 * Freeze the finished run's stats when the game over overlay opens.
+	 * Only score can be a personal best here — moves/time bests are win-only.
+	 */
+	function captureGameOverStats() {
+		if (!game) return;
+
+		const score = game.score;
+		gameOverElapsedMs =
+			typeof game.createdOn === "number" ? Math.max(0, Date.now() - game.createdOn) : null;
+		// bestScore is raised live while playing, so a new best shows up as a tie
+		gameOverNewBestScore = score > 0 && score >= gameState.bestScore;
+		if (score > gameState.bestScore) gameState.bestScore = score;
+	}
 
 	/**
 	 * Freeze this win's stats, flag the ones beating the previous bests, then
@@ -158,6 +184,8 @@
 		showGameOver = false;
 		showWin = false;
 		winElapsedMs = null;
+		gameOverElapsedMs = null;
+		gameOverNewBestScore = false;
 		undoQueued = false;
 		restoreQueued = false;
 		confirmRestoreCheckpoint = false;
@@ -464,7 +492,17 @@
 	<div class="overlay game-over">
 		<div class="overlay-content">
 			<h2>Game Over!</h2>
-			<p>Final Score: {game.score.toLocaleString()}</p>
+			<GameStats
+				stats={[
+					{
+						label: "Score",
+						value: game.score.toLocaleString(),
+						newBest: gameOverNewBestScore,
+					},
+					{ label: "Moves", value: game.moveCount.toLocaleString() },
+					{ label: "Time", value: formatWinDuration(gameOverElapsedMs) },
+				]}
+			/>
 			{#if game.canUndo}
 				<Button class="m-1" onclick={handleUndo}>Undo Last Move</Button>
 			{/if}
@@ -492,7 +530,7 @@
 				variant={game.canUndo || (isPro && gameState.hasCheckpoint) || !isPro
 					? "secondary"
 					: "default"}
-				onclick={newGame}
+				onclick={requestNewGame}
 			>
 				Try Again
 			</Button>
@@ -504,49 +542,24 @@
 	<div class="overlay win">
 		<div class="overlay-content">
 			<h2>You Won!</h2>
-			<div class="win-stats" role="group" aria-label="Game stats">
-				<div
-					class="win-stat"
-					style:background-color={page.data.theme?.boardBackground}
-					style:color={page.data.theme?.textDark}
-				>
-					{#if winNewBest.score}
-						<span class="win-stat-badge">New Best!</span>
-					{/if}
-					<span class="win-stat-label">Score</span>
-					<span class="win-stat-value">{game.score.toLocaleString()}</span>
-				</div>
-				<div
-					class="win-stat"
-					style:background-color={page.data.theme?.boardBackground}
-					style:color={page.data.theme?.textDark}
-				>
-					{#if winNewBest.moves}
-						<span class="win-stat-badge">New Best!</span>
-					{/if}
-					<span class="win-stat-label">Moves</span>
-					<span class="win-stat-value">{game.moveCount.toLocaleString()}</span>
-				</div>
-				<div
-					class="win-stat"
-					style:background-color={page.data.theme?.boardBackground}
-					style:color={page.data.theme?.textDark}
-				>
-					{#if winNewBest.time}
-						<span class="win-stat-badge">New Best!</span>
-					{/if}
-					<span class="win-stat-label">Time</span>
-					<span class="win-stat-value">{formatWinDuration(winElapsedMs)}</span>
-				</div>
-			</div>
+			<GameStats
+				stats={[
+					{ label: "Score", value: game.score.toLocaleString(), newBest: winNewBest.score },
+					{ label: "Moves", value: game.moveCount.toLocaleString(), newBest: winNewBest.moves },
+					{ label: "Time", value: formatWinDuration(winElapsedMs), newBest: winNewBest.time },
+				]}
+			/>
 			<Button class="m-1" onclick={continueGame}>Keep Playing</Button>
-			<Button class="m-1" variant="secondary" onclick={newGame}>New Game</Button>
+			<Button class="m-1" variant="secondary" onclick={requestNewGame} aria-haspopup="dialog">
+				New Game
+			</Button>
 		</div>
 	</div>
 {/if}
 
+<!-- z-[1100] keeps the confirm dialogs above the fixed end-game overlays (z-index 1000) -->
 <AlertDialog.Root bind:open={confirmNewGame}>
-	<AlertDialog.Content>
+	<AlertDialog.Content class="z-[1100]">
 		<AlertDialog.Header>
 			<AlertDialog.Title>Start a new game?</AlertDialog.Title>
 			<AlertDialog.Description>
@@ -562,7 +575,7 @@
 </AlertDialog.Root>
 
 <AlertDialog.Root bind:open={confirmRestoreCheckpoint}>
-	<AlertDialog.Content>
+	<AlertDialog.Content class="z-[1100]">
 		<AlertDialog.Header>
 			<AlertDialog.Title>Restore checkpoint?</AlertDialog.Title>
 			<AlertDialog.Description>
@@ -623,80 +636,5 @@
 	.overlay-content h2 {
 		margin: 0 0 12px 0;
 		font-size: 2rem;
-	}
-
-	.overlay-content p {
-		margin: 0 0 30px 0;
-		color: var(--muted-foreground);
-		font-size: 1.2rem;
-	}
-
-	.win-stats {
-		display: grid;
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-		gap: 0.5rem;
-		margin: 1.25rem 0 1.5rem;
-	}
-
-	.win-stat {
-		position: relative;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		gap: 0.15rem;
-		padding: 0.65rem 0.5rem;
-		border-radius: 0.5rem;
-		min-width: 0;
-	}
-
-	.win-stat-badge {
-		position: absolute;
-		top: -0.55rem;
-		left: 50%;
-		transform: translateX(-50%);
-		padding: 0.16rem 0.45rem;
-		border-radius: 999px;
-		background: linear-gradient(135deg, #fbbf24, #f59e0b);
-		color: #451a03;
-		font-size: 0.58rem;
-		font-weight: 800;
-		letter-spacing: 0.05em;
-		text-transform: uppercase;
-		white-space: nowrap;
-		box-shadow: 0 2px 6px rgb(0 0 0 / 0.25);
-		animation: win-badge-pop 300ms cubic-bezier(0.34, 1.56, 0.64, 1) 250ms both;
-	}
-
-	@keyframes win-badge-pop {
-		from {
-			opacity: 0;
-			transform: translateX(-50%) scale(0.5);
-		}
-		to {
-			opacity: 1;
-			transform: translateX(-50%) scale(1);
-		}
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.win-stat-badge {
-			animation: none;
-		}
-	}
-
-	.win-stat-label {
-		font-size: 0.7rem;
-		font-weight: 700;
-		letter-spacing: 0.04em;
-		text-transform: uppercase;
-		opacity: 0.8;
-	}
-
-	.win-stat-value {
-		font-size: 1.15rem;
-		font-weight: 700;
-		font-variant-numeric: tabular-nums;
-		line-height: 1.2;
 	}
 </style>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Extract the You Won dialog's stat cards into a shared `GameStats` component (`src/lib/components/GameStats.svelte`) with themed cards, adaptive column count, and optional "New Best!" badges.
- **Game Over dialog** now shows the same Score / Moves / Time stat grid instead of a plain "Final Score" line. Stats are frozen when the overlay opens, and Score gets a "New Best!" badge when the run ties or beats the personal best (moves/time bests remain win-only).
- **Challenge result dialog** ("Challenge Cleared!" / "Challenge Failed") now shows the stat grid with the ranked metric first (Moves for recovery, Time for time challenges). Elapsed time is now captured for all challenge types (previously time-only), and finished runs viewed after a reload fall back to the stored run metrics instead of showing zeros.
- **New game confirmations**: the You Won dialog's "New Game" button now routes through the existing confirm dialog (it forfeits a still-continuable run), and the `/animated` page's New Game button gets the same confirm. Fresh or dead boards still skip the confirmation.
- Fix a latent stacking bug: the confirm dialogs (z-50) rendered *behind* the fixed end-game overlays (z-1000), e.g. when restoring a checkpoint from the Game Over dialog. Confirms now use `z-[1100]`.

## Screenshots

| Game Over with stats | You Won (unchanged look, shared component) |
| --- | --- |
| [Game Over dialog with stats](https://cursor.com/agents/bc-019fc98e-b203-7182-9b73-33bf6cb75bd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fgame-over-stats.webp) | [You Won dialog stats](https://cursor.com/agents/bc-019fc98e-b203-7182-9b73-33bf6cb75bd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fwin-dialog-stats.webp) |

| New Game confirm above the win overlay | Challenge Failed with stats |
| --- | --- |
| [New game confirm over win overlay](https://cursor.com/agents/bc-019fc98e-b203-7182-9b73-33bf6cb75bd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fwin-new-game-confirm.webp) | [Challenge failed dialog with stats](https://cursor.com/agents/bc-019fc98e-b203-7182-9b73-33bf6cb75bd9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fchallenge-failed-stats.webp) |

## Testing

- `pnpm lint` passes; `pnpm check` reports the same error count as `main` (146 with the current refreshed toolchain — no new type errors; the "4 pre-existing errors" note in AGENTS.md predates a svelte-check/svelte version bump).
- Manually verified in the browser: game over stats + best-score badge, win dialog stats with badges, win dialog New Game confirm rendering above the overlay (cancel returns with stats intact), header + button confirm regression, `/animated` confirm, challenge failed stats, and stored-metrics fallback after reloading a finished challenge run.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc98e-b203-7182-9b73-33bf6cb75bd9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc98e-b203-7182-9b73-33bf6cb75bd9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

