### PR TITLE
Delay challenge fail overlay and add Reset button

### DIFF
--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -329,7 +329,7 @@
 <form
 	bind:this={completeForm}
 	method="POST"
-	action="?/complete"
+	action="?run={data.run.id}&/complete"
 	class="hidden"
 	use:enhance={() => {
 		return async ({ update }) => {

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -19,8 +19,8 @@
 	import AnimatedBoard from "../../../game/components/AnimatedBoard.svelte";
 	import { RotateCcwIcon } from "@lucide/svelte";
 
-	/** Match classic game-over beat so a stuck board is readable before the fail overlay. */
-	const GAME_OVER_DELAY_MS = 600;
+	/** Pause on the stuck board after animations so the loss is readable before the overlay. */
+	const GAME_OVER_DELAY_MS = 1000;
 
 	let { data } = $props();
 
@@ -131,7 +131,9 @@
 		if (result || submitting || data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) return;
 		pendingLoss = false;
 		result = status;
-		finishedElapsedMs = Math.max(0, Date.now() - data.run.startedOn);
+		if (finishedElapsedMs == null) {
+			finishedElapsedMs = Math.max(0, Date.now() - data.run.startedOn);
+		}
 		submitting = true;
 		queueMicrotask(() => completeForm?.requestSubmit());
 	}
@@ -155,6 +157,8 @@
 			finish("won");
 		} else if (outcome === "lost") {
 			// Hold the fail overlay so the stuck / timed-out board can register.
+			// Freeze elapsed now so the delay doesn't inflate time-challenge stats.
+			finishedElapsedMs = Math.max(0, Date.now() - data.run.startedOn);
 			pendingLoss = true;
 		}
 	}

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -19,29 +19,29 @@
 	import AnimatedBoard from "../../../game/components/AnimatedBoard.svelte";
 	import { RotateCcwIcon } from "@lucide/svelte";
 
-	/** Pause on the stuck board after animations so the loss is readable before the overlay. */
-	const GAME_OVER_DELAY_MS = 1000;
+	/** Keep the stuck board visible this long before the fail overlay. */
+	const GAME_OVER_DELAY_MS = 1200;
 
 	let { data } = $props();
 
 	/** @type {Game | null} */
 	let game = $state(null);
 	let result = $state(/** @type {'won' | 'lost' | null} */ (null));
-	/** Set when a loss is detected; overlay waits for animations + GAME_OVER_DELAY_MS. */
+	/** Set when a loss is detected; overlay opens after GAME_OVER_DELAY_MS. */
 	let pendingLoss = $state(false);
 	let remainingMs = $state(0);
 	/** Elapsed ms captured when the run finishes. */
 	let finishedElapsedMs = $state(/** @type {number | null} */ (null));
 	let submitting = $state(false);
 	let retrying = $state(false);
-	/** Bound from AnimatedBoard — true when move animations have settled. */
-	let animationIdle = $state(true);
 
 	/** @type {import("$lib/types").GameEvent[]} */
 	let pendingEvents = $state([]);
 
 	/** @type {HTMLFormElement | null} */
 	let completeForm = $state(null);
+	/** @type {ReturnType<typeof setTimeout> | null} */
+	let lossDelayTimer = null;
 
 	const challenge = $derived(data.challenge);
 	const isTime = $derived(challenge.type === CHALLENGE_TYPES.TIME);
@@ -98,7 +98,18 @@
 	/**
 	 * @param {number} startedOn
 	 */
+	function clearLossDelay() {
+		if (lossDelayTimer != null) {
+			clearTimeout(lossDelayTimer);
+			lossDelayTimer = null;
+		}
+	}
+
+	/**
+	 * @param {number} startedOn
+	 */
 	function initGame(startedOn) {
+		clearLossDelay();
 		pendingEvents = [];
 		game = createChallengeGame();
 		result = null;
@@ -106,7 +117,6 @@
 		finishedElapsedMs = null;
 		submitting = false;
 		retrying = false;
-		animationIdle = true;
 
 		if (isTime && "durationSec" in challenge.params) {
 			const durationMs = challenge.params.durationSec * 1000;
@@ -129,6 +139,7 @@
 	 */
 	function finish(status) {
 		if (result || submitting || data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) return;
+		clearLossDelay();
 		pendingLoss = false;
 		result = status;
 		if (finishedElapsedMs == null) {
@@ -136,6 +147,20 @@
 		}
 		submitting = true;
 		queueMicrotask(() => completeForm?.requestSubmit());
+	}
+
+	/**
+	 * Show the stuck board briefly, then open the fail overlay.
+	 */
+	function scheduleLossFinish() {
+		if (pendingLoss || result) return;
+		finishedElapsedMs = Math.max(0, Date.now() - data.run.startedOn);
+		pendingLoss = true;
+		clearLossDelay();
+		lossDelayTimer = setTimeout(() => {
+			lossDelayTimer = null;
+			if (pendingLoss && !result) finish("lost");
+		}, GAME_OVER_DELAY_MS);
 	}
 
 	/**
@@ -156,10 +181,7 @@
 		if (outcome === "won") {
 			finish("won");
 		} else if (outcome === "lost") {
-			// Hold the fail overlay so the stuck / timed-out board can register.
-			// Freeze elapsed now so the delay doesn't inflate time-challenge stats.
-			finishedElapsedMs = Math.max(0, Date.now() - data.run.startedOn);
-			pendingLoss = true;
+			scheduleLossFinish();
 		}
 	}
 
@@ -250,12 +272,14 @@
 		return () => {
 			window.removeEventListener("keydown", handleKeydown);
 			if (timer) clearInterval(timer);
+			clearLossDelay();
 		};
 	});
 
 	/** @type {import("@sveltejs/kit").SubmitFunction} */
 	const onReset = () => {
 		// Cancel a pending fail overlay / complete submit if the player resets first.
+		clearLossDelay();
 		pendingLoss = false;
 		retrying = true;
 		return async ({ result: actionResult }) => {
@@ -267,13 +291,6 @@
 			await applyAction(actionResult);
 		};
 	};
-
-	// After the last move animates, pause briefly on the stuck board, then fail.
-	$effect(() => {
-		if (!pendingLoss || !animationIdle || result) return;
-		const timeout = setTimeout(() => finish("lost"), GAME_OVER_DELAY_MS);
-		return () => clearTimeout(timeout);
-	});
 
 	/**
 	 * @param {unknown} value
@@ -404,13 +421,7 @@
 	</div>
 
 	{#if game}
-		<AnimatedBoard
-			{game}
-			{pendingEvents}
-			{popEvent}
-			showControls={false}
-			bind:animationIdle
-		/>
+		<AnimatedBoard {game} {pendingEvents} {popEvent} showControls={false} />
 	{:else}
 		<div
 			class="mb-4 flex aspect-square items-center justify-center rounded-lg"
@@ -420,13 +431,19 @@
 		</div>
 	{/if}
 
+	{#if pendingLoss}
+		<p class="mt-3 text-center text-sm font-semibold" style:color={urgentInk}>
+			{game?.gameOver ? "No moves left…" : isTime ? "Time's up…" : "Challenge over…"}
+		</p>
+	{/if}
+
 	<div class="mt-3 flex flex-wrap items-center justify-center gap-2">
 		<form method="POST" action="?/start" use:enhance={onReset}>
 			<Button
 				type="submit"
 				variant="secondary"
 				class="justify-center gap-1.5"
-				disabled={retrying || submitting || data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS}
+				disabled={retrying || submitting || !!result || data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS}
 			>
 				<RotateCcwIcon size={16} />
 				{retrying ? "Resetting…" : "Reset"}

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -17,17 +17,25 @@
 	import { Button } from "$lib/components/ui/button/index.js";
 	import GameStats from "$lib/components/GameStats.svelte";
 	import AnimatedBoard from "../../../game/components/AnimatedBoard.svelte";
+	import { RotateCcwIcon } from "@lucide/svelte";
+
+	/** Match classic game-over beat so a stuck board is readable before the fail overlay. */
+	const GAME_OVER_DELAY_MS = 600;
 
 	let { data } = $props();
 
 	/** @type {Game | null} */
 	let game = $state(null);
 	let result = $state(/** @type {'won' | 'lost' | null} */ (null));
+	/** Set when a loss is detected; overlay waits for animations + GAME_OVER_DELAY_MS. */
+	let pendingLoss = $state(false);
 	let remainingMs = $state(0);
 	/** Elapsed ms captured when the run finishes. */
 	let finishedElapsedMs = $state(/** @type {number | null} */ (null));
 	let submitting = $state(false);
 	let retrying = $state(false);
+	/** Bound from AnimatedBoard — true when move animations have settled. */
+	let animationIdle = $state(true);
 
 	/** @type {import("$lib/types").GameEvent[]} */
 	let pendingEvents = $state([]);
@@ -94,9 +102,11 @@
 		pendingEvents = [];
 		game = createChallengeGame();
 		result = null;
+		pendingLoss = false;
 		finishedElapsedMs = null;
 		submitting = false;
 		retrying = false;
+		animationIdle = true;
 
 		if (isTime && "durationSec" in challenge.params) {
 			const durationMs = challenge.params.durationSec * 1000;
@@ -119,6 +129,7 @@
 	 */
 	function finish(status) {
 		if (result || submitting || data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS) return;
+		pendingLoss = false;
 		result = status;
 		finishedElapsedMs = Math.max(0, Date.now() - data.run.startedOn);
 		submitting = true;
@@ -129,7 +140,7 @@
 	 * @param {number} [startedOn]
 	 */
 	function checkOutcome(startedOn = data.run.startedOn) {
-		if (!game || result) return;
+		if (!game || result || pendingLoss) return;
 
 		const elapsedMs = isTime ? Date.now() - startedOn : undefined;
 		const outcome = evaluateChallenge(challenge, {
@@ -140,8 +151,11 @@
 			elapsedMs,
 		});
 
-		if (outcome === "won" || outcome === "lost") {
-			finish(outcome);
+		if (outcome === "won") {
+			finish("won");
+		} else if (outcome === "lost") {
+			// Hold the fail overlay so the stuck / timed-out board can register.
+			pendingLoss = true;
 		}
 	}
 
@@ -156,7 +170,7 @@
 	 * @param {number} direction
 	 */
 	function handleMove(direction) {
-		if (!game || result) return;
+		if (!game || result || pendingLoss) return;
 		const events = game.moveTiles(direction);
 		if (events.length > 0) {
 			pendingEvents.push(...events);
@@ -236,7 +250,9 @@
 	});
 
 	/** @type {import("@sveltejs/kit").SubmitFunction} */
-	const onRetry = () => {
+	const onReset = () => {
+		// Cancel a pending fail overlay / complete submit if the player resets first.
+		pendingLoss = false;
 		retrying = true;
 		return async ({ result: actionResult }) => {
 			if (actionResult.type === "redirect") {
@@ -247,6 +263,13 @@
 			await applyAction(actionResult);
 		};
 	};
+
+	// After the last move animates, pause briefly on the stuck board, then fail.
+	$effect(() => {
+		if (!pendingLoss || !animationIdle || result) return;
+		const timeout = setTimeout(() => finish("lost"), GAME_OVER_DELAY_MS);
+		return () => clearTimeout(timeout);
+	});
 
 	/**
 	 * @param {unknown} value
@@ -377,7 +400,13 @@
 	</div>
 
 	{#if game}
-		<AnimatedBoard {game} {pendingEvents} {popEvent} showControls={false} />
+		<AnimatedBoard
+			{game}
+			{pendingEvents}
+			{popEvent}
+			showControls={false}
+			bind:animationIdle
+		/>
 	{:else}
 		<div
 			class="mb-4 flex aspect-square items-center justify-center rounded-lg"
@@ -387,12 +416,28 @@
 		</div>
 	{/if}
 
-	<p class="text-center text-sm text-muted-foreground">
-		Arrow keys or swipe to move. Challenge progress is saved when you finish.
-	</p>
+	<div class="mt-3 flex flex-wrap items-center justify-center gap-2">
+		<form method="POST" action="?/start" use:enhance={onReset}>
+			<Button
+				type="submit"
+				variant="secondary"
+				class="justify-center gap-1.5"
+				disabled={retrying || submitting || data.run.status !== CHALLENGE_RUN_STATUS.IN_PROGRESS}
+			>
+				<RotateCcwIcon size={16} />
+				{retrying ? "Resetting…" : "Reset"}
+			</Button>
+		</form>
+		<a
+			href="/challenges/{challenge.id}"
+			class="text-sm text-primary hover:underline"
+		>
+			Abandon & back
+		</a>
+	</div>
 
-	<p class="mt-3 text-center text-sm">
-		<a href="/challenges/{challenge.id}" class="text-primary hover:underline"> Abandon & back </a>
+	<p class="mt-3 text-center text-sm text-muted-foreground">
+		Arrow keys or swipe to move. Challenge progress is saved when you finish.
 	</p>
 </div>
 
@@ -411,8 +456,9 @@
 			</p>
 			<GameStats stats={resultStats} label="Challenge stats" />
 			<div class="flex flex-wrap justify-center gap-2">
-				<form method="POST" action="?/start" use:enhance={onRetry}>
-					<Button type="submit" class="justify-center" disabled={retrying || submitting}>
+				<form method="POST" action="?/start" use:enhance={onReset}>
+					<Button type="submit" class="justify-center gap-1.5" disabled={retrying || submitting}>
+						<RotateCcwIcon size={16} />
 						{retrying ? "Starting…" : "Retry"}
 					</Button>
 				</form>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- When a daily challenge is lost, the fail overlay waits **1.2s** so the stuck (or timed-out) board can register, with a brief “No moves left…” / “Time’s up…” cue under the board.
- Wins still resolve immediately.
- Adds a one-click **Reset** button under the board that abandons the current run and starts a fresh one (same server action as Retry). Reset cancels a pending fail overlay if clicked during the delay.
- Preserve `run` on the complete form action (`?run={id}&/complete`) so post-action load does not drop the active run.

## Test plan
- [x] Start a recovery challenge, play until stuck — cue appears, then ~1.2s later “Challenge Failed” (measured ~1174ms)
- [x] Confirm Reset under the board restarts with a fresh board / new run id mid-run
- [ ] Confirm Reset during the fail delay cancels the overlay and starts over
- [x] Confirm Retry on the fail dialog still works

[Reset button under challenge board](https://cursor.com/agents/bc-019ffc74-0246-70b8-bcde-125473f76042/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fchallenge-reset-button.webp)
[Challenge Failed overlay after delay](https://cursor.com/agents/bc-019ffc74-0246-70b8-bcde-125473f76042/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fchallenge-failed-overlay.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffc74-0246-70b8-bcde-125473f76042?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffc74-0246-70b8-bcde-125473f76042&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

