### PR TITLE
Make biggest-tile checkpoints single-use after restore

### DIFF
--- a/src/lib/server/checkpoint.js
+++ b/src/lib/server/checkpoint.js
@@ -99,7 +99,8 @@ export function getActiveCheckpoint(userId, gameId) {
  * Checkpoints are automatic: the client saves one right after any move whose
  * merge created (or tied) the run's biggest tile, so the active checkpoint
  * always points at the most recent biggest-tile moment. There is no cooldown —
- * a newer snapshot simply supersedes the old one.
+ * a newer snapshot simply supersedes the old one. Restoring consumes the
+ * active checkpoint; only a later biggest-tile save makes restore available again.
  *
  * @param {string} userId
  * @param {import("$lib/types").CheckpointSaveData} snapshot
@@ -166,7 +167,29 @@ export async function setCheckpoint(userId, snapshot) {
 }
 
 /**
+ * Deactivate a checkpoint owned by the user (e.g. a stale save after restore).
+ * @param {string} userId
+ * @param {string} checkpointId
+ * @returns {boolean} true when a row was deactivated
+ */
+export function deactivateCheckpoint(userId, checkpointId) {
+	assert(checkpointId, "checkpointId is required");
+	const updated = db
+		.update(table.gameCheckpoint)
+		.set({ isActive: false })
+		.where(
+			and(eq(table.gameCheckpoint.id, checkpointId), eq(table.gameCheckpoint.playerId, userId))
+		)
+		.returning({ id: table.gameCheckpoint.id })
+		.get();
+	return !!updated;
+}
+
+/**
  * Restore the active checkpoint into the current game row and return the restored state.
+ *
+ * Checkpoints are single-use: restoring consumes the active row (isActive=false).
+ * A new restorable checkpoint appears only after the next biggest-tile capture.
  *
  * @param {string} userId
  * @param {string} gameId
@@ -219,6 +242,19 @@ export async function restoreCheckpoint(userId, gameId) {
 			updatedOn: new Date(),
 		})
 		.where(eq(table.game.id, gameId));
+
+	// Consume all active checkpoints for this run (the one restored plus any
+	// superseding snapshot that may have landed just before restore).
+	await db
+		.update(table.gameCheckpoint)
+		.set({ isActive: false })
+		.where(
+			and(
+				eq(table.gameCheckpoint.playerId, userId),
+				eq(table.gameCheckpoint.gameId, gameId),
+				eq(table.gameCheckpoint.isActive, true)
+			)
+		);
 
 	return {
 		id: gameId,

--- a/src/lib/server/db/schema/gameSchemas.ts
+++ b/src/lib/server/db/schema/gameSchemas.ts
@@ -35,8 +35,9 @@ export const game = sqliteTable("game", {
  * Checkpoints are captured automatically right after a move whose merge created
  * (or tied) the run's biggest tile, so the active row always points at the most
  * recent biggest-tile moment. Only one row per game should have isActive=true at
- * a time (the restore target). Superseded rows are retained for analytics and
- * are not restorable in the UI.
+ * a time (the restore target). Restoring consumes that row (isActive=false);
+ * the next biggest-tile capture creates a new restorable checkpoint. Superseded
+ * and consumed rows are retained for analytics and are not restorable in the UI.
  */
 export const gameCheckpoint = sqliteTable("game_checkpoint", {
 	id: text("id").primaryKey(),

--- a/src/routes/api/game/checkpoint/+server.js
+++ b/src/routes/api/game/checkpoint/+server.js
@@ -1,6 +1,6 @@
 import { json } from "@sveltejs/kit";
 import { USER_LEVELS } from "$lib/constants";
-import { getActiveCheckpoint, setCheckpoint } from "$lib/server/checkpoint";
+import { deactivateCheckpoint, getActiveCheckpoint, setCheckpoint } from "$lib/server/checkpoint";
 import { getUser } from "$lib/server/user";
 
 /**
@@ -58,6 +58,31 @@ export async function POST({ request, locals }) {
 			moves: body.moves,
 		});
 		return json({ success: true, checkpoint });
+	} catch (error) {
+		const { message, status, code } = normalizeError(error);
+		return json({ error: message, code }, { status });
+	}
+}
+
+/** @type {import("./$types").RequestHandler} */
+export async function DELETE({ request, locals }) {
+	if (!locals.user) {
+		return json({ error: "Not logged in" }, { status: 401 });
+	}
+
+	const user = getUser(locals.user.id);
+	if (!user || user.level !== USER_LEVELS.PRO) {
+		return json({ error: "Checkpoints are a Pro feature", code: "PRO_REQUIRED" }, { status: 403 });
+	}
+
+	const body = await request.json();
+	if (!body?.checkpointId) {
+		return json({ error: "checkpointId is required" }, { status: 400 });
+	}
+
+	try {
+		const deactivated = deactivateCheckpoint(locals.user.id, body.checkpointId);
+		return json({ success: true, deactivated });
 	} catch (error) {
 		const { message, status, code } = normalizeError(error);
 		return json({ error: message, code }, { status });

--- a/src/routes/game/+page.svelte
+++ b/src/routes/game/+page.svelte
@@ -424,7 +424,18 @@
 				throw new Error(result.error || "Failed to save checkpoint");
 			}
 
-			if (gameState.currentGame !== game) return;
+			// Restore (or new game) replaced this run — drop the stale snapshot
+			if (gameState.currentGame !== game) {
+				const staleId = result.checkpoint?.id;
+				if (staleId) {
+					void fetch("/api/game/checkpoint", {
+						method: "DELETE",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ checkpointId: staleId }),
+					}).catch(() => {});
+				}
+				return;
+			}
 			gameState.hasCheckpoint = true;
 			gameState.checkpointMoveCount = result.checkpoint?.moveCount ?? snapshot.moveCount;
 			gameState.checkpointTile = result.checkpoint?.maxTile ?? tile;
@@ -435,11 +446,15 @@
 	}
 
 	/**
-	 * Restore the latest active checkpoint into the current game
+	 * Restore the latest active checkpoint into the current game.
+	 * Consumes it — restore stays unavailable until the next biggest-tile save.
 	 */
 	async function handleRestoreCheckpoint() {
 		const game = gameState.currentGame;
 		if (!game?.id || !page.data.user) return;
+
+		// Drop any queued post-checkpoint snapshot so it can't revive a consumed one
+		pendingCheckpoint = null;
 
 		try {
 			const response = await fetch("/api/game/checkpoint/restore", {
@@ -456,8 +471,10 @@
 				id: result.game.id,
 				initialState: result.game,
 			});
-			gameState.hasCheckpoint = true;
-			gameState.checkpointMoveCount = result.game.moveCount ?? null;
+			// Restore consumes the checkpoint; a new one appears on the next biggest tile
+			gameState.hasCheckpoint = false;
+			gameState.checkpointMoveCount = null;
+			gameState.checkpointTile = null;
 			localSaveGame(gameState.currentGame.json());
 			queueMicrotask(() => flushSaveToServer());
 		} catch (error) {

--- a/src/routes/game/components/GameControls.svelte
+++ b/src/routes/game/components/GameControls.svelte
@@ -318,7 +318,7 @@
 	let restoreCheckpointTitle = $derived.by(() => {
 		if (restoreCheckpointBusy) return "Returning to your biggest tile…";
 		if (!gameState.hasCheckpoint) {
-			return "No checkpoint yet — one is saved automatically when you make your biggest tile";
+			return "No checkpoint available — one is saved when you make a new biggest tile (each restore uses it up)";
 		}
 		const target = checkpointTileLabel
 			? `Go back to your biggest tile (${checkpointTileLabel})`
@@ -549,11 +549,13 @@
 			</AlertDialog.Title>
 			<AlertDialog.Description>
 				{#if checkpointMovesBack === 0}
-					This restores your board to right after the move that made your biggest tile.
+					This restores your board to right after the move that made your biggest tile. Each
+					checkpoint can only be used once — make a new biggest tile to save another.
 				{:else}
 					This goes back {checkpointMovesBack.toLocaleString()} move{checkpointMovesBack === 1
 						? ""
-						: "s"}, to right after the move that made your biggest tile.
+						: "s"}, to right after the move that made your biggest tile. Each checkpoint can only be
+					used once — make a new biggest tile to save another.
 				{/if}
 			</AlertDialog.Description>
 		</AlertDialog.Header>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Biggest-tile checkpoints are now single-use. Restoring consumes the active checkpoint, so losing again without reaching a new milestone leaves restore unavailable. Making a new biggest tile (e.g. 4096 after spending a 2048 checkpoint) saves a fresh restorable checkpoint.

## Changes
- Server `restoreCheckpoint` marks all active checkpoints for the game inactive after restore
- Client clears checkpoint UI state on restore and drops any queued/stale checkpoint saves
- Confirm dialog and empty-state tooltip mention one-time use
- `DELETE /api/game/checkpoint` deactivates a stale checkpoint id if a save lands after restore

## Test plan
- [x] API: save 2048 checkpoint → restore succeeds → second restore returns `NO_CHECKPOINT`
- [x] API: save 4096 checkpoint after consume → restore succeeds once, then blocked again
- [ ] Manual: Pro game, reach 2048, lose, restore, lose again → restore disabled until a new biggest tile
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd339-497c-74bd-867b-670b48a6d0aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd339-497c-74bd-867b-670b48a6d0aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

