### PR TITLE
Default TestFlight API URL to https://play-4096.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ BUILD_VERSION=development
 # Example: https://play-4096.com/api/health
 # HEALTH_CHECK_URL=
 
+# Mobile TestFlight API origin (GitHub Actions variable → EXPO_PUBLIC_API_URL).
+# Example: https://play-4096.com  (origin only; app appends /api/v1)
+# MOBILE_API_URL=
+
 # URL for the database file.
 DATABASE_URL=data/local.db
 

--- a/.github/workflows/MobileRelease.yaml
+++ b/.github/workflows/MobileRelease.yaml
@@ -42,7 +42,9 @@ jobs:
       # Baked into JS at Metro bundle time (archive), not only prebuild.
       EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
       EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-      EXPO_PUBLIC_API_URL: ${{ vars.MOBILE_API_URL }}
+      # Match CI_CD HEALTH_CHECK_URL default. Empty vars.MOBILE_API_URL used to
+      # bake "" → mobile falls back to http://localhost:5173 on device.
+      EXPO_PUBLIC_API_URL: ${{ vars.MOBILE_API_URL != '' && vars.MOBILE_API_URL || 'https://play-4096.com' }}
       PLAY4096_IOS_BUNDLE_ID: ${{ vars.PLAY4096_IOS_BUNDLE_ID }}
     steps:
       - name: Checkout code
@@ -56,6 +58,29 @@ jobs:
             echo "::warning::Apple signing secrets (ASC_KEY_ID, ASC_ISSUER_ID, ASC_PRIVATE_KEY, APPLE_TEAM_ID) are not configured — skipping the signed iOS build. See mobile/README.md."
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate mobile API URL
+        if: steps.creds.outputs.configured == 'true'
+        run: |
+          echo "EXPO_PUBLIC_API_URL=$EXPO_PUBLIC_API_URL"
+          if [ -z "$EXPO_PUBLIC_API_URL" ]; then
+            echo "::error::EXPO_PUBLIC_API_URL is empty. Set GitHub Actions variable MOBILE_API_URL (production API origin, no /api/v1)."
+            exit 1
+          fi
+          case "$EXPO_PUBLIC_API_URL" in
+            http://localhost*|http://127.0.0.1*|https://localhost*|https://127.0.0.1*)
+              echo "::error::EXPO_PUBLIC_API_URL points at localhost ($EXPO_PUBLIC_API_URL). TestFlight builds cannot reach it. Set MOBILE_API_URL to https://play-4096.com (or your production origin)."
+              exit 1
+              ;;
+          esac
+          if [[ "$EXPO_PUBLIC_API_URL" != http://* && "$EXPO_PUBLIC_API_URL" != https://* ]]; then
+            echo "::error::EXPO_PUBLIC_API_URL must be an absolute http(s) origin (got: $EXPO_PUBLIC_API_URL)."
+            exit 1
+          fi
+          if [[ "$EXPO_PUBLIC_API_URL" == */api/v1 || "$EXPO_PUBLIC_API_URL" == */api/v1/ ]]; then
+            echo "::error::EXPO_PUBLIC_API_URL should be the site origin only (e.g. https://play-4096.com), not .../api/v1."
+            exit 1
           fi
 
       - name: Select Xcode (26.4+)

--- a/docs/ASC_Setup.md
+++ b/docs/ASC_Setup.md
@@ -46,7 +46,7 @@ Older ids (`com.joelyoung.play4096*`) are retired; leave any leftover Dev Portal
 | Variable | Purpose |
 |---|---|
 | `PLAY4096_IOS_BUNDLE_ID` | Optional override (default `com.joelyoung.4096`) |
-| `MOBILE_API_URL` | Production API origin baked into the JS bundle |
+| `MOBILE_API_URL` | Production API origin baked into the JS bundle (default `https://play-4096.com` if unset). Origin only — no `/api/v1`. |
 
 ## 4. Backend env (production)
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -59,6 +59,10 @@ App Store Connect / StoreKit CI secrets (same as Sous Kit / Jamez):
 
 Optional GitHub variables: `PLAY4096_IOS_BUNDLE_ID`, `MOBILE_API_URL`.
 
+`MOBILE_API_URL` is baked into TestFlight builds as `EXPO_PUBLIC_API_URL`. If unset,
+Mobile Release defaults it to `https://play-4096.com` (same host as the web deploy
+health check). Leaving it blank used to ship `localhost`, which cannot work on device.
+
 Full ASC + IAP setup: see [`docs/ASC_Setup.md`](../docs/ASC_Setup.md).
 
 Pro purchases post the StoreKit signed transaction to `/api/v1/iap/apple/verify`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
TestFlight builds were still failing sign-in with “Network error” because `vars.MOBILE_API_URL` was never set. Mobile Release logged `EXPO_PUBLIC_API_URL:` as empty, so the app fell back to `http://localhost:5173` on device. The clearer copy from #59 only made that same failure more readable.

Production web/API at `https://play-4096.com` is healthy (`/api/health` → 200).

## Changes
- Default `EXPO_PUBLIC_API_URL` in Mobile Release to `https://play-4096.com` when `MOBILE_API_URL` is unset (same pattern as `HEALTH_CHECK_URL`)
- Fail the signed iOS build if the resolved URL is empty, localhost, or accidentally includes `/api/v1`
- Document the default in `docs/ASC_Setup.md`, `mobile/README.md`, and `.env.example`

## Test plan
- [ ] Merge and let Mobile Release run (or trigger manually)
- [ ] Confirm the job log prints `EXPO_PUBLIC_API_URL=https://play-4096.com` (or your override)
- [ ] Install the new TestFlight build and sign in with Apple/Google/password
- [ ] Optional: set repo variable `MOBILE_API_URL` explicitly if you want a non-default origin
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff421-18ef-706f-aada-66bc146bbd0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff421-18ef-706f-aada-66bc146bbd0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

