### PR TITLE
Fix silent Google sign-in on iOS after OAuth succeeds

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -63,6 +63,10 @@ Optional GitHub variables: `PLAY4096_IOS_BUNDLE_ID`, `MOBILE_API_URL`.
 Mobile Release defaults it to `https://play-4096.com` (same host as the web deploy
 health check). Leaving it blank used to ship `localhost`, which cannot work on device.
 
+Google sign-in on iOS uses the reversed iOS client-id URL scheme
+(`com.googleusercontent.apps.<id>:/oauthredirect`). That scheme is registered in
+`app.config.ts` and must match the redirect URI passed to `expo-auth-session`.
+
 Full ASC + IAP setup: see [`docs/ASC_Setup.md`](../docs/ASC_Setup.md).
 
 Pro purchases post the StoreKit signed transaction to `/api/v1/iap/apple/verify`.

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -37,17 +37,13 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       config: {
         usesNonExemptEncryption: false
       },
-      ...(googleScheme
-        ? {
-            infoPlist: {
-              CFBundleURLTypes: [
-                {
-                  CFBundleURLSchemes: [googleScheme]
-                }
-              ]
-            }
-          }
-        : {})
+      infoPlist: {
+        CFBundleURLTypes: [
+          { CFBundleURLSchemes: ["play4096"] },
+          { CFBundleURLSchemes: [bundleIdentifier] },
+          ...(googleScheme ? [{ CFBundleURLSchemes: [googleScheme] }] : [])
+        ]
+      }
     },
     web: {
       output: "static",

--- a/mobile/src/__tests__/auth-errors.test.ts
+++ b/mobile/src/__tests__/auth-errors.test.ts
@@ -1,5 +1,5 @@
 import { loginWithApple, loginWithGoogle } from "@/api/auth";
-import { alertOnce, resetAlertOnceForTests } from "@/lib/alert";
+import { ALERT_DELAY_MS, alertOnce, resetAlertOnceForTests } from "@/lib/alert";
 import { friendlyAuthNetworkError } from "@/lib/auth-errors";
 import { Alert } from "react-native";
 
@@ -27,8 +27,13 @@ describe("alertOnce", () => {
   const alertSpy = jest.spyOn(Alert, "alert");
 
   beforeEach(() => {
+    jest.useFakeTimers();
     resetAlertOnceForTests();
     alertSpy.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   afterAll(() => {
@@ -39,13 +44,24 @@ describe("alertOnce", () => {
     alertOnce("Apple sign-in", "Network error");
     alertOnce("Apple sign-in", "Network error");
     alertOnce("Apple sign-in", "Network error");
+    jest.advanceTimersByTime(ALERT_DELAY_MS);
     expect(alertSpy).toHaveBeenCalledTimes(1);
   });
 
   it("allows a different message through", () => {
     alertOnce("Apple sign-in", "Network error");
     alertOnce("Apple sign-in", "Something else");
+    jest.advanceTimersByTime(ALERT_DELAY_MS);
     expect(alertSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("delays presentation so iOS can finish dismissing the auth session", () => {
+    alertOnce("Google sign-in", "Could not reach play-4096.com. Check your connection and try again.");
+    expect(alertSpy).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(ALERT_DELAY_MS - 1);
+    expect(alertSpy).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(alertSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/mobile/src/__tests__/google-auth.test.ts
+++ b/mobile/src/__tests__/google-auth.test.ts
@@ -1,0 +1,110 @@
+import * as AuthSession from "expo-auth-session";
+import { Platform } from "react-native";
+import { authedHomeHref, AUTHED_HOME_HREF } from "@/lib/auth-navigation";
+import {
+  exchangeGoogleCodeForIdToken,
+  getGoogleAuthCode,
+  getGoogleIdToken,
+  googleAuthRequestConfig,
+  googleIosRedirectUri
+} from "@/lib/google-auth";
+
+describe("googleIosRedirectUri", () => {
+  it("builds Google's installed-app redirect from an iOS client id", () => {
+    expect(googleIosRedirectUri("123-abc.apps.googleusercontent.com")).toBe(
+      "com.googleusercontent.apps.123-abc:/oauthredirect"
+    );
+  });
+
+  it("returns null for missing or malformed ids", () => {
+    expect(googleIosRedirectUri("")).toBeNull();
+    expect(googleIosRedirectUri(undefined)).toBeNull();
+    expect(googleIosRedirectUri("not-a-google-client")).toBeNull();
+  });
+});
+
+describe("getGoogleIdToken", () => {
+  it("reads id_token from params", () => {
+    expect(getGoogleIdToken({ type: "success", params: { id_token: "jwt" } })).toBe("jwt");
+  });
+
+  it("falls back to authentication.idToken", () => {
+    expect(
+      getGoogleIdToken({ type: "success", params: {}, authentication: { idToken: "from-auth" } })
+    ).toBe("from-auth");
+  });
+
+  it("returns null when the credential is missing", () => {
+    expect(getGoogleIdToken({ type: "success", params: { code: "abc" } })).toBeNull();
+    expect(getGoogleIdToken({ type: "cancel" })).toBeNull();
+    expect(getGoogleIdToken(null)).toBeNull();
+  });
+});
+
+describe("getGoogleAuthCode", () => {
+  it("reads the authorization code from a success response", () => {
+    expect(getGoogleAuthCode({ type: "success", params: { code: "auth-code" } })).toBe("auth-code");
+  });
+});
+
+describe("authedHomeHref", () => {
+  it("sends authed users into the app so OAuth is not stuck on login", () => {
+    expect(authedHomeHref("authed")).toBe(AUTHED_HOME_HREF);
+    expect(authedHomeHref("guest")).toBeNull();
+    expect(authedHomeHref("loading")).toBeNull();
+  });
+});
+
+describe("googleAuthRequestConfig", () => {
+  it("uses the reversed-client-id redirect and disables silent code exchange on iOS", () => {
+    const iosClientId = "123-abc.apps.googleusercontent.com";
+    const config = googleAuthRequestConfig({ iosClientId, webClientId: "" });
+    expect(config.shouldAutoExchangeCode).toBe(false);
+    if (Platform.OS === "ios") {
+      expect(config.redirectUri).toBe("com.googleusercontent.apps.123-abc:/oauthredirect");
+      expect(config.responseType).toBe(AuthSession.ResponseType.Code);
+    }
+  });
+});
+
+describe("exchangeGoogleCodeForIdToken", () => {
+  it("returns the id token from Google's token endpoint", async () => {
+    const spy = jest.spyOn(AuthSession, "exchangeCodeAsync").mockResolvedValue({
+      idToken: "jwt",
+      accessToken: "access",
+      tokenType: "bearer"
+    } as AuthSession.TokenResponse);
+    await expect(
+      exchangeGoogleCodeForIdToken({
+        clientId: "123-abc.apps.googleusercontent.com",
+        code: "auth-code",
+        redirectUri: "com.googleusercontent.apps.123-abc:/oauthredirect",
+        codeVerifier: "verifier"
+      })
+    ).resolves.toBe("jwt");
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "123-abc.apps.googleusercontent.com",
+        code: "auth-code",
+        extraParams: { code_verifier: "verifier" }
+      }),
+      expect.objectContaining({ tokenEndpoint: "https://oauth2.googleapis.com/token" })
+    );
+    spy.mockRestore();
+  });
+
+  it("throws when Google omits the id token", async () => {
+    const spy = jest.spyOn(AuthSession, "exchangeCodeAsync").mockResolvedValue({
+      accessToken: "access",
+      tokenType: "bearer"
+    } as AuthSession.TokenResponse);
+    await expect(
+      exchangeGoogleCodeForIdToken({
+        clientId: "123-abc.apps.googleusercontent.com",
+        code: "auth-code",
+        redirectUri: "com.googleusercontent.apps.123-abc:/oauthredirect"
+      })
+    ).rejects.toThrow("Google sign-in did not return a credential.");
+    spy.mockRestore();
+  });
+});

--- a/mobile/src/__tests__/google-auth.test.ts
+++ b/mobile/src/__tests__/google-auth.test.ts
@@ -1,3 +1,15 @@
+const mockExchangeCodeAsync = jest.fn();
+
+jest.mock("expo-auth-session", () => {
+  const actual = jest.requireActual("expo-auth-session") as typeof import("expo-auth-session");
+  return {
+    ...actual,
+    exchangeCodeAsync: (...args: unknown[]) => mockExchangeCodeAsync(...args)
+  };
+});
+
+/* eslint-disable import/first -- jest.mock must be registered before importing the module under test */
+
 import * as AuthSession from "expo-auth-session";
 import { Platform } from "react-native";
 import { authedHomeHref, AUTHED_HOME_HREF } from "@/lib/auth-navigation";
@@ -68,12 +80,16 @@ describe("googleAuthRequestConfig", () => {
 });
 
 describe("exchangeGoogleCodeForIdToken", () => {
+  beforeEach(() => {
+    mockExchangeCodeAsync.mockReset();
+  });
+
   it("returns the id token from Google's token endpoint", async () => {
-    const spy = jest.spyOn(AuthSession, "exchangeCodeAsync").mockResolvedValue({
+    mockExchangeCodeAsync.mockResolvedValue({
       idToken: "jwt",
       accessToken: "access",
       tokenType: "bearer"
-    } as AuthSession.TokenResponse);
+    });
     await expect(
       exchangeGoogleCodeForIdToken({
         clientId: "123-abc.apps.googleusercontent.com",
@@ -82,7 +98,7 @@ describe("exchangeGoogleCodeForIdToken", () => {
         codeVerifier: "verifier"
       })
     ).resolves.toBe("jwt");
-    expect(spy).toHaveBeenCalledWith(
+    expect(mockExchangeCodeAsync).toHaveBeenCalledWith(
       expect.objectContaining({
         clientId: "123-abc.apps.googleusercontent.com",
         code: "auth-code",
@@ -90,14 +106,13 @@ describe("exchangeGoogleCodeForIdToken", () => {
       }),
       expect.objectContaining({ tokenEndpoint: "https://oauth2.googleapis.com/token" })
     );
-    spy.mockRestore();
   });
 
   it("throws when Google omits the id token", async () => {
-    const spy = jest.spyOn(AuthSession, "exchangeCodeAsync").mockResolvedValue({
+    mockExchangeCodeAsync.mockResolvedValue({
       accessToken: "access",
       tokenType: "bearer"
-    } as AuthSession.TokenResponse);
+    });
     await expect(
       exchangeGoogleCodeForIdToken({
         clientId: "123-abc.apps.googleusercontent.com",
@@ -105,6 +120,5 @@ describe("exchangeGoogleCodeForIdToken", () => {
         redirectUri: "com.googleusercontent.apps.123-abc:/oauthredirect"
       })
     ).rejects.toThrow("Google sign-in did not return a credential.");
-    spy.mockRestore();
   });
 });

--- a/mobile/src/app/(auth)/_layout.tsx
+++ b/mobile/src/app/(auth)/_layout.tsx
@@ -1,2 +1,10 @@
-import { Stack } from "expo-router";
-export default function AuthLayout() { return <Stack screenOptions={{ headerShown: false }} />; }
+import { authedHomeHref } from "@/lib/auth-navigation";
+import { useSessionStore } from "@/stores/session";
+import { Redirect, Stack } from "expo-router";
+
+export default function AuthLayout() {
+  const status = useSessionStore((s) => s.status);
+  const href = authedHomeHref(status);
+  if (href) return <Redirect href={href} />;
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/mobile/src/components/GoogleLoginButton.tsx
+++ b/mobile/src/components/GoogleLoginButton.tsx
@@ -51,9 +51,11 @@ function ConfiguredGoogleLoginButton({ onPendingChange, onError }: Props) {
     onErrorRef.current = onError;
   }, [onPendingChange, onError]);
 
+  // completeGoogleResponse is recreated each render; handledKey prevents duplicates.
   useEffect(() => {
     if (!response) return;
     void completeGoogleResponse(response);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [response]);
 
   async function completeGoogleResponse(authResponse: NonNullable<typeof response>) {
@@ -133,5 +135,5 @@ function ConfiguredGoogleLoginButton({ onPendingChange, onError }: Props) {
     >
       Continue with Google
     </Button>
-  >
+  );
 }

--- a/mobile/src/components/GoogleLoginButton.tsx
+++ b/mobile/src/components/GoogleLoginButton.tsx
@@ -1,6 +1,13 @@
 import { loginWithGoogle } from "@/api/auth";
 import { getErrorMessage } from "@/api/errors";
 import { friendlyAuthNetworkError } from "@/lib/auth-errors";
+import {
+  exchangeGoogleCodeForIdToken,
+  getGoogleAuthCode,
+  getGoogleIdToken,
+  googleAuthRequestConfig,
+  googleIosRedirectUri
+} from "@/lib/google-auth";
 import { GOOGLE_IOS_CLIENT_ID, GOOGLE_WEB_CLIENT_ID } from "@/config";
 import { useSessionStore } from "@/stores/session";
 import * as Google from "expo-auth-session/providers/google";
@@ -23,60 +30,108 @@ export function GoogleLoginButton(props: Props) {
 }
 
 function ConfiguredGoogleLoginButton({ onPendingChange, onError }: Props) {
-  const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
-    iosClientId: GOOGLE_IOS_CLIENT_ID || undefined,
-    webClientId: GOOGLE_WEB_CLIENT_ID || undefined,
-    clientId: GOOGLE_WEB_CLIENT_ID || undefined
-  });
+  const [request, response, promptAsync] = Google.useAuthRequest(
+    googleAuthRequestConfig({
+      iosClientId: GOOGLE_IOS_CLIENT_ID,
+      webClientId: GOOGLE_WEB_CLIENT_ID
+    })
+  );
   const exchanging = useRef(false);
-  const handledResponse = useRef<typeof response>(undefined);
+  const handledKey = useRef<string | null>(null);
+  const requestRef = useRef(request);
+  const onPendingChangeRef = useRef(onPendingChange);
+  const onErrorRef = useRef(onError);
+
+  useEffect(() => {
+    requestRef.current = request;
+  }, [request]);
+
+  useEffect(() => {
+    onPendingChangeRef.current = onPendingChange;
+    onErrorRef.current = onError;
+  }, [onPendingChange, onError]);
 
   useEffect(() => {
     if (!response) return;
-    // Same auth response object must only be handled once. Parent re-renders (from
-    // onPendingChange / Alert) used to re-fire this effect and stack dialogs.
-    if (handledResponse.current === response) return;
+    void completeGoogleResponse(response);
+  }, [response]);
 
-    if (response.type === "success") {
-      const idToken = response.params.id_token;
-      if (!idToken) {
-        handledResponse.current = response;
-        onPendingChange(false);
-        onError("Google sign-in did not return a credential.");
-        return;
-      }
-      if (exchanging.current) return;
-      exchanging.current = true;
-      handledResponse.current = response;
-      loginWithGoogle({ credential: idToken })
-        .then((payload) => useSessionStore.getState().setSession(payload.access_token, payload.user))
-        .catch((err) =>
-          onError(friendlyAuthNetworkError(getErrorMessage(err, "Google sign-in failed")))
-        )
-        .finally(() => {
-          exchanging.current = false;
-          onPendingChange(false);
-        });
-    } else if (response.type === "error") {
-      handledResponse.current = response;
-      onPendingChange(false);
-      onError(friendlyAuthNetworkError(response.error?.message ?? "Google sign-in failed"));
-    } else if (response.type === "cancel" || response.type === "dismiss") {
-      handledResponse.current = response;
-      onPendingChange(false);
+  async function completeGoogleResponse(authResponse: NonNullable<typeof response>) {
+    if (authResponse.type === "opened") return;
+    const errorMessage =
+      authResponse.type === "error" ? (authResponse.error?.message ?? "Google sign-in failed") : "";
+    const key =
+      authResponse.type === "success"
+        ? getGoogleIdToken(authResponse) || getGoogleAuthCode(authResponse) || authResponse.type
+        : `${authResponse.type}:${errorMessage}`;
+    if (handledKey.current === key) return;
+    handledKey.current = key;
+
+    if (authResponse.type === "cancel" || authResponse.type === "dismiss") {
+      onPendingChangeRef.current(false);
+      return;
     }
-  }, [response, onPendingChange, onError]);
+    if (authResponse.type === "error" || authResponse.type === "locked") {
+      onPendingChangeRef.current(false);
+      onErrorRef.current(friendlyAuthNetworkError(errorMessage || "Google sign-in failed"));
+      return;
+    }
+    if (authResponse.type !== "success") {
+      return;
+    }
+
+    if (exchanging.current) return;
+    exchanging.current = true;
+    onPendingChangeRef.current(true);
+    try {
+      let idToken = getGoogleIdToken(authResponse);
+      const code = getGoogleAuthCode(authResponse);
+      if (!idToken && code) {
+        const currentRequest = requestRef.current;
+        const redirectUri =
+          currentRequest?.redirectUri || googleIosRedirectUri(GOOGLE_IOS_CLIENT_ID) || "";
+        idToken = await exchangeGoogleCodeForIdToken({
+          clientId: GOOGLE_IOS_CLIENT_ID || GOOGLE_WEB_CLIENT_ID,
+          code,
+          redirectUri,
+          codeVerifier: currentRequest?.codeVerifier
+        });
+      }
+      if (!idToken) {
+        throw new Error("Google sign-in did not return a credential.");
+      }
+      const payload = await loginWithGoogle({ credential: idToken });
+      if (!payload?.access_token || !payload?.user) {
+        throw new Error("Google sign-in did not return a session.");
+      }
+      await useSessionStore.getState().setSession(payload.access_token, payload.user);
+    } catch (err) {
+      onErrorRef.current(friendlyAuthNetworkError(getErrorMessage(err, "Google sign-in failed")));
+    } finally {
+      exchanging.current = false;
+      onPendingChangeRef.current(false);
+    }
+  }
 
   return (
     <Button
       variant="outline"
       disabled={!request}
       onPress={() => {
-        onPendingChange(true);
-        void promptAsync();
+        // Do not set pending before the auth session — a parent re-render can
+        // prevent ASWebAuthenticationSession from presenting on iOS.
+        void (async () => {
+          try {
+            const result = await promptAsync();
+            if (result) await completeGoogleResponse(result);
+          } catch (err) {
+            onPendingChangeRef.current(false);
+            onErrorRef.current(friendlyAuthNetworkError(getErrorMessage(err, "Google sign-in failed")));
+          }
+        })();
       }}
     >
       Continue with Google
     </Button>
-  );
+  >
 }

--- a/mobile/src/lib/alert.ts
+++ b/mobile/src/lib/alert.ts
@@ -3,8 +3,11 @@ import { Alert } from "react-native";
 type RecentAlert = { title: string; message: string; at: number };
 
 let recent: RecentAlert | null = null;
+const alertTimers: ReturnType<typeof setTimeout>[] = [];
 
 const DEDUPE_MS = 1500;
+/** iOS drops Alert.alert while ASWebAuthenticationSession is still dismissing. */
+export const ALERT_DELAY_MS = 400;
 
 /**
  * Show an Alert, ignoring duplicate title+message calls within a short window.
@@ -21,10 +24,16 @@ export function alertOnce(title: string, message: string): void {
     return;
   }
   recent = { title, message, at: now };
-  Alert.alert(title, message);
+  alertTimers.push(
+    setTimeout(() => {
+      Alert.alert(title, message);
+    }, ALERT_DELAY_MS)
+  );
 }
 
 /** Test helper. */
 export function resetAlertOnceForTests(): void {
   recent = null;
+  for (const timer of alertTimers) clearTimeout(timer);
+  alertTimers.length = 0;
 }

--- a/mobile/src/lib/auth-navigation.ts
+++ b/mobile/src/lib/auth-navigation.ts
@@ -1,0 +1,11 @@
+/** Home route used after a session becomes authenticated. */
+export const AUTHED_HOME_HREF = "/(app)/(tabs)/home" as const;
+
+/**
+ * The login/register stack is already mounted after index.tsx redirects guests
+ * here, so a later OAuth `setSession` would otherwise leave the user on login
+ * with no error and no navigation.
+ */
+export function authedHomeHref(status: string): typeof AUTHED_HOME_HREF | null {
+  return status === "authed" ? AUTHED_HOME_HREF : null;
+}

--- a/mobile/src/lib/google-auth.ts
+++ b/mobile/src/lib/google-auth.ts
@@ -1,0 +1,78 @@
+import * as AuthSession from "expo-auth-session";
+import { Platform } from "react-native";
+
+/** Google's installed-app redirect for an iOS OAuth client id. */
+export function googleIosRedirectUri(clientId: string | undefined): string | null {
+  if (!clientId) return null;
+  const match = /^([\w-]+)\.apps\.googleusercontent\.com$/i.exec(clientId.trim());
+  return match ? `com.googleusercontent.apps.${match[1]}:/oauthredirect` : null;
+}
+
+type GoogleAuthResponse = {
+  type: string;
+  params?: Record<string, unknown>;
+  authentication?: { idToken?: string | null } | null;
+};
+
+function firstString(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (Array.isArray(value) && typeof value[0] === "string" && value[0].length > 0) return value[0];
+  return null;
+}
+
+/** ID token from an implicit response or a completed code exchange. */
+export function getGoogleIdToken(response: GoogleAuthResponse | null | undefined): string | null {
+  if (!response || response.type !== "success") return null;
+  return firstString(response.params?.id_token) ?? response.authentication?.idToken ?? null;
+}
+
+export function getGoogleAuthCode(response: GoogleAuthResponse | null | undefined): string | null {
+  if (!response || response.type !== "success") return null;
+  return firstString(response.params?.code);
+}
+
+const googleDiscovery: AuthSession.DiscoveryDocument = {
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  revocationEndpoint: "https://oauth2.googleapis.com/revoke",
+  userInfoEndpoint: "https://openidconnect.googleapis.com/v1/userinfo"
+};
+
+/**
+ * Exchange an auth code for an ID token. Expo's Google hook does this internally
+ * and swallows failures, which left iOS on the login screen with no alert.
+ */
+export async function exchangeGoogleCodeForIdToken(opts: {
+  clientId: string;
+  code: string;
+  redirectUri: string;
+  codeVerifier?: string | null;
+}): Promise<string> {
+  const tokens = await AuthSession.exchangeCodeAsync(
+    {
+      clientId: opts.clientId,
+      code: opts.code,
+      redirectUri: opts.redirectUri,
+      extraParams: opts.codeVerifier ? { code_verifier: opts.codeVerifier } : {}
+    },
+    googleDiscovery
+  );
+  const idToken = tokens.idToken;
+  if (!idToken) {
+    throw new Error("Google sign-in did not return a credential.");
+  }
+  return idToken;
+}
+
+export function googleAuthRequestConfig(opts: { iosClientId: string; webClientId: string }) {
+  const iosRedirect = googleIosRedirectUri(opts.iosClientId);
+  return {
+    iosClientId: opts.iosClientId || undefined,
+    webClientId: opts.webClientId || undefined,
+    clientId: opts.webClientId || undefined,
+    redirectUri: Platform.OS === "ios" ? iosRedirect ?? undefined : undefined,
+    shouldAutoExchangeCode: false as const,
+    responseType:
+      Platform.OS === "web" ? AuthSession.ResponseType.IdToken : AuthSession.ResponseType.Code
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After #64, production `/api/v1/auth/google` no longer returns `GOOGLE_CLIENT_IDS is not configured`, so the old network/config alert is gone. Google sign-in on iOS still left people on the login screen with **no error and no session**.

Three client bugs stacked:

1. **Wrong redirect URI.** Expo’s Google provider defaults to `com.joelyoung.4096:/oauthredirect`. Google iOS clients expect `com.googleusercontent.apps.<id>:/oauthredirect` (the scheme we already register in Info.plist). The auth sheet can complete, then the code exchange fails.
2. **Swallowed code-exchange errors.** `useIdTokenAuthRequest` on iOS actually uses `response_type=code` and auto-exchanges *without a `.catch()`*. A failed exchange never updates hook state, so the login button does nothing.
3. **No navigation after `setSession`.** Password login calls `router.replace`. Google/Apple only write the session. `index.tsx` already redirected to login, so a later authed status never leaves that screen.

## Changes

- Use Google’s reversed-client-id redirect and disable Expo’s silent auto-exchange; exchange the code ourselves and show failures
- Don’t `setState` before `promptAsync` (same iOS sheet issue as Apple in #59)
- Redirect authed users out of the `(auth)` stack
- Delay OAuth alerts 400ms so iOS doesn’t drop them while `ASWebAuthenticationSession` dismisses
- Keep `play4096` / bundle-id URL schemes alongside the Google scheme

## Test plan

- [x] `pnpm test` / `pnpm typecheck` / `pnpm lint` in `mobile/` (18 tests passing)
- [ ] Install the new TestFlight build (this needs a Mobile Release after merge)
- [ ] Tap Continue with Google: Google UI appears, then the app goes to Home
- [ ] Cancel the Google sheet: back on login, no alert
- [ ] Force a bad API URL / failed exchange: a single Google sign-in alert after the sheet closes
- [ ] Sign in with Apple and password still reach Home

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55c11dcd-0318-454a-81e7-5b91284d5906?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55c11dcd-0318-454a-81e7-5b91284d5906&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

