### PR TITLE
Fix iOS crash when swiping the game board.

### DIFF
--- a/mobile/src/__tests__/use-board-swipe.test.ts
+++ b/mobile/src/__tests__/use-board-swipe.test.ts
@@ -1,0 +1,57 @@
+import { DIRECTIONS } from "@/game/constants";
+import { createBoardSwipe } from "@/hooks/useBoardSwipe";
+
+type EndHandler = (event: { translationX: number; translationY: number }) => void;
+
+jest.mock("react-native-gesture-handler", () => {
+  const runOnJS = jest.fn().mockReturnThis();
+  const onEndHandlers: EndHandler[] = [];
+  const chain = {
+    runOnJS,
+    enabled: jest.fn().mockReturnThis(),
+    activeOffsetX: jest.fn().mockReturnThis(),
+    activeOffsetY: jest.fn().mockReturnThis(),
+    onEnd: jest.fn((handler: EndHandler) => {
+      onEndHandlers.push(handler);
+      return chain;
+    })
+  };
+  return {
+    Gesture: {
+      Pan: () => chain
+    },
+    __swipeMocks: { runOnJS, onEndHandlers }
+  };
+});
+
+const { __swipeMocks: swipeMocks } = jest.requireMock("react-native-gesture-handler") as {
+  __swipeMocks: { runOnJS: jest.Mock; onEndHandlers: EndHandler[] };
+};
+
+describe("createBoardSwipe", () => {
+  beforeEach(() => {
+    swipeMocks.onEndHandlers.length = 0;
+    swipeMocks.runOnJS.mockClear();
+  });
+
+  it("runs pan callbacks on the JS thread", () => {
+    createBoardSwipe(jest.fn());
+    expect(swipeMocks.runOnJS).toHaveBeenCalledWith(true);
+  });
+
+  it("maps a completed swipe to a board direction without a UI-thread worklet", () => {
+    const onMove = jest.fn();
+    createBoardSwipe(onMove);
+
+    expect(swipeMocks.onEndHandlers).toHaveLength(1);
+    swipeMocks.onEndHandlers[0]({ translationX: -80, translationY: 8 });
+    expect(onMove).toHaveBeenCalledWith(DIRECTIONS.LEFT);
+  });
+
+  it("ignores tiny movements", () => {
+    const onMove = jest.fn();
+    createBoardSwipe(onMove);
+    swipeMocks.onEndHandlers[0]({ translationX: -10, translationY: 4 });
+    expect(onMove).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/src/hooks/useBoardSwipe.ts
+++ b/mobile/src/hooks/useBoardSwipe.ts
@@ -1,19 +1,22 @@
 import { directionFromSwipe } from "@/lib/swipe";
 import { useMemo } from "react";
 import { Gesture } from "react-native-gesture-handler";
-import { runOnJS } from "react-native-reanimated";
+
+export function createBoardSwipe(onMove: (direction: number) => void, enabled = true) {
+  // Pan callbacks are UI-thread worklets by default; this swipe only maps a
+  // translation, so stay on JS. Calling directionFromSwipe from a worklet
+  // aborts Hermes in release (TestFlight SIGABRT on swipe).
+  return Gesture.Pan()
+    .runOnJS(true)
+    .enabled(enabled)
+    .activeOffsetX([-16, 16])
+    .activeOffsetY([-16, 16])
+    .onEnd((event) => {
+      const direction = directionFromSwipe(event.translationX, event.translationY);
+      if (direction != null) onMove(direction);
+    });
+}
 
 export function useBoardSwipe(onMove: (direction: number) => void, enabled = true) {
-  return useMemo(
-    () =>
-      Gesture.Pan()
-        .enabled(enabled)
-        .activeOffsetX([-16, 16])
-        .activeOffsetY([-16, 16])
-        .onEnd((event) => {
-          const direction = directionFromSwipe(event.translationX, event.translationY);
-          if (direction != null) runOnJS(onMove)(direction);
-        }),
-    [enabled, onMove]
-  );
+  return useMemo(() => createBoardSwipe(onMove, enabled), [enabled, onMove]);
 }


### PR DESCRIPTION
Pan gesture onEnd callbacks were auto-workletized onto the UI thread, then called directionFromSwipe which is not a worklet. Hermes threw and aborted the TestFlight build. Run the swipe mapping on the JS thread instead.