### PR TITLE
Apply design guidelines to color themes

### DIFF
--- a/scripts/theme-audit.js
+++ b/scripts/theme-audit.js
@@ -1,0 +1,164 @@
+/**
+ * Theme palette audit — run after editing src/lib/assets/themes.js:
+ *
+ *   node scripts/theme-audit.js
+ *
+ * Checks every theme against the palette conventions documented in themes.js:
+ *
+ * - No pure #000/#fff in chrome colors (near-black / near-white only).
+ *   Tile ramps and the unknown-tile fallback are game content and exempt.
+ * - Important elements reach WCAG AA (4.5:1): body text, button fills under
+ *   their picked ink, secondary surfaces, destructive/error text, muted text.
+ * - `primary` holds ≥ 3:1 as heading text on the page background.
+ * - Board-colored HUD surfaces (score boxes etc.) hold ≥ 4.2:1 under the ink
+ *   getInkColor picks. Classic is exempt: its light-on-brown score box is the
+ *   historical 2048 look, kept deliberately.
+ * - Reports (non-fatal): HSB ladder of surfaces, neutral tint/temperature,
+ *   container brightness deltas, worst tile ink per theme.
+ *
+ * Exits 1 when a hard check fails.
+ */
+import { contrastRatio, getInkColor, listThemes } from "../src/lib/assets/themes.js";
+import { applyThemeTokens } from "../src/lib/themeTokens.js";
+
+/** @param {string} hex */
+function hsb(hex) {
+	const h = hex.replace("#", "");
+	const [r, g, b] = [0, 2, 4].map((i) => parseInt(h.substring(i, i + 2), 16));
+	const max = Math.max(r, g, b);
+	const min = Math.min(r, g, b);
+	const d = max - min;
+	let hue = 0;
+	if (d !== 0) {
+		if (max === r) hue = 60 * (((g - b) / d + 6) % 6);
+		else if (max === g) hue = 60 * ((b - r) / d + 2);
+		else hue = 60 * ((r - g) / d + 4);
+	}
+	return {
+		h: Math.round(hue),
+		s: max === 0 ? 0 : Math.round((d / max) * 100),
+		b: Math.round((max / 255) * 100),
+	};
+}
+
+/** Fake CSSStyleDeclaration that records what applyThemeTokens computes. */
+function computeTokens(theme) {
+	const store = new Map();
+	applyThemeTokens({ setProperty: (k, v) => store.set(k, v) }, theme);
+	return store;
+}
+
+const CHROME_FIELDS = [
+	"background",
+	"boardBackground",
+	"emptyTile",
+	"border",
+	"primary",
+	"secondary",
+	"secondaryForeground",
+	"destructive",
+	"text",
+	"textLight",
+	"textDark",
+];
+
+let failures = 0;
+
+/** @param {boolean} ok */
+function check(ok, label, detail) {
+	if (!ok) failures++;
+	console.log(`  ${ok ? " ok " : "FAIL"}  ${label}${detail ? `  (${detail})` : ""}`);
+}
+
+const r2 = (x) => Math.round(x * 100) / 100;
+
+for (const theme of listThemes()) {
+	const tokens = computeTokens(theme);
+	console.log(`\n=== ${theme.name} (${theme.id}) ===`);
+
+	// Surface ladder report
+	for (const key of ["background", "boardBackground", "emptyTile", "primary", "secondary"]) {
+		const { h, s, b } = hsb(theme[key]);
+		console.log(`       ${key.padEnd(16)} ${theme[key]}  H${h}° S${s}% B${b}%`);
+	}
+	const dBoard = Math.abs(hsb(theme.boardBackground).b - hsb(theme.background).b);
+	const dEmpty = Math.abs(hsb(theme.emptyTile).b - hsb(theme.boardBackground).b);
+	console.log(`       brightness steps: page→board ${dBoard}%, board→empty ${dEmpty}%`);
+
+	// Pure-value ban (chrome only; tiles are game content)
+	for (const key of CHROME_FIELDS) {
+		const value = theme[key];
+		if (!value) continue;
+		const v = value.toLowerCase();
+		check(
+			v !== "#000000" && v !== "#ffffff" && v !== "#000" && v !== "#fff",
+			`${key} is not pure black/white`,
+			value
+		);
+	}
+
+	// Contrast gates for important elements (WCAG AA)
+	const fg = tokens.get("--foreground");
+	const primaryFg = tokens.get("--primary-foreground");
+	const secondaryFg = tokens.get("--secondary-foreground");
+	const mutedFg = tokens.get("--muted-foreground");
+	const destructive = tokens.get("--destructive");
+
+	check(
+		contrastRatio(fg, theme.background) >= 4.5,
+		"body text on page ≥ 4.5",
+		r2(contrastRatio(fg, theme.background))
+	);
+	check(
+		contrastRatio(primaryFg, theme.primary) >= 4.5,
+		"button ink on primary ≥ 4.5",
+		r2(contrastRatio(primaryFg, theme.primary))
+	);
+	check(
+		contrastRatio(theme.primary, theme.background) >= 3,
+		"primary as heading text ≥ 3",
+		r2(contrastRatio(theme.primary, theme.background))
+	);
+	check(
+		contrastRatio(secondaryFg, theme.secondary) >= 4.5,
+		"ink on secondary ≥ 4.5",
+		r2(contrastRatio(secondaryFg, theme.secondary))
+	);
+	check(
+		contrastRatio(destructive, theme.background) >= 4.5,
+		"destructive text on page ≥ 4.5",
+		r2(contrastRatio(destructive, theme.background))
+	);
+	check(
+		contrastRatio(mutedFg, theme.background) >= 4.5,
+		"muted text on page ≥ 4.5",
+		r2(contrastRatio(mutedFg, theme.background))
+	);
+
+	const boardInk = getInkColor(theme.boardBackground, theme);
+	const boardInkRatio = contrastRatio(boardInk, theme.boardBackground);
+	if (theme.id === "classic") {
+		console.log(
+			`   --   HUD ink on board = ${r2(boardInkRatio)} (historical light-on-brown, exempt)`
+		);
+	} else {
+		check(boardInkRatio >= 4.2, "HUD ink on board ≥ 4.2", r2(boardInkRatio));
+	}
+
+	// Tile ink report (classic keeps its historical threshold ink)
+	let worst = Infinity;
+	let worstTile = null;
+	for (const [value, tile] of Object.entries(theme.tiles)) {
+		const ratio = contrastRatio(tile, getInkColor(tile, theme));
+		if (ratio < worst) {
+			worst = ratio;
+			worstTile = value;
+		}
+	}
+	console.log(
+		`   --   worst tile ink: ${worstTile} → ${r2(worst)}${theme.id === "classic" ? " (historical, exempt)" : ""}`
+	);
+}
+
+console.log(failures === 0 ? "\nAll theme checks passed." : `\n${failures} check(s) failed.`);
+process.exit(failures === 0 ? 0 : 1);

--- a/src/app.css
+++ b/src/app.css
@@ -7,28 +7,32 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-	/* Defaults match Classic; runtime theme bridge overwrites these */
+	/* Defaults mirror what applyThemeTokens computes for Classic; the runtime
+	   theme bridge overwrites these */
 	--background: #fbf8ef;
 	--foreground: #776e65;
 	--card: #fbf8ef;
 	--card-foreground: #776e65;
-	--popover: #ffffff;
+	--popover: #fbf9f1;
 	--popover-foreground: #776e65;
-	--primary: #e88f4f;
+	--primary: #b8541a;
 	--primary-foreground: #f9f6f2;
 	--secondary: #c2d4b0;
 	--secondary-foreground: #3e5641;
-	--muted: #eee4d9;
+	--muted: #cdc1b4;
 	--muted-foreground: #776e65;
-	--accent: #ece0c8;
-	--accent-foreground: #776e65;
-	--destructive: #e95937;
+	--accent: #bbada0;
+	--accent-foreground: #f9f6f2;
+	--destructive: #c93d20;
 	--border: #cdc1b4;
 	--input: #cdc1b4;
-	--ring: #e88f4f;
+	--ring: #b8541a;
 	--radius: 0.5rem;
 
-	--chart-1: #e88f4f;
+	/* Small floating elements: blur = 2× the y-offset, per the depth scale */
+	--shadow-pop: 0 2px 4px rgb(0 0 0 / 0.25);
+
+	--chart-1: #b8541a;
 	--chart-2: #c2d4b0;
 	--chart-3: #f2b179;
 	--chart-4: #5eda92;
@@ -36,12 +40,12 @@
 
 	--sidebar: #fbf8ef;
 	--sidebar-foreground: #776e65;
-	--sidebar-primary: #e88f4f;
+	--sidebar-primary: #b8541a;
 	--sidebar-primary-foreground: #f9f6f2;
-	--sidebar-accent: #eee4d9;
+	--sidebar-accent: #cdc1b4;
 	--sidebar-accent-foreground: #776e65;
 	--sidebar-border: #cdc1b4;
-	--sidebar-ring: #e88f4f;
+	--sidebar-ring: #b8541a;
 
 	/* Game / board tokens (also set at runtime) */
 	--color-board-background: #bbada0;
@@ -52,6 +56,17 @@
 	--text-scale: 3;
 	--luminance-threshold: 0.7;
 	--movement-speed: 50ms;
+}
+
+/* One depth technique per theme: themes with `shadows: false` (dark UIs)
+   render flat, since drop shadows don't read against dark backgrounds —
+   elevation comes from lighter surfaces instead. Unlayered so it outranks
+   Tailwind's shadow-* utilities; rings/outlines are unaffected. */
+html[data-shadows="none"] * {
+	--tw-shadow: 0 0 #0000;
+}
+html[data-shadows="none"] {
+	--shadow-pop: 0 0 rgb(0 0 0 / 0);
 }
 
 @theme inline {
@@ -117,8 +132,10 @@
 	input:disabled,
 	textarea:disabled,
 	select:disabled {
-		background-color: #f3f3f3;
-		color: #b5b5b5;
+		/* Theme-tinted neutrals instead of pure greys, so disabled fields
+		   stay coherent on dark and tinted backgrounds alike */
+		background-color: var(--muted);
+		color: var(--muted-foreground);
 		opacity: 1;
 		cursor: default;
 	}

--- a/src/lib/assets/themes.js
+++ b/src/lib/assets/themes.js
@@ -1,4 +1,20 @@
 /**
+ * Color theme presets.
+ *
+ * Palette conventions (checked by `node scripts/theme-audit.js`):
+ * - Chrome neutrals are near-black / near-white — never pure #000/#fff — and
+ *   carry a low-saturation tint of the theme's accent. Each theme commits to
+ *   one temperature (warm or cool) for its neutrals; mixing both breaks
+ *   coherence. Tile ramps are game content and are exempt.
+ * - Chrome surfaces sit on distinct brightness steps (page → board well →
+ *   empty cells), keeping container deltas inside ~12% (dark UIs) / ~7%
+ *   (light UIs) HSB brightness.
+ * - Important elements get high contrast: `primary` and `destructive` are
+ *   tuned to ≥ 4.5:1 (WCAG AA) both as text on `background` and under their
+ *   picked ink; structural elements (borders, empty cells) stay low-contrast.
+ * - Dark themes set `shadows: false` — drop shadows don't read on dark
+ *   backgrounds, so elevation comes from lighter surfaces instead.
+ *
  * @typedef {Object} Theme
  * @property {string} id
  * @property {string} name
@@ -8,10 +24,14 @@
  * @property {string} background
  * @property {string} boardBackground
  * @property {string} emptyTile
- * @property {string} textLight
- * @property {string} textDark
+ * @property {string} textLight Dark ink, used on light surfaces/tiles
+ * @property {string} textDark Light ink, used on dark surfaces/tiles
  * @property {string} [text]
  * @property {string} unknownTile
+ * @property {string} [secondaryForeground] Explicit ink for secondary surfaces when neither text ink reaches AA contrast
+ * @property {string} [border] Border/input color when `emptyTile` sits too close to `background` to read as an edge
+ * @property {string} [destructive] Error/danger accent tuned for AA contrast against `background`
+ * @property {boolean} [shadows] false = flat depth (dark UIs); drop shadows are suppressed app-wide
  * @property {number} textScale
  * @property {number} luminanceThreshold
  * @property {number} movementSpeed
@@ -23,7 +43,60 @@
  * @property {string} challengeLost
  */
 
-/** Shared tile ramp used by Classic / Light / Soft */
+/**
+ * Relative luminance of a hex color (0–1), per WCAG 2.
+ * @param {string} hex
+ * @returns {number}
+ */
+export function relativeLuminance(hex) {
+	hex = hex.replace(/^#/, "");
+	if (hex.length === 3) {
+		hex = hex
+			.split("")
+			.map((x) => x + x)
+			.join("");
+	}
+	const num = parseInt(hex, 16);
+	const channels = [(num >> 16) & 255, (num >> 8) & 255, num & 255].map((v) => {
+		v /= 255;
+		return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+	});
+	return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+/**
+ * WCAG contrast ratio between two hex colors.
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+export function contrastRatio(a, b) {
+	const l1 = relativeLuminance(a);
+	const l2 = relativeLuminance(b);
+	const lighter = Math.max(l1, l2);
+	const darker = Math.min(l1, l2);
+	return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Readable ink (textLight vs textDark) for a theme-colored surface.
+ * Classic keeps its historical luminance-threshold pick — light ink on the
+ * board browns is part of the original 2048 look — while every other theme
+ * picks whichever ink has the higher WCAG contrast.
+ * @param {string} bg
+ * @param {Theme} theme
+ * @returns {string}
+ */
+export function getInkColor(bg, theme) {
+	if (theme.id === "classic") {
+		return relativeLuminance(bg) < theme.luminanceThreshold ? theme.textDark : theme.textLight;
+	}
+	return contrastRatio(bg, theme.textLight) >= contrastRatio(bg, theme.textDark)
+		? theme.textLight
+		: theme.textDark;
+}
+
+/** Classic tile ramp — preserved byte-for-byte; do not retune. */
 const classicTiles = {
 	2: "#eee4d9",
 	4: "#ece0c8",
@@ -48,13 +121,24 @@ const classicTiles = {
 	2097152: "#63A375",
 };
 
-/** @type {Theme} */
+/**
+ * The historical 2048 look. Tiles, board browns and inks are untouched; the
+ * warm neutrals (hue ≈ 30°, ~5% saturation on the page) already follow the
+ * palette conventions. Only the accents were retuned: primary and destructive
+ * deepened from their bright originals so buttons and headings clear AA, and
+ * secondary gets an explicit deep-sage ink (both theme inks are midtone-weak
+ * on the sage pill).
+ * @type {Theme}
+ */
 export const classicTheme = {
 	id: "classic",
 	name: "Classic",
 	pro: false,
-	primary: "#e88f4f",
+	// Deepened from #e88f4f: 4.6:1 as heading text on the cream page and
+	// 4.5:1 under its near-white ink as a button fill (was ~2.3:1).
+	primary: "#b8541a",
 	secondary: "#C2D4B0",
+	secondaryForeground: "#3e5641",
 	background: "#fbf8ef",
 	boardBackground: "#bbada0",
 	emptyTile: "#cdc1b4",
@@ -62,6 +146,9 @@ export const classicTheme = {
 	textDark: "#f9f6f2",
 	text: "#776e65",
 	unknownTile: "#5f5f5f",
+	// Deepened from the tile-64 red #e95937 (3.3:1) for AA error text.
+	destructive: "#c93d20",
+	shadows: true,
 	textScale: 3,
 	luminanceThreshold: 0.7,
 	movementSpeed: 50,
@@ -71,20 +158,30 @@ export const classicTheme = {
 	tiles: { ...classicTiles },
 };
 
-/** @type {Theme} */
+/**
+ * Warm near-black. Neutrals re-tinted from blue-grey toward the orange
+ * accent — cool neutrals under a warm accent (and a warm tile ramp) mixed
+ * temperatures. Surfaces climb ~7% brightness per step (page 11% → board
+ * 18% → empty cells 24%), inside the ≤12% container band for dark UIs.
+ * Flat depth: elevation reads through lighter surfaces, not shadows.
+ * @type {Theme}
+ */
 export const darkTheme = {
 	id: "dark",
 	name: "Dark",
 	pro: false,
 	primary: "#e88f4f",
 	secondary: "#3d5a45",
-	background: "#1a1a1e",
-	boardBackground: "#2a2a32",
-	emptyTile: "#3a3a45",
-	textLight: "#e8e4df",
-	textDark: "#1a1a1e",
+	background: "#1c1a18",
+	boardBackground: "#2d2a26",
+	emptyTile: "#3e3a34",
+	textLight: "#1c1a18",
+	textDark: "#e8e4df",
 	text: "#e8e4df",
 	unknownTile: "#6b6b78",
+	// Brighter than the shared red so error text holds ~5.5:1 on near-black.
+	destructive: "#f2643f",
+	shadows: false,
 	textScale: 3,
 	luminanceThreshold: 0.45,
 	movementSpeed: 50,
@@ -115,20 +212,32 @@ export const darkTheme = {
 	},
 };
 
-/** @type {Theme} */
+/**
+ * Cool, airy counterpart to Classic. The page is a near-white saturated ~2%
+ * toward the blue accent (pure #ffffff was too harsh), which also brings the
+ * board well inside the ≤7% brightness band. Primary deepened to hold white
+ * button text at AA, and `border` steps a shade past the empty-cell tone so
+ * container edges contrast with both the fill and the page.
+ * @type {Theme}
+ */
 export const lightTheme = {
 	id: "light",
 	name: "Light",
 	pro: false,
-	primary: "#4a90d9",
+	// Deepened from #4a90d9 (3.1:1) to 4.6:1 under near-white button text.
+	primary: "#2f74c0",
 	secondary: "#a8c5a0",
-	background: "#ffffff",
+	secondaryForeground: "#2b4226",
+	background: "#f7fafc",
 	boardBackground: "#dce3ea",
 	emptyTile: "#eef2f6",
+	border: "#c9d3dc",
 	textLight: "#4a5560",
-	textDark: "#ffffff",
+	textDark: "#f9fcfe",
 	text: "#2d3740",
 	unknownTile: "#8899aa",
+	destructive: "#c22f2f",
+	shadows: true,
 	textScale: 3,
 	luminanceThreshold: 0.65,
 	movementSpeed: 50,
@@ -160,20 +269,30 @@ export const lightTheme = {
 	},
 };
 
-/** @type {Theme} */
+/**
+ * Maximum-legibility palette. Chrome swaps pure #000/#fff for warm
+ * near-black / near-white — still ≈18:1 and gentler on halation — while the
+ * full-saturation neon tile ramp keeps its punch. `border` is lifted well
+ * clear of the background so inputs and container edges stay findable.
+ * Flat depth like Dark.
+ * @type {Theme}
+ */
 export const highContrastTheme = {
 	id: "high-contrast",
 	name: "High Contrast",
 	pro: true,
 	primary: "#ffcc00",
 	secondary: "#00e5ff",
-	background: "#000000",
-	boardBackground: "#111111",
-	emptyTile: "#222222",
-	textLight: "#ffffff",
-	textDark: "#000000",
-	text: "#ffffff",
+	background: "#0c0b09",
+	boardBackground: "#171412",
+	emptyTile: "#262220",
+	border: "#4a443c",
+	textLight: "#0c0b09",
+	textDark: "#f8f6f1",
+	text: "#f8f6f1",
 	unknownTile: "#888888",
+	destructive: "#ff4d42",
+	shadows: false,
 	textScale: 3,
 	luminanceThreshold: 0.5,
 	movementSpeed: 50,
@@ -204,21 +323,29 @@ export const highContrastTheme = {
 	},
 };
 
-/** Soft / muted palette — Pro exclusive */
-/** @type {Theme} */
+/**
+ * Muted warm greys — Pro exclusive. Ink and the clay primary deepened so
+ * text and buttons clear AA against the deliberately low-contrast surfaces
+ * without losing the hushed look; secondary gets an explicit deep-green ink.
+ * @type {Theme}
+ */
 export const softTheme = {
 	id: "soft",
 	name: "Soft",
 	pro: true,
-	primary: "#a67c6d",
+	// Deepened from #a67c6d (3.2:1 under ink) to 5.4:1 / 4.8:1 on the page.
+	primary: "#7e5a4c",
 	secondary: "#9aab9a",
+	secondaryForeground: "#2a3428",
 	background: "#e8e4df",
 	boardBackground: "#c4b8ae",
 	emptyTile: "#d4cbc3",
-	textLight: "#5c534c",
+	textLight: "#52493f",
 	textDark: "#f5f2ee",
-	text: "#5c534c",
+	text: "#52493f",
 	unknownTile: "#8a8078",
+	destructive: "#a83a1e",
+	shadows: true,
 	textScale: 3,
 	luminanceThreshold: 0.65,
 	movementSpeed: 50,
@@ -249,21 +376,29 @@ export const softTheme = {
 	},
 };
 
-/** Playful teal / coral alternate — Pro exclusive */
-/** @type {Theme} */
+/**
+ * Playful teal / coral alternate — Pro exclusive. Background eased off full
+ * brightness with a <5% coral tint, and primary deepened from the tile coral
+ * to a red that holds near-white button text at AA (the tiles keep the
+ * bright coral).
+ * @type {Theme}
+ */
 export const coralTheme = {
 	id: "coral",
 	name: "Coral",
 	pro: true,
-	primary: "#ff6b6b",
+	// Deepened from #ff6b6b (2.7:1 under ink) to 5.1:1 / 4.9:1 on the page.
+	primary: "#c73333",
 	secondary: "#4ecdc4",
-	background: "#fff5f0",
+	background: "#fbf3ef",
 	boardBackground: "#e8a090",
 	emptyTile: "#f0c8bc",
 	textLight: "#5a4038",
 	textDark: "#fff8f5",
 	text: "#5a4038",
 	unknownTile: "#8a6860",
+	destructive: "#c93d20",
+	shadows: true,
 	textScale: 3,
 	luminanceThreshold: 0.6,
 	movementSpeed: 50,

--- a/src/lib/components/GameStats.svelte
+++ b/src/lib/components/GameStats.svelte
@@ -22,11 +22,7 @@
 
 <div class="game-stats" role="group" aria-label={label} style:--stat-columns={stats.length}>
 	{#each stats as stat (stat.label)}
-		<div
-			class="game-stat"
-			style:background-color={theme?.boardBackground}
-			style:color={boardInk}
-		>
+		<div class="game-stat" style:background-color={theme?.boardBackground} style:color={boardInk}>
 			{#if stat.newBest}
 				<span class="game-stat-badge">New Best!</span>
 			{/if}

--- a/src/lib/components/GameStats.svelte
+++ b/src/lib/components/GameStats.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { page } from "$app/state";
+	import { getInkColor } from "$lib/assets/themes.js";
 
 	/**
 	 * Themed stat cards shared by the end-game dialogs (win, game over,
@@ -13,14 +14,18 @@
 
 	/** @type {{ stats: GameStat[], label?: string }} */
 	let { stats, label = "Game stats" } = $props();
+
+	const theme = $derived(page.data.theme);
+	// Readable ink for the board-colored stat cards
+	const boardInk = $derived(theme ? getInkColor(theme.boardBackground, theme) : "#f9f6f2");
 </script>
 
 <div class="game-stats" role="group" aria-label={label} style:--stat-columns={stats.length}>
 	{#each stats as stat (stat.label)}
 		<div
 			class="game-stat"
-			style:background-color={page.data.theme?.boardBackground}
-			style:color={page.data.theme?.textDark}
+			style:background-color={theme?.boardBackground}
+			style:color={boardInk}
 		>
 			{#if stat.newBest}
 				<span class="game-stat-badge">New Best!</span>
@@ -65,7 +70,7 @@
 		letter-spacing: 0.05em;
 		text-transform: uppercase;
 		white-space: nowrap;
-		box-shadow: 0 2px 6px rgb(0 0 0 / 0.25);
+		box-shadow: var(--shadow-pop);
 		animation: game-stat-badge-pop 300ms cubic-bezier(0.34, 1.56, 0.64, 1) 250ms both;
 	}
 

--- a/src/lib/components/ui/sonner/sonner.svelte
+++ b/src/lib/components/ui/sonner/sonner.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { Toaster as Sonner } from "svelte-sonner";
-	import { mode } from "mode-watcher";
+	import { page } from "$app/state";
+	import { isDarkTheme } from "$lib/themeTokens.js";
 	import Loader2Icon from "@lucide/svelte/icons/loader-2";
 	import CircleCheckIcon from "@lucide/svelte/icons/circle-check";
 	import OctagonXIcon from "@lucide/svelte/icons/octagon-x";
@@ -8,10 +9,18 @@
 	import TriangleAlertIcon from "@lucide/svelte/icons/triangle-alert";
 
 	let { ...restProps } = $props();
+
+	// Follow the selected game theme, not the OS scheme, so toasts stay
+	// coherent with the rest of the palette
+	let toasterTheme = $derived(
+		/** @type {"dark" | "light"} */ (
+			page.data.theme && isDarkTheme(page.data.theme) ? "dark" : "light"
+		)
+	);
 </script>
 
 <Sonner
-	theme={mode.current}
+	theme={toasterTheme}
 	class="toaster group"
 	style="--normal-bg: var(--color-popover); --normal-text: var(--color-popover-foreground); --normal-border: var(--color-border);"
 	{...restProps}

--- a/src/lib/game.svelte.js
+++ b/src/lib/game.svelte.js
@@ -1,5 +1,5 @@
 import { browser } from "$app/environment";
-import { defaultTheme } from "./assets/themes";
+import { defaultTheme, getInkColor } from "./assets/themes";
 import {
 	DEFAULT_BOARD_SIZE,
 	DEFAULT_STARTING_TILES,
@@ -26,76 +26,15 @@ export function getTileBackground(value, theme = defaultTheme) {
 }
 
 /**
- * Relative luminance of a hex color (0–1), per WCAG 2.
- * @param {string} hex
- * @returns {number}
- */
-function relativeLuminance(hex) {
-	hex = hex.replace(/^#/, "");
-	if (hex.length === 3) {
-		hex = hex
-			.split("")
-			.map((x) => x + x)
-			.join("");
-	}
-	const num = parseInt(hex, 16);
-	const channels = [(num >> 16) & 255, (num >> 8) & 255, num & 255].map((v) => {
-		v /= 255;
-		return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
-	});
-	return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
-}
-
-/**
- * WCAG contrast ratio between two hex colors.
- * @param {string} a
- * @param {string} b
- * @returns {number}
- */
-function contrastRatio(a, b) {
-	const l1 = relativeLuminance(a);
-	const l2 = relativeLuminance(b);
-	const lighter = Math.max(l1, l2);
-	const darker = Math.min(l1, l2);
-	return (lighter + 0.05) / (darker + 0.05);
-}
-
-/**
- * Classic keeps its historical luminance-threshold ink choice.
- * @param {string} bg
- * @param {typeof defaultTheme} theme
- * @returns {string}
- */
-function classicTileColor(bg, theme) {
-	return relativeLuminance(bg) < theme.luminanceThreshold ? theme.textDark : theme.textLight;
-}
-
-/**
- * Pick the higher-contrast ink (textLight vs textDark) for WCAG readability.
- * @param {string} bg
- * @param {typeof defaultTheme} theme
- * @returns {string}
- */
-function accessibleTileColor(bg, theme) {
-	const a = theme.textLight;
-	const b = theme.textDark;
-	return contrastRatio(bg, a) >= contrastRatio(bg, b) ? a : b;
-}
-
-/**
  * Get the number color for a tile using current theme.
  * Classic is unchanged (luminance threshold). Other themes pick dark/light
- * ink by WCAG contrast against the tile background.
+ * ink by WCAG contrast against the tile background. See getInkColor.
  * @param {number} value
  * @param {typeof defaultTheme} theme
  * @returns {string}
  */
 export function getTileColor(value, theme = defaultTheme) {
-	const bg = getTileBackground(value, theme);
-	if (theme.id === "classic") {
-		return classicTileColor(bg, theme);
-	}
-	return accessibleTileColor(bg, theme);
+	return getInkColor(getTileBackground(value, theme), theme);
 }
 
 /**

--- a/src/lib/themeTokens.js
+++ b/src/lib/themeTokens.js
@@ -2,6 +2,7 @@
  * Map play4096 theme presets onto shadcn semantic tokens + game tokens.
  * @typedef {import('$lib/assets/themes.js').Theme} Theme
  */
+import { contrastRatio, getInkColor, relativeLuminance } from "./assets/themes.js";
 
 /**
  * @param {string} hex
@@ -36,28 +37,26 @@ export function lightenColor(hex, amount = 0.2) {
 }
 
 /**
- * Relative luminance of a hex color (0–1).
- * @param {string} hex
- * @returns {number}
+ * Whether a theme is dark-surfaced (drives elevation + toast styling).
+ * @param {Theme} theme
+ * @returns {boolean}
  */
-function luminance(hex) {
-	hex = hex.replace("#", "");
-	const r = parseInt(hex.substring(0, 2), 16) / 255;
-	const g = parseInt(hex.substring(2, 4), 16) / 255;
-	const b = parseInt(hex.substring(4, 6), 16) / 255;
-	const toLinear = (c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
-	return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+export function isDarkTheme(theme) {
+	return relativeLuminance(theme.background) < 0.45;
 }
 
 /**
- * Pick light or dark text for contrast against a background.
+ * Pick whichever theme ink (textLight vs textDark) reads better on a surface.
+ * Unlike getInkColor this never uses Classic's historical threshold — chrome
+ * accents like primary are midtones where only the max-contrast ink works.
  * @param {string} bg
- * @param {string} light
- * @param {string} dark
+ * @param {Theme} theme
  * @returns {string}
  */
-function contrastText(bg, light, dark) {
-	return luminance(bg) > 0.45 ? dark : light;
+function pickInk(bg, theme) {
+	return contrastRatio(bg, theme.textLight) >= contrastRatio(bg, theme.textDark)
+		? theme.textLight
+		: theme.textDark;
 }
 
 /**
@@ -66,13 +65,19 @@ function contrastText(bg, light, dark) {
  * @param {Theme} theme
  */
 export function applyThemeTokens(style, theme) {
-	const foreground = theme.text ?? theme.textLight;
-	const primaryFg = contrastText(theme.primary, theme.textDark, theme.textLight);
-	const secondaryFg = contrastText(theme.secondary, theme.textDark, theme.textLight);
+	const dark = isDarkTheme(theme);
+	const foreground = theme.text ?? pickInk(theme.background, theme);
+	const primaryFg = pickInk(theme.primary, theme);
+	// Some secondaries are midtones where neither ink clears AA — themes
+	// provide an explicit ink for those.
+	const secondaryFg = theme.secondaryForeground ?? pickInk(theme.secondary, theme);
 	const muted = theme.emptyTile;
-	const border = theme.emptyTile;
-	const card = theme.background;
-	const popover = lightenColor(theme.background, 0.15);
+	const border = theme.border ?? theme.emptyTile;
+	// Closer surfaces are lighter (in both light and dark themes). Dark themes
+	// get smaller lifts so raised surfaces stay within a narrow brightness
+	// band of the page — they also rely on this instead of drop shadows.
+	const card = dark ? lightenColor(theme.background, 0.035) : theme.background;
+	const popover = lightenColor(theme.background, dark ? 0.06 : 0.15);
 
 	// shadcn chrome tokens
 	style.setProperty("--background", theme.background);
@@ -86,13 +91,10 @@ export function applyThemeTokens(style, theme) {
 	style.setProperty("--secondary", theme.secondary);
 	style.setProperty("--secondary-foreground", secondaryFg);
 	style.setProperty("--muted", muted);
-	style.setProperty("--muted-foreground", theme.textLight);
+	style.setProperty("--muted-foreground", pickInk(theme.emptyTile, theme));
 	style.setProperty("--accent", theme.boardBackground);
-	style.setProperty(
-		"--accent-foreground",
-		contrastText(theme.boardBackground, theme.textDark, theme.textLight)
-	);
-	style.setProperty("--destructive", "#e95937");
+	style.setProperty("--accent-foreground", getInkColor(theme.boardBackground, theme));
+	style.setProperty("--destructive", theme.destructive ?? "#e95937");
 	style.setProperty("--border", border);
 	style.setProperty("--input", border);
 	style.setProperty("--ring", theme.primary);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,6 +22,8 @@
 		const theme = page.data.theme;
 		if (theme) {
 			applyThemeTokens(document.documentElement.style, theme);
+			// Flat-depth themes (dark UIs) suppress drop shadows app-wide
+			document.documentElement.dataset.shadows = theme.shadows === false ? "none" : "soft";
 		}
 	});
 </script>

--- a/src/routes/challenges/+page.svelte
+++ b/src/routes/challenges/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { page } from "$app/state";
+	import { getInkColor } from "$lib/assets/themes.js";
 	import { CHALLENGE_RUN_STATUS, formatChallengeTypeLabel } from "$lib/challenges.js";
 	import { Button } from "$lib/components/ui/button/index.js";
 	import { CrownIcon, ChevronLeftIcon, ChevronRightIcon, CheckIcon, XIcon } from "@lucide/svelte";
@@ -7,6 +8,10 @@
 	let { data } = $props();
 
 	const weekdays = ["S", "M", "T", "W", "T", "F", "S"];
+
+	let theme = $derived(page.data.theme);
+	// Readable ink for board-colored surfaces (hero card, locked days)
+	let boardInk = $derived(theme ? getInkColor(theme.boardBackground, theme) : "#f9f6f2");
 
 	/**
 	 * @param {string | null} status
@@ -26,51 +31,27 @@
 	 * @param {{ status: string | null; isToday: boolean }} day
 	 */
 	function dayBackground(day) {
-		if (day.status === CHALLENGE_RUN_STATUS.WON) return page.data.theme?.challengeWon;
-		if (day.status === CHALLENGE_RUN_STATUS.LOST) return page.data.theme?.challengeLost;
-		if (day.isToday) return page.data.theme?.primary;
-		return page.data.theme?.boardBackground;
+		if (day.status === CHALLENGE_RUN_STATUS.WON) return theme?.challengeWon;
+		if (day.status === CHALLENGE_RUN_STATUS.LOST) return theme?.challengeLost;
+		if (day.isToday) return theme?.primary;
+		return theme?.boardBackground;
 	}
 
 	/**
-	 * Relative luminance of a hex color (0–1).
-	 * @param {string} hex
-	 */
-	function luminance(hex) {
-		const h = hex.replace("#", "");
-		const r = parseInt(h.substring(0, 2), 16) / 255;
-		const g = parseInt(h.substring(2, 4), 16) / 255;
-		const b = parseInt(h.substring(4, 6), 16) / 255;
-		const toLinear = (/** @type {number} */ c) =>
-			c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
-		return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
-	}
-
-	/**
-	 * Ink color for a calendar day. Status fills pick contrasting theme text;
-	 * today / open days keep the established light-on-board look.
-	 * @param {{ status: string | null; isToday: boolean }} day
-	 */
-	function dayColor(day) {
-		if (day.status === CHALLENGE_RUN_STATUS.WON || day.status === CHALLENGE_RUN_STATUS.LOST) {
-			const bg = dayBackground(day);
-			if (!bg) return "#ffffff";
-			// theme.textLight = dark ink (for light tiles); textDark = light ink
-			const lightInk = page.data.theme?.textDark ?? "#f9f6f2";
-			const darkInk = page.data.theme?.textLight ?? "#776e65";
-			return luminance(bg) > 0.45 ? darkInk : lightInk;
-		}
-		return page.data.theme?.textDark;
-	}
-
-	/**
+	 * Readable ink for a theme surface: Classic keeps its historical
+	 * light-on-board look, other themes pick the higher-contrast ink.
 	 * @param {string | undefined} bg
 	 */
 	function statusInk(bg) {
-		if (!bg) return "#ffffff";
-		const lightInk = page.data.theme?.textDark ?? "#f9f6f2";
-		const darkInk = page.data.theme?.textLight ?? "#776e65";
-		return luminance(bg) > 0.45 ? darkInk : lightInk;
+		if (!bg || !theme) return "#f9f6f2";
+		return getInkColor(bg, theme);
+	}
+
+	/**
+	 * @param {{ status: string | null; isToday: boolean }} day
+	 */
+	function dayColor(day) {
+		return statusInk(dayBackground(day));
 	}
 </script>
 
@@ -91,8 +72,8 @@
 	{#if data.todayChallenge}
 		<section
 			class="mb-6 rounded-xl p-4"
-			style:background-color={page.data.theme?.boardBackground}
-			style:color={page.data.theme?.textDark}
+			style:background-color={theme?.boardBackground}
+			style:color={boardInk}
 		>
 			<p class="mb-1 text-xs font-bold tracking-wide uppercase opacity-70">Today · {data.today}</p>
 			<h2 class="text-xl font-bold">{data.todayChallenge.title}</h2>
@@ -107,11 +88,8 @@
 	{/if}
 
 	{#if !data.isPro}
-		<div
-			class="mb-5 rounded-lg p-4 text-center"
-			style:background-color={page.data.theme?.boardBackground}
-		>
-			<p class="mb-3 text-sm" style:color={page.data.theme?.textDark}>
+		<div class="mb-5 rounded-lg p-4 text-center" style:background-color={theme?.boardBackground}>
+			<p class="mb-3 text-sm" style:color={boardInk}>
 				Browse today's challenge below. Starting any challenge — and opening past days — requires
 				Pro.
 			</p>
@@ -176,8 +154,8 @@
 					<a
 						href="/stripe"
 						class="day locked flex aspect-square flex-col items-center justify-center rounded-lg text-sm"
-						style:background-color={page.data.theme?.boardBackground}
-						style:color={page.data.theme?.textDark}
+						style:background-color={theme?.boardBackground}
+						style:color={boardInk}
 						title="Pro unlocks past challenges"
 					>
 						<span class="font-semibold">{day.day}</span>
@@ -209,16 +187,16 @@
 			<span class="inline-flex items-center gap-1.5">
 				<span
 					class="swatch"
-					style:background-color={page.data.theme?.primary}
-					style:box-shadow="0 0 0 2px color-mix(in srgb, {page.data.theme?.primary ?? '#000'} 70%, transparent)"
+					style:background-color={theme?.primary}
+					style:box-shadow="0 0 0 2px color-mix(in srgb, {theme?.primary ?? '#000'} 70%, transparent)"
 				></span>
 				Today
 			</span>
 			<span class="inline-flex items-center gap-1.5">
 				<span
 					class="swatch"
-					style:background-color={page.data.theme?.challengeWon}
-					style:color={statusInk(page.data.theme?.challengeWon)}
+					style:background-color={theme?.challengeWon}
+					style:color={statusInk(theme?.challengeWon)}
 				>
 					<CheckIcon size={8} strokeWidth={3} aria-hidden="true" />
 				</span>
@@ -227,8 +205,8 @@
 			<span class="inline-flex items-center gap-1.5">
 				<span
 					class="swatch"
-					style:background-color={page.data.theme?.challengeLost}
-					style:color={statusInk(page.data.theme?.challengeLost)}
+					style:background-color={theme?.challengeLost}
+					style:color={statusInk(theme?.challengeLost)}
 				>
 					<XIcon size={8} strokeWidth={3} aria-hidden="true" />
 				</span>

--- a/src/routes/challenges/[id]/+page.svelte
+++ b/src/routes/challenges/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { enhance } from "$app/forms";
 	import { page } from "$app/state";
+	import { getInkColor } from "$lib/assets/themes.js";
 	import BoardPreview from "$lib/components/BoardPreview.svelte";
 	import {
 		CHALLENGE_RUN_STATUS,
@@ -15,6 +16,10 @@
 	let { data } = $props();
 
 	let starting = $state(false);
+
+	const theme = $derived(page.data.theme);
+	// Readable ink for board-colored surfaces (locked banner, leaderboard link)
+	const boardInk = $derived(theme ? getInkColor(theme.boardBackground, theme) : "#f9f6f2");
 
 	const challenge = $derived(data.challenge);
 	const typeLabel = $derived(formatChallengeTypeLabel(challenge.type));
@@ -77,11 +82,8 @@
 	<h1 class="text-3xl font-bold text-primary">{challenge.title}</h1>
 
 	{#if data.locked}
-		<div
-			class="mt-6 rounded-lg p-4 text-center"
-			style:background-color={page.data.theme?.boardBackground}
-		>
-			<p class="mb-3 text-sm" style:color={page.data.theme?.textDark}>
+		<div class="mt-6 rounded-lg p-4 text-center" style:background-color={theme?.boardBackground}>
+			<p class="mb-3 text-sm" style:color={boardInk}>
 				Past daily challenges are a Pro feature — same archive pattern as game history.
 			</p>
 			{#if data.user}
@@ -99,12 +101,12 @@
 		<p class="mb-1 text-sm text-muted-foreground">{challenge.difficulty} · {typeLabel}</p>
 		<p class="mb-6 text-base">{data.overview}</p>
 
-		{#if previewBoard && page.data.theme}
+		{#if previewBoard && theme}
 			<div class="mb-6">
 				<p class="mb-2 text-xs font-bold tracking-wide text-muted-foreground uppercase">
 					Starting board
 				</p>
-				<BoardPreview theme={page.data.theme} board={previewBoard} />
+				<BoardPreview {theme} board={previewBoard} />
 			</div>
 		{/if}
 
@@ -133,11 +135,8 @@
 				</Button>
 			</form>
 		{:else}
-			<div
-				class="rounded-lg p-4 text-center"
-				style:background-color={page.data.theme?.boardBackground}
-			>
-				<p class="mb-3 text-sm" style:color={page.data.theme?.textDark}>
+			<div class="rounded-lg p-4 text-center" style:background-color={theme?.boardBackground}>
+				<p class="mb-3 text-sm" style:color={boardInk}>
 					{#if data.user}
 						Upgrade to Pro to play daily challenges.
 					{:else}
@@ -160,8 +159,8 @@
 		<a
 			href={leaderboardHref}
 			class="mt-6 flex items-center gap-3 rounded-lg px-4 py-3 transition-colors hover:brightness-95"
-			style:background-color={page.data.theme?.boardBackground}
-			style:color={page.data.theme?.textDark}
+			style:background-color={theme?.boardBackground}
+			style:color={boardInk}
 		>
 			<span
 				class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-secondary text-primary"

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from "$app/navigation";
 	import { untrack } from "svelte";
 	import { page } from "$app/state";
+	import { contrastRatio, getInkColor } from "$lib/assets/themes.js";
 	import { Game } from "$lib/game.svelte.js";
 	import { DIRECTIONS } from "$lib/constants.js";
 	import { createSwipeHandlers } from "$lib/swipe.js";
@@ -37,6 +38,21 @@
 	const challenge = $derived(data.challenge);
 	const isTime = $derived(challenge.type === CHALLENGE_TYPES.TIME);
 	const isRecovery = $derived(challenge.type === CHALLENGE_TYPES.RECOVERY);
+
+	const theme = $derived(page.data.theme);
+	// Readable ink for the board-colored stat boxes
+	const boardInk = $derived(theme ? getInkColor(theme.boardBackground, theme) : "#f9f6f2");
+	// Urgent countdown red: keep the historical deep red unless the theme's
+	// destructive accent reads better on the board (dark boards need it)
+	const urgentInk = $derived.by(() => {
+		const fallback = "#b91c1c";
+		if (!theme) return fallback;
+		const themed = theme.destructive ?? fallback;
+		return contrastRatio(theme.boardBackground, themed) >
+			contrastRatio(theme.boardBackground, fallback)
+			? themed
+			: fallback;
+	});
 
 	const winTile = $derived(
 		isRecovery && "winTile" in challenge.params ? challenge.params.winTile : null
@@ -321,8 +337,8 @@
 			{#if isRecovery}
 				<div
 					class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
-					style:background-color={page.data.theme?.boardBackground}
-					style:color={page.data.theme?.textDark}
+					style:background-color={theme?.boardBackground}
+					style:color={boardInk}
 				>
 					<div class="text-xs font-bold uppercase">Moves</div>
 					<div class="font-bold">{game?.moveCount ?? 0}</div>
@@ -330,8 +346,8 @@
 				{#if winTile}
 					<div
 						class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
-						style:background-color={page.data.theme?.boardBackground}
-						style:color={page.data.theme?.textDark}
+						style:background-color={theme?.boardBackground}
+						style:color={boardInk}
 					>
 						<div class="text-xs font-bold uppercase">Goal</div>
 						<div class="font-bold">{winTile}</div>
@@ -340,8 +356,8 @@
 			{:else}
 				<div
 					class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
-					style:background-color={page.data.theme?.boardBackground}
-					style:color={page.data.theme?.textDark}
+					style:background-color={theme?.boardBackground}
+					style:color={boardInk}
 				>
 					<div class="text-xs font-bold uppercase">Score</div>
 					<div class="font-bold">{game?.score.toLocaleString() ?? "—"}</div>
@@ -349,8 +365,8 @@
 				{#if isTime}
 					<div
 						class="min-w-[4.5rem] rounded-md px-3 py-2 text-center"
-						style:background-color={page.data.theme?.boardBackground}
-						style:color={remainingMs <= 10000 ? "#b91c1c" : page.data.theme?.textDark}
+						style:background-color={theme?.boardBackground}
+						style:color={remainingMs <= 10000 ? urgentInk : boardInk}
 					>
 						<div class="text-xs font-bold uppercase">Time</div>
 						<div class="font-bold">{formatTime(remainingMs)}</div>
@@ -365,7 +381,7 @@
 	{:else}
 		<div
 			class="mb-4 flex aspect-square items-center justify-center rounded-lg"
-			style:background-color={page.data.theme?.boardBackground}
+			style:background-color={theme?.boardBackground}
 		>
 			Loading…
 		</div>

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { untrack } from "svelte";
 	import { page } from "$app/state";
+	import { getInkColor } from "$lib/assets/themes.js";
 	import { CHECKPOINT_COOLDOWN_MOVES, USER_LEVELS } from "$lib/constants.js";
 	import { formatWinDuration } from "$lib/formatTime.js";
 	import { Game } from "$lib/game.svelte.js";
@@ -25,6 +26,10 @@
 	let game = $derived(gameState.currentGame);
 	let isPro = $derived(page.data.user?.level === USER_LEVELS.PRO);
 	let isLoggedIn = $derived(!!page.data.user);
+
+	let theme = $derived(page.data.theme);
+	// Readable ink for the board-colored score boxes
+	let boardInk = $derived(theme ? getInkColor(theme.boardBackground, theme) : "#f9f6f2");
 
 	/**
 	 * @typedef {Object} Props
@@ -365,8 +370,8 @@
 		<div class="flex gap-2">
 			<div
 				class="flex-1/2 overflow-hidden rounded-md py-2 text-center"
-				style:background-color={page.data.theme?.boardBackground}
-				style:color={page.data.theme?.textDark}
+				style:background-color={theme?.boardBackground}
+				style:color={boardInk}
 			>
 				<div class="text-center text-sm font-bold uppercase sm:text-lg">SCORE</div>
 				<div class="mt-1 text-sm font-bold sm:text-lg">
@@ -375,8 +380,8 @@
 			</div>
 			<div
 				class="flex-1/2 overflow-hidden rounded-md py-2 text-center"
-				style:background-color={page.data.theme?.boardBackground}
-				style:color={page.data.theme?.textDark}
+				style:background-color={theme?.boardBackground}
+				style:color={boardInk}
 			>
 				<div class="text-center text-sm font-bold uppercase sm:text-lg">BEST</div>
 				<div class="mt-1 text-sm font-bold sm:text-xl">

--- a/src/routes/themes/+page.svelte
+++ b/src/routes/themes/+page.svelte
@@ -59,8 +59,8 @@
 					href="/stripe"
 					class="theme-card flex flex-col gap-2 rounded-lg p-3 text-left transition-opacity hover:opacity-90"
 					style:background={theme.background}
-					style:color={theme.textLight ?? theme.text}
-					style:border={`2px solid ${active ? theme.primary : theme.emptyTile}`}
+					style:color={theme.text ?? theme.textLight}
+					style:border={`2px solid ${active ? theme.primary : (theme.border ?? theme.emptyTile)}`}
 				>
 					<div class="pointer-events-none">
 						<ThemePreview {theme} selected={active} />
@@ -81,8 +81,8 @@
 						disabled={saving}
 						class="theme-card flex flex-col gap-2 rounded-lg p-3 text-left transition-transform hover:scale-[1.02] disabled:opacity-60"
 						style:background={theme.background}
-						style:color={theme.textLight ?? theme.text}
-						style:border={`2px solid ${active ? theme.primary : theme.emptyTile}`}
+						style:color={theme.text ?? theme.textLight}
+						style:border={`2px solid ${active ? theme.primary : (theme.border ?? theme.emptyTile)}`}
 					>
 						<div class="pointer-events-none">
 							<ThemePreview {theme} selected={active} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Applies the color/contrast, depth, and container guidelines from the design tips document to all six themes. Per the constraint, **Classic's tile colors are untouched** — every tile fill in every theme is byte-for-byte identical to before. Everything around the tiles (page chrome, buttons, text inks, elevation) has been reworked.

Rebased onto `main` after [#53](https://github.com/JoelYoung01/Play4096/pull/53): the win-stats markup this branch had recolored moved into the new shared `GameStats.svelte`, so the contrast-picked ink and themed badge shadow now live there and automatically cover the win, game-over, and challenge-result dialogs.

## What changed, by guideline

**Near-black / near-white instead of pure values**
- High Contrast's chrome moved off pure `#000`/`#fff` to warm near-black (`#0c0b09`) and near-white (`#f8f6f1`). Its tile fills (which include pure black/white) are unchanged.
- No theme's chrome uses a pure value anymore (verified by the audit script).

**Saturate neutrals with the accent, one temperature per theme**
- Dark's neutrals were blue-grey next to a warm orange primary; they're now warm-tinted (`#1c1a18` / `#2d2a26` / `#3e3a34`, all ≤16% HSB saturation).
- Light stays uniformly cool (blue-tinted greys), Classic/Soft/Coral stay uniformly warm.

**High contrast for important elements**
- Primaries that failed WCAG as button fills or heading text were deepened: Classic `#e88f4f`→`#b8541a`, Light `#4a90d9`→`#2f74c0`, Soft `#a67c6d`→`#7e5a4c`, Coral `#ff6b6b`→`#c73333`. All button inks and destructive/secondary text now clear 4.5:1 (3:1 for large headings).
- Score/timer/stat text on board-colored surfaces (HUD score boxes, challenge stat boxes, and the shared `GameStats` cards) now picks its ink by contrast (`getInkColor`, centralized in `themes.js`) instead of hardcoding `textDark`. Dark and High Contrast previously had inverted `textLight`/`textDark` semantics that produced dark-on-dark text; those are normalized. Classic's light-on-brown HUD is preserved as the one deliberate historical exception.

**No shadows in dark interfaces; don't mix depth techniques**
- Themes can declare `shadows: false` (Dark, High Contrast do). The layout sets `data-shadows` on `<html>` and a CSS rule zeroes out all Tailwind shadows, so dark themes use flat depth only.
- Dark themes instead express elevation through the brightness ladder: cards and popovers are *lighter* than the page ("closer elements should be lighter").

**Container brightness limits (≤12% dark / ≤7% light)**
- Dark: page→board→empty-cell steps are 7% / 6%. Light: 7% / 4%. High Contrast: 4% / 6%. Classic keeps its iconic 25% page→board jump as a deliberate exception (the brown board is the game's identity), with the inner board→cell step at 7%.

**Container borders contrast with both fill and background**
- Themes can declare an explicit `border` (Light, High Contrast do); others derive it from the empty-tile neutral rather than an arbitrary grey.

## Implementation notes

- `relativeLuminance` / `contrastRatio` / `getInkColor` now live in `themes.js` and are shared by the game logic, the token bridge, and components (previously duplicated in three places with drift).
- `themeTokens.js` derives all shadcn chrome tokens (`--card`, `--popover`, `--secondary-foreground`, `--border`, `--destructive`, …) from the theme by contrast, with optional per-theme overrides.
- `GameStats.svelte` (from #53) uses the shared `getInkColor` for its stat cards and `var(--shadow-pop)` for the "New Best!" badge, so the badge shadow is suppressed on flat-depth themes like the other floating elements.
- `app.css` root variables re-synced to the computed Classic values; disabled inputs use theme-tinted neutrals instead of hardcoded greys.
- New `scripts/theme-audit.js` (run with `node scripts/theme-audit.js`) validates every theme against these rules — pure-value check, WCAG ratios for body/button/secondary/destructive/muted text, brightness ladder report — and exits non-zero on violations. All checks pass.

## Screenshots

| Classic (tiles unchanged) | Dark (warm neutrals, flat depth) |
|---|---|
| [Classic theme game board](https://cursor.com/agents/bc-019fc994-5137-7806-b621-ed2414b72448/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftheme-classic-game.png) | [Dark theme game board](https://cursor.com/agents/bc-019fc994-5137-7806-b621-ed2414b72448/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftheme-dark-game.png) |

| High Contrast (near-black chrome) | Themes page (Light) |
|---|---|
| [High Contrast theme game board](https://cursor.com/agents/bc-019fc994-5137-7806-b621-ed2414b72448/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftheme-high-contrast-game.png) | [Themes page in Light theme](https://cursor.com/agents/bc-019fc994-5137-7806-b621-ed2414b72448/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fthemes-page-light.png) |

## Testing

- `node scripts/theme-audit.js` — all themes pass every hard check (re-run after the rebase).
- `pnpm lint` — clean.
- `pnpm build` — succeeds.
- `pnpm check` — 145 errors vs. 146 on `main` (this branch removes one pre-existing error in `themeTokens.js`; no new ones).
- Manually reviewed all six themes across the game, themes, and challenges pages in the browser.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc994-5137-7806-b621-ed2414b72448?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc994-5137-7806-b621-ed2414b72448&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

