### PR TITLE
Replace manual checkpoints with automatic biggest-tile checkpoints

### DIFF
--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -6,8 +6,6 @@ export const DEFAULT_BOARD_SIZE = 4;
 export const DEFAULT_STARTING_TILES = 2;
 /** Moves required after an undo before undo can be used again */
 export const UNDO_COOLDOWN_MOVES = 10;
-/** Board progress (moves) required past the active checkpoint before a new one can be set */
-export const CHECKPOINT_COOLDOWN_MOVES = 100;
 export const SPAWN_START_SCALE = 0.5;
 export const DEFAULT_LUMINANCE_THRESHOLD = 0.7;
 export const TILE_SPAWN_DURATION = 100;

--- a/src/lib/game.svelte.js
+++ b/src/lib/game.svelte.js
@@ -162,6 +162,20 @@ export class Game {
 	}
 
 	/**
+	 * Largest tile currently on the board
+	 * @returns {number}
+	 */
+	get maxTile() {
+		let max = 0;
+		for (const row of this.board) {
+			for (const cell of row) {
+				if (cell > max) max = cell;
+			}
+		}
+		return max;
+	}
+
+	/**
 	 * Initialize game state
 	 * @param {import("./types").GameState?} initialState
 	 * @param {number} startingTiles

--- a/src/lib/server/checkpoint.js
+++ b/src/lib/server/checkpoint.js
@@ -1,7 +1,7 @@
 import assert from "node:assert";
 import { and, desc, eq } from "drizzle-orm";
 
-import { CHECKPOINT_COOLDOWN_MOVES, USER_LEVELS } from "$lib/constants";
+import { USER_LEVELS } from "$lib/constants";
 import { db } from "$lib/server/db";
 import * as table from "$lib/server/db/schema";
 import { getUser } from "$lib/server/user";
@@ -41,6 +41,20 @@ function requireOwnedGame(gameId, userId) {
 }
 
 /**
+ * Largest tile on a checkpoint board — the milestone the checkpoint represents.
+ * @param {number[][]} board
+ */
+function boardMaxTile(board) {
+	let max = 0;
+	for (const row of board) {
+		for (const cell of row) {
+			if (cell > max) max = cell;
+		}
+	}
+	return max;
+}
+
+/**
  * Map a checkpoint row to client-facing metadata.
  * @param {typeof table.gameCheckpoint.$inferSelect} row
  * @returns {import("$lib/types").CheckpointInfo}
@@ -52,6 +66,7 @@ function toCheckpointInfo(row) {
 		createdOn: row.createdOn.getTime(),
 		score: row.score,
 		moveCount: row.moveCount,
+		maxTile: boardMaxTile(row.board),
 	};
 }
 
@@ -79,7 +94,12 @@ export function getActiveCheckpoint(userId, gameId) {
 }
 
 /**
- * Set a checkpoint for the current game. Marks any prior active checkpoint as inactive.
+ * Set the checkpoint for the current game. Marks any prior active checkpoint as inactive.
+ *
+ * Checkpoints are automatic: the client saves one right after any move whose
+ * merge created (or tied) the run's biggest tile, so the active checkpoint
+ * always points at the most recent biggest-tile moment. There is no cooldown —
+ * a newer snapshot simply supersedes the old one.
  *
  * @param {string} userId
  * @param {import("$lib/types").CheckpointSaveData} snapshot
@@ -92,26 +112,6 @@ export async function setCheckpoint(userId, snapshot) {
 	assert(typeof snapshot.score === "number", "score is required");
 
 	const existingGame = requireOwnedGame(snapshot.gameId, userId);
-
-	// Checkpoints recharge with board progress: the next one unlocks
-	// CHECKPOINT_COOLDOWN_MOVES moves past the active checkpoint. Anchoring to
-	// the checkpoint's move count means undo/restore can't shortcut the wait.
-	const activeCheckpoint = getActiveCheckpoint(userId, snapshot.gameId);
-	if (activeCheckpoint) {
-		const movesSince =
-			(snapshot.moveCount ?? existingGame.moveCount ?? 0) - activeCheckpoint.moveCount;
-		if (movesSince < CHECKPOINT_COOLDOWN_MOVES) {
-			const remaining = Math.min(CHECKPOINT_COOLDOWN_MOVES, CHECKPOINT_COOLDOWN_MOVES - movesSince);
-			const error = new Error(
-				`Checkpoint available in ${remaining} move${remaining === 1 ? "" : "s"}`
-			);
-			// @ts-ignore attach status for API handlers
-			error.status = 429;
-			// @ts-ignore
-			error.code = "CHECKPOINT_COOLDOWN";
-			throw error;
-		}
-	}
 
 	await db
 		.update(table.gameCheckpoint)

--- a/src/lib/server/db/schema/gameSchemas.ts
+++ b/src/lib/server/db/schema/gameSchemas.ts
@@ -32,8 +32,11 @@ export const game = sqliteTable("game", {
 /**
  * Checkpoint snapshots for a game run.
  *
- * Only one row per game should have isActive=true at a time (the restore target).
- * Superseded rows are retained for analytics and are not restorable in the UI.
+ * Checkpoints are captured automatically right after a move whose merge created
+ * (or tied) the run's biggest tile, so the active row always points at the most
+ * recent biggest-tile moment. Only one row per game should have isActive=true at
+ * a time (the restore target). Superseded rows are retained for analytics and
+ * are not restorable in the UI.
  */
 export const gameCheckpoint = sqliteTable("game_checkpoint", {
 	id: text("id").primaryKey(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -120,7 +120,10 @@ export type GameHistorySort = "date" | "score" | "moves";
 export type GameHistoryFilter = "all" | "active" | "won" | "lost";
 
 
-/** Snapshot payload used when setting a checkpoint */
+/**
+ * Snapshot payload used when saving a checkpoint — captured by the client
+ * right after a move whose merge created (or tied) the run's biggest tile.
+ */
 export interface CheckpointSaveData {
   gameId: string;
   board: number[][];
@@ -141,6 +144,8 @@ export interface CheckpointInfo {
   createdOn: number;
   score: number;
   moveCount: number;
+  /** Largest tile on the checkpoint board — the milestone the checkpoint represents */
+  maxTile: number;
 }
 
 /** Full checkpoint state used when restoring into the current game */

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -4,7 +4,7 @@
 	import { toast } from "svelte-sonner";
 
 	import { Game, isSameGame } from "$lib/game.svelte.js";
-	import { DIRECTIONS } from "$lib/constants.js";
+	import { DIRECTIONS, USER_LEVELS } from "$lib/constants.js";
 	import { saveGame as localSaveGame } from "$lib/localStorage.svelte.js";
 
 	import AnimatedBoard from "./components/AnimatedBoard.svelte";
@@ -131,6 +131,7 @@
 		const applies = !!checkpoint && gameState.currentGame?.id === checkpoint.gameId;
 		gameState.hasCheckpoint = applies;
 		gameState.checkpointMoveCount = applies && checkpoint ? checkpoint.moveCount : null;
+		gameState.checkpointTile = applies && checkpoint ? (checkpoint.maxTile ?? null) : null;
 	}
 
 	/**
@@ -247,8 +248,10 @@
 		}
 
 		pendingEvents.splice(0, pendingEvents.length);
+		pendingCheckpoint = null;
 		gameState.hasCheckpoint = false;
 		gameState.checkpointMoveCount = null;
+		gameState.checkpointTile = null;
 		gameState.currentGame = new Game();
 	}
 
@@ -322,22 +325,84 @@
 	}
 
 	/**
-	 * Capture the current board as the active checkpoint for this run
+	 * Latest biggest-tile snapshot awaiting upload. Coalesced: a newer
+	 * biggest-tile moment replaces an older one that hasn't been sent yet.
+	 * @type {{
+	 *   game: import("$lib/game.svelte.js").Game,
+	 *   snapshot: Omit<import("$lib/types").GameSaveData, "playerId">,
+	 *   tile: number,
+	 * } | null}
 	 */
-	async function handleSetCheckpoint() {
-		const game = gameState.currentGame;
-		if (!game || !page.data.user) return;
+	let pendingCheckpoint = null;
+	let checkpointSaveInFlight = false;
+
+	/**
+	 * Largest tile created by merges in a move's event list (0 when nothing merged)
+	 * @param {import("$lib/types").GameEvent[]} events
+	 */
+	function largestMergedTile(events) {
+		let largest = 0;
+		for (const event of events) {
+			if (event.merged && typeof event.value === "number") {
+				// Merge events carry the pre-merge tile value; the created tile doubles it
+				largest = Math.max(largest, event.value * 2);
+			}
+		}
+		return largest;
+	}
+
+	/**
+	 * Auto-checkpoint: when a move's merge created (or tied) the run's biggest
+	 * tile, capture the post-move state so the player can return to it later.
+	 * Pro-only and silent — the most recent biggest-tile moment wins.
+	 *
+	 * @param {import("$lib/game.svelte.js").Game} game
+	 * @param {import("$lib/types").GameEvent[]} events
+	 * @param {number} maxTileBefore Largest tile on the board before the move
+	 */
+	function maybeCaptureCheckpoint(game, events, maxTileBefore) {
+		if (page.data.user?.level !== USER_LEVELS.PRO) return;
+		// A checkpoint at a dead board would be useless to restore
+		if (game.gameOver) return;
+
+		const createdTile = largestMergedTile(events);
+		if (createdTile === 0 || createdTile < maxTileBefore) return;
+
+		pendingCheckpoint = { game, snapshot: game.json(), tile: createdTile };
+		void flushCheckpointQueue();
+	}
+
+	/**
+	 * Upload pending checkpoints one at a time so an older snapshot can never
+	 * land after (and overwrite) a newer one.
+	 */
+	async function flushCheckpointQueue() {
+		if (checkpointSaveInFlight) return;
+		checkpointSaveInFlight = true;
+		try {
+			while (pendingCheckpoint) {
+				const { game, snapshot, tile } = pendingCheckpoint;
+				pendingCheckpoint = null;
+				await saveCheckpoint(game, snapshot, tile);
+			}
+		} finally {
+			checkpointSaveInFlight = false;
+		}
+	}
+
+	/**
+	 * Persist one biggest-tile snapshot as the run's active checkpoint
+	 * @param {import("$lib/game.svelte.js").Game} game
+	 * @param {Omit<import("$lib/types").GameSaveData, "playerId">} snapshot
+	 * @param {number} tile
+	 */
+	async function saveCheckpoint(game, snapshot, tile) {
+		// The run may have ended or been replaced while this save waited
+		if (gameState.currentGame !== game) return;
 
 		const gameId = await ensurePersistedGameId();
-		if (!gameId) {
-			console.error("Unable to set checkpoint: game is not saved");
-			toast.error("Couldn't set checkpoint", {
-				description: "The game hasn't synced to the server yet. Try again in a moment.",
-			});
-			return;
-		}
+		if (!gameId || gameState.currentGame !== game) return;
 
-		const snapshot = game.json();
 		try {
 			const response = await fetch("/api/game/checkpoint", {
 				method: "POST",
@@ -356,18 +421,16 @@
 			});
 			const result = await response.json();
 			if (!response.ok || !result.success) {
-				throw new Error(result.error || "Failed to set checkpoint");
+				throw new Error(result.error || "Failed to save checkpoint");
 			}
+
+			if (gameState.currentGame !== game) return;
 			gameState.hasCheckpoint = true;
 			gameState.checkpointMoveCount = result.checkpoint?.moveCount ?? snapshot.moveCount;
-			toast.success("Checkpoint saved", {
-				description: `Score ${snapshot.score.toLocaleString()} · move ${snapshot.moveCount.toLocaleString()}`,
-			});
+			gameState.checkpointTile = result.checkpoint?.maxTile ?? tile;
 		} catch (error) {
-			console.error("Failed to set checkpoint:", error);
-			toast.error("Couldn't set checkpoint", {
-				description: error instanceof Error ? error.message : "Please try again.",
-			});
+			// Auto-checkpoints fail silently; the next biggest-tile merge retries
+			console.error("Failed to save checkpoint:", error);
 		}
 	}
 
@@ -429,11 +492,14 @@
 	 * @param {number} direction
 	 */
 	function handleMove(direction) {
-		if (!gameState.currentGame) return;
+		const game = gameState.currentGame;
+		if (!game) return;
 
-		const events = gameState.currentGame.moveTiles(direction);
+		const maxTileBefore = game.maxTile;
+		const events = game.moveTiles(direction);
 		if (events.length > 0) {
 			pendingEvents.push(...events);
+			maybeCaptureCheckpoint(game, events, maxTileBefore);
 		}
 	}
 
@@ -534,7 +600,6 @@
 		{pendingEvents}
 		{popEvent}
 		onNewGame={handleNewGame}
-		onSetCheckpoint={handleSetCheckpoint}
 		onRestoreCheckpoint={handleRestoreCheckpoint}
 	/>
 

--- a/src/routes/game/components/AnimatedBoard.svelte
+++ b/src/routes/game/components/AnimatedBoard.svelte
@@ -20,7 +20,6 @@
 	 *   popEvent: () => import("$lib/types").GameEvent | undefined,
 	 *   onUndo?: () => void,
 	 *   onNewGame?: () => void | Promise<void>,
-	 *   onSetCheckpoint?: () => void | Promise<void>,
 	 *   onRestoreCheckpoint?: () => void | Promise<void>,
 	 *   game?: import("$lib/game.svelte.js").Game | null,
 	 *   showControls?: boolean,
@@ -33,7 +32,6 @@
 		popEvent,
 		onUndo = undefined,
 		onNewGame = undefined,
-		onSetCheckpoint = undefined,
 		onRestoreCheckpoint = undefined,
 		game: gameProp = undefined,
 		showControls = true,
@@ -222,7 +220,6 @@
 		{animationIdle}
 		onUndo={handleUndo}
 		{onNewGame}
-		{onSetCheckpoint}
 		onRestoreCheckpoint={handleRestoreCheckpoint}
 	/>
 {/if}

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -2,7 +2,7 @@
 	import { untrack } from "svelte";
 	import { page } from "$app/state";
 	import { getInkColor } from "$lib/assets/themes.js";
-	import { CHECKPOINT_COOLDOWN_MOVES, USER_LEVELS } from "$lib/constants.js";
+	import { USER_LEVELS } from "$lib/constants.js";
 	import { formatWinDuration } from "$lib/formatTime.js";
 	import { Game } from "$lib/game.svelte.js";
 	import { saveBestWinStats } from "$lib/localStorage.svelte.js";
@@ -11,7 +11,6 @@
 	import GameStats from "$lib/components/GameStats.svelte";
 	import { gameState } from "../state.svelte.js";
 	import {
-		BookmarkPlusIcon,
 		CrownIcon,
 		LoaderCircleIcon,
 		MoveHorizontalIcon,
@@ -36,7 +35,6 @@
 	 * @property {boolean} [animationIdle]
 	 * @property {(() => void) | undefined} [onUndo]
 	 * @property {(() => void | Promise<void>) | undefined} [onNewGame]
-	 * @property {(() => void | Promise<void>) | undefined} [onSetCheckpoint]
 	 * @property {(() => void | Promise<void>) | undefined} [onRestoreCheckpoint]
 	 */
 
@@ -45,7 +43,6 @@
 		animationIdle = true,
 		onUndo = undefined,
 		onNewGame = undefined,
-		onSetCheckpoint = undefined,
 		onRestoreCheckpoint = undefined,
 	} = $props();
 
@@ -70,9 +67,8 @@
 	let undoQueued = $state(false);
 	/** True while waiting for animations before restoring a checkpoint */
 	let restoreQueued = $state(false);
-	let checkpointBusy = $state(false);
-	/** Which checkpoint op is in flight, so only that button shows a spinner @type {"set" | "restore" | null} */
-	let checkpointAction = $state(null);
+	/** True while a checkpoint restore request is in flight */
+	let restoreBusy = $state(false);
 
 	$effect(() => {
 		if (!game) return;
@@ -179,7 +175,7 @@
 			return;
 		}
 
-		if (!animationIdle || checkpointBusy) return;
+		if (!animationIdle || restoreBusy) return;
 
 		restoreQueued = false;
 		void runRestoreCheckpoint();
@@ -200,6 +196,7 @@
 		}
 		gameState.hasCheckpoint = false;
 		gameState.checkpointMoveCount = null;
+		gameState.checkpointTile = null;
 		gameState.currentGame = new Game();
 	}
 
@@ -254,36 +251,22 @@
 		onUndo?.();
 	}
 
-	async function runSetCheckpoint() {
-		if (!isPro || !game || checkpointBusy || checkpointCooldownRemaining > 0) return;
-		checkpointBusy = true;
-		checkpointAction = "set";
-		try {
-			await onSetCheckpoint?.();
-		} finally {
-			checkpointBusy = false;
-			checkpointAction = null;
-		}
-	}
-
 	async function runRestoreCheckpoint() {
-		if (!isPro || !game || !gameState.hasCheckpoint || checkpointBusy) return;
-		checkpointBusy = true;
-		checkpointAction = "restore";
+		if (!isPro || !game || !gameState.hasCheckpoint || restoreBusy) return;
+		restoreBusy = true;
 		try {
 			await onRestoreCheckpoint?.();
 			showGameOver = false;
 			showWin = false;
 			winElapsedMs = null;
 		} finally {
-			checkpointBusy = false;
-			checkpointAction = null;
+			restoreBusy = false;
 		}
 	}
 
 	/** Ask before discarding progress since the checkpoint */
 	function requestRestoreCheckpoint() {
-		if (!isPro || !gameState.hasCheckpoint || checkpointBusy || restoreQueued) return;
+		if (!isPro || !gameState.hasCheckpoint || restoreBusy || restoreQueued) return;
 		confirmRestoreCheckpoint = true;
 	}
 
@@ -293,7 +276,7 @@
 	}
 
 	function handleRestoreCheckpoint() {
-		if (!isPro || !gameState.hasCheckpoint || checkpointBusy || restoreQueued) return;
+		if (!isPro || !gameState.hasCheckpoint || restoreBusy || restoreQueued) return;
 
 		if (!animationIdle) {
 			restoreQueued = true;
@@ -317,16 +300,7 @@
 						: "Nothing to undo"
 	);
 
-	let canRestoreCheckpoint = $derived(isPro && gameState.hasCheckpoint && !checkpointBusy);
-
-	// Checkpoints recharge with board progress: the next one unlocks
-	// CHECKPOINT_COOLDOWN_MOVES moves past the active checkpoint. Anchoring to the
-	// checkpoint's move count means undo/restore can't shortcut the wait.
-	let checkpointCooldownRemaining = $derived.by(() => {
-		if (!game || !gameState.hasCheckpoint || gameState.checkpointMoveCount == null) return 0;
-		const movesSince = game.moveCount - gameState.checkpointMoveCount;
-		return Math.min(CHECKPOINT_COOLDOWN_MOVES, Math.max(0, CHECKPOINT_COOLDOWN_MOVES - movesSince));
-	});
+	let canRestoreCheckpoint = $derived(isPro && gameState.hasCheckpoint && !restoreBusy);
 
 	/** How many board moves restoring the checkpoint will rewind */
 	let checkpointMovesBack = $derived.by(() => {
@@ -334,29 +308,25 @@
 		return Math.max(0, game.moveCount - gameState.checkpointMoveCount);
 	});
 
-	let setCheckpointBusy = $derived(checkpointBusy && checkpointAction === "set");
-	let restoreCheckpointBusy = $derived(
-		restoreQueued || (checkpointBusy && checkpointAction === "restore")
+	/** Biggest tile the checkpoint returns to, shown as it appears on the board (null when unknown) */
+	let checkpointTileLabel = $derived(
+		gameState.hasCheckpoint && gameState.checkpointTile ? String(gameState.checkpointTile) : null
 	);
 
-	let setCheckpointTitle = $derived(
-		setCheckpointBusy
-			? "Saving checkpoint…"
-			: game?.gameOver
-				? "Checkpoints can only be set during an active game"
-				: checkpointCooldownRemaining > 0
-					? `Checkpoint available in ${checkpointCooldownRemaining} move${checkpointCooldownRemaining === 1 ? "" : "s"}`
-					: "Set a checkpoint for this run"
-	);
-	let restoreCheckpointTitle = $derived(
-		restoreCheckpointBusy
-			? "Restoring checkpoint…"
-			: gameState.hasCheckpoint
-				? checkpointMovesBack === 0
-					? "Restore your last checkpoint"
-					: `Restore checkpoint (${checkpointMovesBack} move${checkpointMovesBack === 1 ? "" : "s"} back)`
-				: "No checkpoint set"
-	);
+	let restoreCheckpointBusy = $derived(restoreQueued || restoreBusy);
+
+	let restoreCheckpointTitle = $derived.by(() => {
+		if (restoreCheckpointBusy) return "Returning to your biggest tile…";
+		if (!gameState.hasCheckpoint) {
+			return "No checkpoint yet — one is saved automatically when you make your biggest tile";
+		}
+		const target = checkpointTileLabel
+			? `Go back to your biggest tile (${checkpointTileLabel})`
+			: "Go back to your biggest tile";
+		return checkpointMovesBack > 0
+			? `${target} — ${checkpointMovesBack} move${checkpointMovesBack === 1 ? "" : "s"} back`
+			: target;
+	});
 </script>
 
 <!-- Header -->
@@ -406,23 +376,6 @@
 	{#if isPro}
 		<button
 			class="controls-btn relative bg-primary text-primary-foreground hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-40"
-			onclick={() => void runSetCheckpoint()}
-			disabled={!game || game.gameOver || checkpointBusy || checkpointCooldownRemaining > 0}
-			title={setCheckpointTitle}
-			aria-label={setCheckpointTitle}
-			aria-busy={setCheckpointBusy}
-		>
-			{#if setCheckpointBusy}
-				<LoaderCircleIcon class="animate-spin" size={18} />
-			{:else}
-				<BookmarkPlusIcon size={18} />
-			{/if}
-			{#if checkpointCooldownRemaining > 0 && !setCheckpointBusy}
-				<span class="cooldown-badge">{checkpointCooldownRemaining}</span>
-			{/if}
-		</button>
-		<button
-			class="controls-btn relative bg-primary text-primary-foreground hover:bg-primary/80 disabled:cursor-not-allowed disabled:opacity-40"
 			onclick={requestRestoreCheckpoint}
 			disabled={!canRestoreCheckpoint && !restoreQueued}
 			title={restoreCheckpointTitle}
@@ -435,15 +388,18 @@
 			{:else}
 				<BookmarkUndoIcon size={18} />
 			{/if}
+			{#if checkpointTileLabel && !restoreCheckpointBusy}
+				<span class="tile-badge">{checkpointTileLabel}</span>
+			{/if}
 		</button>
 	{:else}
 		<a
 			href={isLoggedIn ? "/stripe" : "/login"}
 			class="controls-btn relative flex items-center justify-center bg-primary text-primary-foreground hover:bg-primary/80"
-			title="Checkpoints (Pro)"
-			aria-label="Checkpoints (Pro)"
+			title="Biggest-tile checkpoints (Pro)"
+			aria-label="Biggest-tile checkpoints (Pro)"
 		>
-			<BookmarkPlusIcon size={18} />
+			<BookmarkUndoIcon size={18} />
 			<span class="pro-badge"><CrownIcon size={10} /></span>
 		</a>
 	{/if}
@@ -516,13 +472,15 @@
 					class="m-1"
 					variant={game.canUndo ? "secondary" : "default"}
 					onclick={requestRestoreCheckpoint}
-					disabled={checkpointBusy || restoreQueued}
+					disabled={restoreBusy || restoreQueued}
 					aria-haspopup="dialog"
 				>
 					{#if restoreCheckpointBusy}
 						Restoring…
+					{:else if checkpointTileLabel}
+						Back to Your {checkpointTileLabel}
 					{:else}
-						Restore Checkpoint
+						Back to Your Biggest Tile
 					{/if}
 				</Button>
 			{:else if !isPro}
@@ -582,20 +540,26 @@
 <AlertDialog.Root bind:open={confirmRestoreCheckpoint}>
 	<AlertDialog.Content class="z-[1100]">
 		<AlertDialog.Header>
-			<AlertDialog.Title>Restore checkpoint?</AlertDialog.Title>
+			<AlertDialog.Title>
+				{#if checkpointTileLabel}
+					Go back to your {checkpointTileLabel} tile?
+				{:else}
+					Go back to your biggest tile?
+				{/if}
+			</AlertDialog.Title>
 			<AlertDialog.Description>
 				{#if checkpointMovesBack === 0}
-					This restores your board to the saved checkpoint.
+					This restores your board to right after the move that made your biggest tile.
 				{:else}
 					This goes back {checkpointMovesBack.toLocaleString()} move{checkpointMovesBack === 1
 						? ""
-						: "s"} and restores your board to the saved checkpoint.
+						: "s"}, to right after the move that made your biggest tile.
 				{/if}
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
 			<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-			<AlertDialog.Action onclick={confirmRestoreCheckpointAction}>Restore</AlertDialog.Action>
+			<AlertDialog.Action onclick={confirmRestoreCheckpointAction}>Go Back</AlertDialog.Action>
 		</AlertDialog.Footer>
 	</AlertDialog.Content>
 </AlertDialog.Root>
@@ -609,6 +573,11 @@
 
 	.cooldown-badge {
 		@apply absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-black/70 px-1 text-[10px] leading-none font-bold text-white;
+	}
+
+	/* Which biggest-tile moment the checkpoint returns to */
+	.tile-badge {
+		@apply absolute -top-1 -right-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-400 px-1 text-[9px] leading-none font-bold text-amber-950;
 	}
 
 	.pro-badge {

--- a/src/routes/game/state.svelte.js
+++ b/src/routes/game/state.svelte.js
@@ -14,8 +14,11 @@ export const gameState = $state({
 	/** Whether the current game has an active restorable checkpoint */
 	hasCheckpoint: false,
 
-	/** Move count when the active checkpoint was set — drives the set-checkpoint cooldown @type {number | null} */
+	/** Move count when the active checkpoint was captured — drives the "N moves back" copy @type {number | null} */
 	checkpointMoveCount: null,
+
+	/** Biggest tile the active checkpoint represents (e.g. 2048) @type {number | null} */
+	checkpointTile: null,
 });
 
 export const general = $state({

--- a/src/routes/stripe/+page.svelte
+++ b/src/routes/stripe/+page.svelte
@@ -31,7 +31,7 @@
 			implemented: true,
 		},
 		{
-			name: "Checkpoints",
+			name: "Biggest-tile checkpoints",
 			implemented: true,
 		},
 		{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks the Pro checkpoint system: instead of manually setting a checkpoint on a 100-move cooldown, the game now automatically keeps one checkpoint per run, pointing at the state right after the most recent move whose merge created (or tied) the run's biggest tile. If you merge into your 2048 on move A, keep playing, and eventually lose, you can go back to the state right after move A.

## Behavior

- **Capture (new):** after every successful move, if a merge produced a tile at least as big as anything on the board before the move, the client silently saves that post-move snapshot as the run's active checkpoint. Most recent biggest-tile moment wins — making a second, tied biggest tile advances the checkpoint (that is the most recent move that created your biggest tile). Moves that end the game don't capture — a dead board is useless to restore.
- **Restore (unchanged mechanics):** Pro-only, unlimited, confirm dialog, available from the controls row and the Game Over overlay; restores board/score/rng/move history into the same game so the run stays replayable.
- **Removed:** the manual set button, the set cooldown (`CHECKPOINT_COOLDOWN_MOVES`), and the save/cooldown toasts.

## Implementation

- `src/routes/game/+page.svelte`: detects biggest-tile merges in `handleMove` (largest merged tile vs. pre-move board max) and uploads snapshots through a coalescing, serialized queue so an older snapshot can never land after a newer one; snapshots are dropped if the run is replaced before the upload finishes.
- `src/lib/server/checkpoint.js`: cooldown check removed; `CheckpointInfo` now includes `maxTile` (computed from the stored board — no schema change, existing checkpoints keep working).
- `src/lib/game.svelte.js`: adds a `maxTile` getter.
- `GameControls.svelte`: restore button now shows a tile badge (e.g. `512`) and tile-aware copy ("Go back to your biggest tile (512) — 12 moves back"); Game Over overlay button reads "Back to Your {tile}"; confirm dialog updated to match.
- No DB migration needed; the `game_checkpoint` table and API endpoints are unchanged apart from the removed cooldown error.

## Testing

- `pnpm lint` and `pnpm build` pass. `pnpm check` reports 142 errors vs. 143 on `main` — the repo-wide baseline (Button prop typings etc.) predates this change; none of the errors are new.
- API end-to-end (dev server, scripted): checkpoint save returns `maxTile`; a second checkpoint is accepted immediately (no 429 cooldown); restore rewinds a game from move 30 back to the move-11 snapshot with board, score, rngState, and move history intact and `complete` reset; restore works repeatedly; free users get `403 PRO_REQUIRED`; restoring someone else's game is rejected.
- Manual browser testing (Pro user): badge appears on the first biggest-tile merge and updates silently on later ones; checkpoint survives reload; confirm dialog shows the correct "goes back N moves" count; restore visibly rewinds the board (verified via board rotations, which count as moves but never advance the checkpoint); play continues normally afterward; logged-out users see the crown upsell linking to /login. No console errors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcdc5-902d-73d6-ae96-ee8862f755a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcdc5-902d-73d6-ae96-ee8862f755a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

