### PR TITLE
Fix Google sign-in network error after OAuth redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,9 +55,12 @@ FROM_EMAIL=noreply@yourdomain.com
 APPLE_CLIENT_ID=com.joelyoung.4096
 # Comma-separated extra Apple client ids (optional).
 APPLE_CLIENT_IDS=
-# Comma-separated Google OAuth client ids (iOS + web) accepted as ID-token aud.
+# Google OAuth audiences for /api/v1/auth/google (ID-token `aud`).
+# Prefer GOOGLE_CLIENT_IDS; otherwise GOOGLE_IOS_CLIENT_ID and/or GOOGLE_CLIENT_ID are used.
 # Include the same value as GitHub secret GOOGLE_IOS_CLIENT_ID (and web client if used).
 GOOGLE_CLIENT_IDS=
+GOOGLE_IOS_CLIENT_ID=
+GOOGLE_CLIENT_ID=
 # StoreKit non-consumable product that unlocks Pro (under the app bundle above).
 APPLE_IAP_PRODUCT_ID=com.joelyoung.4096.pro
 APPLE_IAP_BUNDLE_ID=com.joelyoung.4096

--- a/.github/workflows/BuildApp.yml
+++ b/.github/workflows/BuildApp.yml
@@ -17,8 +17,14 @@ on:
 
     secrets:
       GOOGLE_CLIENT_ID:
-        description: "Google client ID of app"
+        description: "Google web OAuth client ID (optional; also used as an accepted ID-token audience)"
         required: true
+      GOOGLE_IOS_CLIENT_ID:
+        description: "Google iOS OAuth client ID (ID-token aud for the mobile app)"
+        required: false
+      GOOGLE_CLIENT_IDS:
+        description: "Comma-separated Google OAuth client ids (overrides iOS+web composition when set)"
+        required: false
       DATABASE_URL:
         description: "The URL of the database"
         required: true
@@ -52,8 +58,16 @@ jobs:
           BUILD_VERSION: ${{ github.sha }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
+          # Prefer explicit list; fall back to iOS + web client ids (comma-joined).
+          GOOGLE_CLIENT_IDS: ${{ secrets.GOOGLE_CLIENT_IDS }}
         run: |
           pnpm install --frozen-lockfile
+          if [ -z "$GOOGLE_CLIENT_IDS" ]; then
+            GOOGLE_CLIENT_IDS="$(printf '%s,%s' "${GOOGLE_IOS_CLIENT_ID:-}" "${GOOGLE_CLIENT_ID:-}" | sed 's/^,//;s/,$//;s/,,/,/g')"
+            export GOOGLE_CLIENT_IDS
+          fi
+          echo "Google OAuth audiences configured: $([ -n "$GOOGLE_CLIENT_IDS" ] && echo yes || echo NO)"
           pnpm run build
 
       - name: Upload Svelte build artifacts
@@ -91,10 +105,33 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Resolve Google OAuth build args
+        id: google_oauth
+        env:
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
+          GOOGLE_CLIENT_IDS: ${{ secrets.GOOGLE_CLIENT_IDS }}
+        run: |
+          if [ -z "$GOOGLE_CLIENT_IDS" ]; then
+            GOOGLE_CLIENT_IDS="$(printf '%s,%s' "${GOOGLE_IOS_CLIENT_ID:-}" "${GOOGLE_CLIENT_ID:-}" | sed 's/^,//;s/,$//;s/,,/,/g')"
+          fi
+          {
+            echo "client_id=$GOOGLE_CLIENT_ID"
+            echo "ios_client_id=$GOOGLE_IOS_CLIENT_ID"
+            echo "client_ids=$GOOGLE_CLIENT_IDS"
+          } >> "$GITHUB_OUTPUT"
+          if [ -z "$GOOGLE_CLIENT_IDS" ]; then
+            echo "::warning::No Google OAuth client ids available at image build — /api/v1/auth/google will fail until GOOGLE_CLIENT_IDS (or GOOGLE_IOS_CLIENT_ID) is set on the host."
+          fi
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          build-args: |
+            GOOGLE_CLIENT_ID=${{ steps.google_oauth.outputs.client_id }}
+            GOOGLE_IOS_CLIENT_ID=${{ steps.google_oauth.outputs.ios_client_id }}
+            GOOGLE_CLIENT_IDS=${{ steps.google_oauth.outputs.client_ids }}
           tags: |
             ghcr.io/${{ inputs.ghcr_namespace }}/${{ inputs.image_name }}:latest

--- a/.github/workflows/CI_CD.yaml
+++ b/.github/workflows/CI_CD.yaml
@@ -12,6 +12,8 @@ jobs:
       image_name: ${{ vars.IMAGE_NAME }}
     secrets:
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
+      GOOGLE_CLIENT_IDS: ${{ secrets.GOOGLE_CLIENT_IDS }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
   DeployApp:

--- a/.github/workflows/Manual_Deploy.yaml
+++ b/.github/workflows/Manual_Deploy.yaml
@@ -16,6 +16,8 @@ jobs:
       image_name: ${{ inputs.image_name }}
     secrets:
       GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+      GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
+      GOOGLE_CLIENT_IDS: ${{ secrets.GOOGLE_CLIENT_IDS }}
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
   DeployApp:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,15 @@ WORKDIR /app
 ENV CI=true
 ENV NODE_ENV=production
 
+# Google OAuth client ids are public (also embedded in the iOS app). Bake them into
+# the image so /api/v1/auth/google works even when the host .env omits GOOGLE_CLIENT_IDS.
+ARG GOOGLE_CLIENT_IDS=
+ARG GOOGLE_CLIENT_ID=
+ARG GOOGLE_IOS_CLIENT_ID=
+ENV GOOGLE_CLIENT_IDS=$GOOGLE_CLIENT_IDS \
+    GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID \
+    GOOGLE_IOS_CLIENT_ID=$GOOGLE_IOS_CLIENT_ID
+
 RUN corepack enable
 
 COPY package.json .npmrc ./

--- a/docs/ASC_Setup.md
+++ b/docs/ASC_Setup.md
@@ -29,6 +29,7 @@ Older ids (`com.joelyoung.play4096*`) are retired; leave any leftover Dev Portal
 2. Store the client id as GitHub secret `GOOGLE_IOS_CLIENT_ID` (already wired into Mobile Release as `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID` at prebuild **and** archive).
 3. Optional web client → secret `GOOGLE_CLIENT_ID`.
 4. On the **backend**, set `GOOGLE_CLIENT_IDS` to the same iOS (and web) client id(s), comma-separated — the API verifies the ID token `aud` against that list.
+   - CI also bakes `GOOGLE_IOS_CLIENT_ID` / `GOOGLE_CLIENT_ID` into the Docker image, and the API accepts those env names individually if `GOOGLE_CLIENT_IDS` is unset.
 
 ## 3. GitHub secrets & variables
 
@@ -53,7 +54,7 @@ Older ids (`com.joelyoung.play4096*`) are retired; leave any leftover Dev Portal
 | Env | Purpose |
 |---|---|
 | `APPLE_CLIENT_ID` | `com.joelyoung.4096` |
-| `GOOGLE_CLIENT_IDS` | Same as `GOOGLE_IOS_CLIENT_ID` (+ web if used) |
+| `GOOGLE_CLIENT_IDS` | Same as `GOOGLE_IOS_CLIENT_ID` (+ web if used). Optional if `GOOGLE_IOS_CLIENT_ID` / `GOOGLE_CLIENT_ID` are set (CI bakes these into the image). |
 | `APPLE_IAP_PRODUCT_ID` | `com.joelyoung.4096.pro` |
 | `APPLE_IAP_BUNDLE_ID` | `com.joelyoung.4096` |
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -38,7 +38,7 @@ pnpm ios
 
 Runtime JS config:
 
-- `EXPO_PUBLIC_API_URL` - backend origin, defaults to `http://localhost:5173`.
+- `EXPO_PUBLIC_API_URL` - backend origin, defaults to `https://play-4096.com` (set `http://localhost:5173` for local backend).
 - `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID` - Google OAuth iOS client id (bundle must be `com.joelyoung.4096`).
 - `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID` - Google OAuth web client id for development/web.
 

--- a/mobile/src/__tests__/auth-errors.test.ts
+++ b/mobile/src/__tests__/auth-errors.test.ts
@@ -15,6 +15,12 @@ describe("friendlyAuthNetworkError", () => {
   it("leaves unrelated auth errors intact", () => {
     expect(friendlyAuthNetworkError("access_denied")).toBe("access_denied");
   });
+
+  it("preserves host-aware Could not reach messages", () => {
+    expect(friendlyAuthNetworkError("Could not reach play-4096.com. Check your connection and try again.")).toBe(
+      "Could not reach play-4096.com. Check your connection and try again."
+    );
+  });
 });
 
 describe("alertOnce", () => {
@@ -50,16 +56,16 @@ describe("oauth login network failures", () => {
     global.fetch = originalFetch;
   });
 
-  it("maps Google fetch failures to a stable AuthApiError message", async () => {
+  it("maps Google fetch failures to a host-aware AuthApiError message", async () => {
     global.fetch = jest.fn().mockRejectedValue(new TypeError("Network request failed")) as typeof fetch;
     await expect(loginWithGoogle({ credential: "token" })).rejects.toMatchObject({
       name: "AuthApiError",
       status: 503,
-      userMessage: "Network error. Check your connection and try again."
+      userMessage: expect.stringMatching(/^Could not reach .+\. Check your connection and try again\.$/)
     });
   });
 
-  it("maps Apple fetch failures to a stable AuthApiError message", async () => {
+  it("maps Apple fetch failures to a host-aware AuthApiError message", async () => {
     global.fetch = jest.fn().mockRejectedValue(
       new TypeError(
         "fetch failed: UnexpectedException: Could not connect to the server. (at ExpoModulesCore/Promise.swift:56)"
@@ -68,7 +74,7 @@ describe("oauth login network failures", () => {
     await expect(loginWithApple({ identity_token: "token" })).rejects.toMatchObject({
       name: "AuthApiError",
       status: 503,
-      userMessage: "Network error. Check your connection and try again."
+      userMessage: expect.stringMatching(/^Could not reach .+\. Check your connection and try again\.$/)
     });
   });
 });

--- a/mobile/src/api/auth.ts
+++ b/mobile/src/api/auth.ts
@@ -3,7 +3,14 @@ import type { TokenPayload } from "@/types";
 import { get, post } from "./client";
 import { parseApiErrorBody } from "./errors";
 
-const NETWORK_MESSAGE = "Network error. Check your connection and try again.";
+function networkErrorMessage(): string {
+  try {
+    const host = new URL(API_BASE_URL).host;
+    return `Could not reach ${host}. Check your connection and try again.`;
+  } catch {
+    return "Network error. Check your connection and try again.";
+  }
+}
 
 export class AuthApiError extends Error {
   status: number;
@@ -27,7 +34,7 @@ async function authPost<T>(path: string, body: object): Promise<T> {
       body: JSON.stringify(body)
     });
   } catch (err) {
-    throw new AuthApiError(NETWORK_MESSAGE, 503, err);
+    throw new AuthApiError(networkErrorMessage(), 503, err);
   }
   const text = await response.text();
   let data: unknown = null;

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -3,7 +3,14 @@ import { queryClient } from "@/lib/query-client";
 import { useSessionStore } from "@/stores/session";
 import { parseApiErrorBody } from "./errors";
 
-const NETWORK_MESSAGE = "Network error. Check your connection and try again.";
+function networkErrorMessage(): string {
+  try {
+    const host = new URL(API_BASE_URL).host;
+    return `Could not reach ${host}. Check your connection and try again.`;
+  } catch {
+    return "Network error. Check your connection and try again.";
+  }
+}
 
 export class ApiError extends Error {
   status: number;
@@ -52,7 +59,7 @@ export async function doFetch<T>(url: string, options?: RequestInit): Promise<T>
   try {
     response = await fetch(resolveUrl(url), { ...options, headers });
   } catch {
-    throw new ApiError(NETWORK_MESSAGE, 503, { userMessage: NETWORK_MESSAGE });
+    throw new ApiError(networkErrorMessage(), 503, { userMessage: networkErrorMessage() });
   }
 
   if (!response.ok) {

--- a/mobile/src/config.ts
+++ b/mobile/src/config.ts
@@ -1,5 +1,6 @@
 export const APP_NAME = "Play4096";
-export const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:5173";
+/** Production origin; local/dev should set EXPO_PUBLIC_API_URL explicitly (see mobile/README.md). */
+export const API_URL = process.env.EXPO_PUBLIC_API_URL || "https://play-4096.com";
 export const API_BASE_URL = `${API_URL.replace(/\/$/, "")}/api/v1`;
 export const GOOGLE_IOS_CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID || "";
 export const GOOGLE_WEB_CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID || "";

--- a/mobile/src/lib/auth-errors.ts
+++ b/mobile/src/lib/auth-errors.ts
@@ -1,6 +1,10 @@
 /** Rewrite Expo/RN connection failures into a clear, actionable message. */
 export function friendlyAuthNetworkError(message: string): string {
-  if (/could not connect|network request failed|fetch failed|timed?\s*out/i.test(message)) {
+  // Already rewritten by AuthApiError / prior pass — keep host-specific wording.
+  if (/^Could not reach /i.test(message)) {
+    return message;
+  }
+  if (/could not connect|network request failed|fetch failed|timed?\s*out|network error/i.test(message)) {
     return "Could not reach the server. Check your connection and API URL, then try again.";
   }
   return message;

--- a/scripts/test-google-audiences.js
+++ b/scripts/test-google-audiences.js
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { resolveGoogleAudiences } from "../src/lib/server/mobile/googleAudiences.js";
+
+assert.deepEqual(resolveGoogleAudiences({}), []);
+
+assert.deepEqual(resolveGoogleAudiences({ GOOGLE_CLIENT_IDS: "ios.apps.googleusercontent.com, web.apps.googleusercontent.com" }), [
+	"ios.apps.googleusercontent.com",
+	"web.apps.googleusercontent.com"
+]);
+
+assert.deepEqual(
+	resolveGoogleAudiences({
+		GOOGLE_IOS_CLIENT_ID: "ios.apps.googleusercontent.com",
+		GOOGLE_CLIENT_ID: "web.apps.googleusercontent.com"
+	}),
+	["ios.apps.googleusercontent.com", "web.apps.googleusercontent.com"]
+);
+
+assert.deepEqual(
+	resolveGoogleAudiences({
+		GOOGLE_CLIENT_IDS: "ios.apps.googleusercontent.com",
+		GOOGLE_IOS_CLIENT_ID: "ios.apps.googleusercontent.com",
+		GOOGLE_CLIENT_ID: "web.apps.googleusercontent.com"
+	}),
+	["ios.apps.googleusercontent.com", "web.apps.googleusercontent.com"]
+);
+
+assert.deepEqual(resolveGoogleAudiences({ GOOGLE_CLIENT_IDS: " , , " }), []);
+
+console.log("resolveGoogleAudiences: ok");

--- a/src/lib/server/mobile/googleAudiences.js
+++ b/src/lib/server/mobile/googleAudiences.js
@@ -1,0 +1,22 @@
+/**
+ * Resolve accepted Google ID-token audiences from env.
+ *
+ * Accepts any of:
+ * - GOOGLE_CLIENT_IDS — comma-separated list (preferred)
+ * - GOOGLE_IOS_CLIENT_ID — iOS OAuth client (mobile ID-token `aud`)
+ * - GOOGLE_CLIENT_ID — web OAuth client (optional)
+ *
+ * @param {Record<string, string | undefined> | object} envMap
+ * @returns {string[]}
+ */
+export function resolveGoogleAudiences(envMap) {
+	const record = /** @type {Record<string, string | undefined>} */ (envMap);
+	const ids = [
+		...(record.GOOGLE_CLIENT_IDS || "").split(","),
+		record.GOOGLE_IOS_CLIENT_ID,
+		record.GOOGLE_CLIENT_ID
+	]
+		.map((s) => (typeof s === "string" ? s.trim() : ""))
+		.filter(Boolean);
+	return [...new Set(ids)];
+}

--- a/src/lib/server/mobile/oauth.js
+++ b/src/lib/server/mobile/oauth.js
@@ -7,6 +7,7 @@ import { db } from "$lib/server/db";
 import * as table from "$lib/server/db/schema";
 import { generateUserId } from "$lib/server/auth/utils";
 import { USER_STATUS } from "$lib/constants";
+import { resolveGoogleAudiences } from "$lib/server/mobile/googleAudiences";
 
 const appleJwks = createRemoteJWKSet(new URL("https://appleid.apple.com/auth/keys"));
 const googleJwks = createRemoteJWKSet(new URL("https://www.googleapis.com/oauth2/v3/certs"));
@@ -27,10 +28,7 @@ function appleAudiences() {
  * @returns {string[]}
  */
 function googleAudiences() {
-	return (env.GOOGLE_CLIENT_IDS || "")
-		.split(",")
-		.map((s) => s.trim())
-		.filter(Boolean);
+	return resolveGoogleAudiences(env);
 }
 
 /**
@@ -64,7 +62,9 @@ export async function verifyAppleIdentityToken(identityToken) {
 export async function verifyGoogleIdToken(idToken) {
 	const audiences = googleAudiences();
 	if (audiences.length === 0) {
-		throw new Error("GOOGLE_CLIENT_IDS is not configured");
+		throw new Error(
+			"Google sign-in is not configured on the server (set GOOGLE_CLIENT_IDS or GOOGLE_IOS_CLIENT_ID)"
+		);
 	}
 	const { payload } = await jwtVerify(idToken, googleJwks, {
 		issuer: ["https://accounts.google.com", "accounts.google.com"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Google sign-in on iOS completed Google’s flow, then failed when the app posted the ID token to `/api/v1/auth/google`.

**Root causes**
1. Production returned `GOOGLE_CLIENT_IDS is not configured` — the API only read `GOOGLE_CLIENT_IDS`, which was unset on the host, while CI already had `GOOGLE_IOS_CLIENT_ID` / `GOOGLE_CLIENT_ID`.
2. Misconfigured mobile builds could still fall back to `localhost`, which surfaces as a generic “Network error” after redirect (even with working device internet).

## Changes
- Resolve Google ID-token audiences from `GOOGLE_CLIENT_IDS`, `GOOGLE_IOS_CLIENT_ID`, and `GOOGLE_CLIENT_ID`.
- Bake those public client IDs into the Docker image from CI secrets so deploy works without a host `.env` update.
- Default mobile `EXPO_PUBLIC_API_URL` fallback to `https://play-4096.com`.
- Include the API host in auth/network error messages for easier diagnosis.

## Verification
- `node scripts/test-google-audiences.js`
- `pnpm exec jest --testPathPattern=auth-errors` (mobile)
- Local API: empty Google env → clear config error; with `GOOGLE_IOS_CLIENT_ID` → past config check into JWT verify
- Production probe (pre-deploy): still returns `GOOGLE_CLIENT_IDS is not configured` until this lands

After merge, wait for CI/CD deploy + a Mobile Release TestFlight build, then retry Google sign-in on device.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffeb1-6a9a-7573-95a8-2c86817b8bf1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffeb1-6a9a-7573-95a8-2c86817b8bf1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

