### PR TITLE
Align iOS swipe distance with the web app's 5px threshold.

### DIFF
--- a/mobile/src/__tests__/swipe.test.ts
+++ b/mobile/src/__tests__/swipe.test.ts
@@ -15,7 +15,11 @@ describe("directionFromSwipe", () => {
     expect(directionFromSwipe(-3, 90)).toBe(DIRECTIONS.DOWN);
   });
 
+  it("maps a short swipe that meets the web threshold", () => {
+    expect(directionFromSwipe(-6, 2)).toBe(DIRECTIONS.LEFT);
+  });
+
   it("ignores tiny movements", () => {
-    expect(directionFromSwipe(-10, 4)).toBeNull();
+    expect(directionFromSwipe(-4, 3)).toBeNull();
   });
 });

--- a/mobile/src/__tests__/use-board-swipe.test.ts
+++ b/mobile/src/__tests__/use-board-swipe.test.ts
@@ -20,12 +20,17 @@ jest.mock("react-native-gesture-handler", () => {
     Gesture: {
       Pan: () => chain
     },
-    __swipeMocks: { runOnJS, onEndHandlers }
+    __swipeMocks: { runOnJS, onEndHandlers, activeOffsetX: chain.activeOffsetX, activeOffsetY: chain.activeOffsetY }
   };
 });
 
 const { __swipeMocks: swipeMocks } = jest.requireMock("react-native-gesture-handler") as {
-  __swipeMocks: { runOnJS: jest.Mock; onEndHandlers: EndHandler[] };
+  __swipeMocks: {
+    runOnJS: jest.Mock;
+    onEndHandlers: EndHandler[];
+    activeOffsetX: jest.Mock;
+    activeOffsetY: jest.Mock;
+  };
 };
 
 describe("createBoardSwipe", () => {
@@ -48,10 +53,23 @@ describe("createBoardSwipe", () => {
     expect(onMove).toHaveBeenCalledWith(DIRECTIONS.LEFT);
   });
 
+  it("activates the pan at the web swipe threshold", () => {
+    createBoardSwipe(jest.fn());
+    expect(swipeMocks.activeOffsetX).toHaveBeenCalledWith([-5, 5]);
+    expect(swipeMocks.activeOffsetY).toHaveBeenCalledWith([-5, 5]);
+  });
+
+  it("maps a short swipe that meets the web threshold", () => {
+    const onMove = jest.fn();
+    createBoardSwipe(onMove);
+    swipeMocks.onEndHandlers[0]({ translationX: -6, translationY: 2 });
+    expect(onMove).toHaveBeenCalledWith(DIRECTIONS.LEFT);
+  });
+
   it("ignores tiny movements", () => {
     const onMove = jest.fn();
     createBoardSwipe(onMove);
-    swipeMocks.onEndHandlers[0]({ translationX: -10, translationY: 4 });
+    swipeMocks.onEndHandlers[0]({ translationX: -4, translationY: 3 });
     expect(onMove).not.toHaveBeenCalled();
   });
 });

--- a/mobile/src/hooks/useBoardSwipe.ts
+++ b/mobile/src/hooks/useBoardSwipe.ts
@@ -1,4 +1,4 @@
-import { directionFromSwipe } from "@/lib/swipe";
+import { directionFromSwipe, SWIPE_THRESHOLD } from "@/lib/swipe";
 import { useMemo } from "react";
 import { Gesture } from "react-native-gesture-handler";
 
@@ -9,8 +9,8 @@ export function createBoardSwipe(onMove: (direction: number) => void, enabled = 
   return Gesture.Pan()
     .runOnJS(true)
     .enabled(enabled)
-    .activeOffsetX([-16, 16])
-    .activeOffsetY([-16, 16])
+    .activeOffsetX([-SWIPE_THRESHOLD, SWIPE_THRESHOLD])
+    .activeOffsetY([-SWIPE_THRESHOLD, SWIPE_THRESHOLD])
     .onEnd((event) => {
       const direction = directionFromSwipe(event.translationX, event.translationY);
       if (direction != null) onMove(direction);

--- a/mobile/src/lib/swipe.ts
+++ b/mobile/src/lib/swipe.ts
@@ -1,6 +1,9 @@
 import { DIRECTIONS } from "@/game/constants";
 
-export function directionFromSwipe(dx: number, dy: number, threshold = 24) {
+/** Matches the web app `createSwipeHandlers` default in `src/lib/swipe.js`. */
+export const SWIPE_THRESHOLD = 5;
+
+export function directionFromSwipe(dx: number, dy: number, threshold = SWIPE_THRESHOLD) {
   const ax = Math.abs(dx);
   const ay = Math.abs(dy);
   if (Math.max(ax, ay) < threshold) return null;


### PR DESCRIPTION
Short board swipes were ignored on iOS because the pan needed 16px to activate and 24px to count as a move, while the web app uses 5px.