### PR TITLE
Fix nginx 502 from oversized Link headers on challenge play

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -6,6 +6,31 @@ import { getLogger, withRequestContext } from "$lib/server/requestContext.js";
 import { basicLogger } from "$lib/server/logger.js";
 import { env } from "$env/dynamic/private";
 
+/**
+ * Drop oversized `Link` preload headers before they hit a reverse proxy.
+ *
+ * SvelteKit SSR responses (especially `/game` and challenge play) emit a large
+ * `Link: … rel=modulepreload` list. Authenticated responses also refresh the
+ * session `Set-Cookie`. Together those headers often exceed nginx's default
+ * `proxy_buffer_size` (~4kb), which surfaces as **502 Bad Gateway**
+ * (`upstream sent too big header`) — commonly noticed after challenge complete
+ * when the play page is re-rendered. See sveltejs/kit#11084.
+ *
+ * Keep small Link headers (early hints still help); strip once they crowd the
+ * proxy buffer when combined with cookies and other response headers.
+ */
+const LINK_HEADER_MAX_LEN = 2048;
+
+/** @type {import('@sveltejs/kit').Handle} */
+const handleProxySafeHeaders = async ({ event, resolve }) => {
+	const response = await resolve(event);
+	const link = response.headers.get("link");
+	if (link && link.length > LINK_HEADER_MAX_LEN) {
+		response.headers.delete("link");
+	}
+	return response;
+};
+
 /** @type {import('@sveltejs/kit').Handle} */
 export const handleLogging = async ({ event, resolve }) => {
 	return withRequestContext(event.request, async () => {
@@ -95,4 +120,4 @@ const checkSus = async ({ event, resolve }) => {
 };
 
 /** @type {import('@sveltejs/kit').Handle} */
-export const handle = sequence(handleLogging, checkSus, handleAuth);
+export const handle = sequence(handleProxySafeHeaders, handleLogging, checkSus, handleAuth);

--- a/src/routes/challenges/[id]/play/+page.svelte
+++ b/src/routes/challenges/[id]/play/+page.svelte
@@ -285,7 +285,7 @@
 <form
 	bind:this={completeForm}
 	method="POST"
-	action="?/complete"
+	action="?run={data.run.id}&/complete"
 	class="hidden"
 	use:enhance={() => {
 		return async ({ update }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Hypothesis
Nginx returns **502 Bad Gateway** with `upstream sent too big header` when SvelteKit’s SSR `Link` preload header is too large for the default `proxy_buffer_size` (~4kb).

On this app, authenticated **challenge play** responses were the worst offenders:
- `Link` alone ≈ **3689** bytes (45 `modulepreload`s)
- plus session `Set-Cookie` refresh and other headers → **~3963** bytes total
- that sits right at nginx’s default buffer; any small growth tips into 502

That matches “every time I complete a challenge” — complete re-renders / revisits the heavy play page behind the proxy. Same class of issue as [sveltejs/kit#11084](https://github.com/sveltejs/kit/issues/11084).

## Fix
- Strip `Link` headers larger than 2kb in `hooks.server.js` (keeps small early-hint Link values; drops the oversized preload lists).
- Preserve `run` on the complete form action (`?run={id}&/complete`) so post-action `load` does not lose the active run when the query string is replaced.

## Test plan
- [x] Production build: authenticated GET `/challenges/.../play?run=…` has `Link` stripped; header estimate ≪ 4kb
- [x] `?/complete` (enhance JSON) still marks the run won/lost
- [ ] Deploy behind host nginx and confirm challenge complete no longer 502s
- [ ] Optional host-side hardening: raise `proxy_buffer_size` / `proxy_buffers` if other large-header routes appear

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffc74-0246-70b8-bcde-125473f76042?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffc74-0246-70b8-bcde-125473f76042&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

